### PR TITLE
fix: use git-bug bridge commands instead of SSH transport

### DIFF
--- a/.agent/scripts/gh_create_issue.sh
+++ b/.agent/scripts/gh_create_issue.sh
@@ -176,11 +176,11 @@ if [ "${GITBUG_CREATE:-}" = "1" ] && command -v git-bug &>/dev/null; then
             _GB_ARGS+=(--message "$_BODY")
         fi
         if git bug new "${_GB_ARGS[@]}" 2>/dev/null; then
-            if git bug push 2>/dev/null; then
+            if git bug bridge push github 2>/dev/null; then
                 echo "✅ Issue created via git-bug and synced to GitHub"
             else
                 echo "✅ Issue created locally via git-bug"
-                echo "⚠️  git bug push failed — sync manually with: git bug push"
+                echo "⚠️  git bug bridge push failed — sync manually with: git bug bridge push github"
             fi
             exit 0
         else

--- a/.agent/scripts/git_bug_setup.sh
+++ b/.agent/scripts/git_bug_setup.sh
@@ -116,10 +116,10 @@ else
     echo "GitHub bridge already configured."
 fi
 
-# 4. Initial sync
+# 4. Initial sync via GitHub bridge (uses API token, not SSH transport)
 echo "Pulling issues from GitHub..."
-if git bug pull 2>/dev/null; then
+if git bug bridge pull github 2>/dev/null; then
     echo "✅ git-bug sync complete."
 else
-    echo "⚠️  git bug pull failed — issues may not be up to date."
+    echo "⚠️  git bug bridge pull failed — issues may not be up to date."
 fi

--- a/.agent/scripts/sync_project.py
+++ b/.agent/scripts/sync_project.py
@@ -120,12 +120,15 @@ def sync_gitbug(repo_path, dry_run=False):
 
     repo_name = repo_path.name
     if dry_run:
-        print(f"  [DRY-RUN] {repo_name}: git bug pull")
-        print(f"  [DRY-RUN] {repo_name}: git bug push")
+        print(f"  [DRY-RUN] {repo_name}: git bug bridge pull github")
+        print(f"  [DRY-RUN] {repo_name}: git bug bridge push github")
         return
 
     print(f"  Syncing git-bug issues for {repo_name}...")
-    for cmd in [["git", "bug", "pull"], ["git", "bug", "push"]]:
+    for cmd in [
+        ["git", "bug", "bridge", "pull", "github"],
+        ["git", "bug", "bridge", "push", "github"],
+    ]:
         result = subprocess.run(
             cmd, cwd=str(repo_path), capture_output=True, text=True, check=False
         )


### PR DESCRIPTION
## Summary

- Switch `git bug pull/push` to `git bug bridge pull/push github` in all three scripts that sync with GitHub
- The git-transport commands require `SSH_AUTH_SOCK`; the bridge commands use the API token configured during setup

**Files changed:**
- `.agent/scripts/git_bug_setup.sh` — initial sync after bridge creation
- `.agent/scripts/sync_project.py` — ongoing `make sync` 
- `.agent/scripts/gh_create_issue.sh` — push after offline issue creation

Closes #91

## Test plan

- [ ] Run `git_bug_setup.sh` in a session without `SSH_AUTH_SOCK` — sync should succeed
- [ ] Run `make sync` — git-bug step should use bridge commands
- [ ] Run `gh_create_issue.sh` with `GITBUG_CREATE=1` — push should use bridge

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
