### PR TITLE
docs: add project vs workspace terminology to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@ setup (environment, identity, features), see your framework's adapter file:
 - **Workspace**: the agent infrastructure in this repo — skills, governance,
   scripts, worktrees, docs, and configuration.
 
-When scope is ambiguous, default to **project** (the thing being built) unless
-the topic is clearly about agent tooling or workspace internals.
+When scope is ambiguous in conversation, default to **project** (the thing
+being built) unless the topic is clearly about agent tooling or workspace
+internals.
 
 **Repo ownership**: The working directory contains files from both repos
 (workspace infrastructure is layered onto the project checkout). Don't assume
@@ -28,7 +29,7 @@ code being changed:
 | Scope | Repo | What lives there |
 |-------|------|-----------------|
 | Workspace | `agent_workspace` | `AGENTS.md`, `.agent/`, skills, scripts, docs |
-| Project | project repo (e.g. `daddy_camp`) | Product source code in `project/` |
+| Project | project repo (e.g. `daddy_camp`) | The product being built (`project/`) |
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

Adds a "Terminology" section to `AGENTS.md` (before "Boundaries") that:

- Defines **project** (managed product in `project/`) vs **workspace** (agent infrastructure)
- Sets the default: when scope is ambiguous, assume project
- Clarifies repo ownership — the working directory mixes files from both repos, so agents must use `gh repo view` / `git remote -v` to confirm which GitHub repo to target
- Includes a table mapping scope to repo ownership

Addresses the repo mixup incident described in the [issue comment](https://github.com/rolker/agent_workspace/issues/75#issuecomment-4147919378).

Closes #75

## Test plan

- [ ] Verify the section renders correctly in GitHub markdown
- [ ] Confirm placement (after framework adapter table, before Boundaries)
- [ ] Check that the guidance is generic enough to apply to any workspace, not just game projects

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
