### PR TITLE
Add inspiration digest for ros2_agent_workspace

### DIFF
--- a/.agent/knowledge/inspiration_ros2_agent_workspace_digest.md
+++ b/.agent/knowledge/inspiration_ros2_agent_workspace_digest.md
@@ -1,0 +1,33 @@
+# Inspiration Digest: ros2_agent_workspace
+
+Type: fork
+Last checked: 2026-03-21
+Repo: rolker/ros2_agent_workspace @ 54a2ef469eeaddc7aa30f11ff34078aa94836e74
+
+## Activity Snapshot
+
+- 20 open issues, 1 open PR (agent dashboard Phase 1)
+- ~50 recently closed issues / merged PRs (last 30 days)
+- Notable: review system foundation (multi-specialist code review), git-bug
+  integration, agent orchestrator research, tmux session strategy, worktree UX
+  improvements, Forgejo evaluation
+
+## Ported/Adapted
+
+- `worktree_list.sh --json` — adapted in PR #15 (2026-03-21)
+- `gh_create_issue.sh` git-bug offline fallback — adapted in PR #15 (2026-03-21)
+
+## Skipped
+
+(none)
+
+## Deferred
+
+- `tests/` directory for scripts — upstream has tests for generic scripts (test_detect_cli_env.sh, test_generate_make_skills.sh, test_revert_feature.sh, test_worktree_create.sh) (2026-03-21)
+- `ci_workflow.yml` template — CI workflow template for project repos (2026-03-21)
+- `pre-commit-config.yaml` template — pre-commit config template for project repos (2026-03-21)
+- `.github/copilot-instructions.md` — GitHub Copilot adapter file (2026-03-21)
+
+## Pending Issues
+
+(none)


### PR DESCRIPTION
## Summary

Add initial inspiration digest for `ros2_agent_workspace` fork tracking.

Records decisions from the first `inspiration-tracker` run:
- **Ported**: `worktree_list.sh --json`, `gh_create_issue.sh` git-bug fallback (PR #15)
- **Deferred**: script tests directory, CI workflow template, pre-commit config template, Copilot instructions

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
