### PR TITLE
docs: add tool-preference and shell-chaining guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,14 +74,15 @@ code being changed:
 
 ## Tool Usage
 
-- **Prefer dedicated tools over shell equivalents** — Use Glob instead of
-  `ls`/`find`, Grep instead of `grep`/`rg`, Read instead of `cat`/`head`/`tail`,
-  Edit instead of `sed`/`awk`. Dedicated tools are auto-approved and provide
-  better audit trails.
+- **Prefer dedicated tools over shell equivalents** — When your framework
+  provides built-in tools for file search, content search, file reading, or
+  file editing, use those instead of shell commands (`ls`, `find`, `grep`,
+  `cat`, `sed`, etc.). Dedicated tools provide better audit trails and
+  typically require fewer permission prompts.
 - **Chain shell commands only when state depends on it** — Use `&&` when the
   second command needs shell state from the first (sourced environments, directory
-  changes). For independent commands, use separate tool calls so each can match
-  allowlist patterns independently.
+  changes). For independent commands, use separate tool calls so each can be
+  evaluated independently.
 
 ## Worktree Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,21 @@ Replace `<your-model-id>` with your actual model ID from your system prompt
 (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`). The 3-arg form skips all
 detection and uses exactly what you provide — do NOT edit `framework_config.sh`.
 
+## Tool Mapping
+
+The AGENTS.md "Tool Usage" section applies to all frameworks. In Claude Code,
+the dedicated tools are:
+
+| Instead of | Use |
+|------------|-----|
+| `ls`, `find` | Glob |
+| `grep`, `rg` | Grep |
+| `cat`, `head`, `tail` | Read |
+| `sed`, `awk` | Edit |
+| `echo >`, heredoc redirection | Write |
+
+These are auto-approved and don't consume permission prompts.
+
 ## Claude-Specific Notes
 
 - Makefile `.PHONY` targets (excluding `help`) are available as `/make_*` slash commands


### PR DESCRIPTION
## Summary

- Add "Tool Usage" section to AGENTS.md with two guidelines:
  - Prefer dedicated tools (Glob, Grep, Read, Edit) over Bash equivalents
  - Chain shell commands with `&&` only when the second depends on shell state from the first

Based on analysis of 611 tool-use log entries showing 22% of Bash calls could have used auto-approved dedicated tools instead.

Closes #78

## Test plan

- [ ] Verify AGENTS.md renders correctly
- [ ] Confirm new section appears between "Communication Standards" and "Worktree Workflow"

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
