### PR TITLE
feat: add standalone linters to venv requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 # Workspace dev-tool dependencies — installed into .venv by `make lint`.
 # Keep minimal: only tools wired into Makefile targets or CI.
+# Linter versions should match .pre-commit-config.yaml to avoid divergence.
 pre-commit
+flake8==7.0.0
+pylint==3.0.3
+yamllint==1.33.0
+shellcheck-py==0.9.0.6


### PR DESCRIPTION
## Summary

- Adds flake8, pylint, yamllint, and shellcheck-py to `requirements.txt`
- Versions pinned to match `.pre-commit-config.yaml` to avoid divergence
- Enables the `review-code` skill to run individual linters standalone

| Tool | Version | Pre-commit match |
|------|---------|-----------------|
| flake8 | 7.0.0 | yes |
| pylint | 3.0.3 | yes |
| yamllint | 1.33.0 | yes |
| shellcheck-py | 0.9.0.6 | yes |

Closes #93

## Test plan

- [ ] `make lint` still works (pre-commit unaffected)
- [ ] `.venv/bin/flake8 --version` returns 7.0.0
- [ ] `.venv/bin/pylint --version` returns 3.0.3
- [ ] `.venv/bin/yamllint --version` returns 1.33.0
- [ ] `.venv/bin/shellcheck --version` returns 0.9.0

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
