### PR TITLE
fix: harden gemini CLI detection with fallback paths

### DIFF
--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -63,8 +63,31 @@ if ! command -v tmux &>/dev/null; then
     exit 1
 fi
 
-if ! command -v gemini &>/dev/null; then
-    echo "WARNING: gemini CLI not installed — Gemini adversarial review unavailable" >&2
+# Find gemini CLI — check PATH first, then common install locations
+GEMINI_BIN=""
+if command -v gemini &>/dev/null; then
+    GEMINI_BIN="$(command -v gemini)"
+else
+    # Common install paths for npm/nvm global installs
+    FALLBACK_PATHS=(
+        "${HOME}/.nvm/versions/node"/*/bin/gemini
+        "${HOME}/.local/bin/gemini"
+        "${HOME}/.npm-global/bin/gemini"
+        /usr/local/bin/gemini
+    )
+    for candidate in "${FALLBACK_PATHS[@]}"; do
+        if [[ -x "$candidate" ]]; then
+            GEMINI_BIN="$candidate"
+            echo "INFO: gemini not in PATH, found at: ${GEMINI_BIN}" >&2
+            break
+        fi
+    done
+fi
+
+if [[ -z "$GEMINI_BIN" ]]; then
+    echo "WARNING: gemini CLI not found — Gemini adversarial review unavailable" >&2
+    echo "  PATH searched: ${PATH}" >&2
+    echo "  Also checked: ~/.nvm/versions/node/*/bin/, ~/.local/bin/, ~/.npm-global/bin/, /usr/local/bin/" >&2
     exit 1
 fi
 
@@ -174,7 +197,7 @@ fi
 # tmux session works regardless of CWD. On Gemini failure, an error marker is
 # written so downstream consumers can distinguish "crashed" from "still running".
 tmux new-session -d -s "$SESSION_NAME" \
-    "gemini -p < \"${PROMPT_FILE}\" > \"${FINDINGS_FILE}\" 2>&1 && echo '--- Review complete ---' >> \"${FINDINGS_FILE}\" || echo '--- Review failed ---' >> \"${FINDINGS_FILE}\""
+    "\"${GEMINI_BIN}\" -p < \"${PROMPT_FILE}\" > \"${FINDINGS_FILE}\" 2>&1 && echo '--- Review complete ---' >> \"${FINDINGS_FILE}\" || echo '--- Review failed ---' >> \"${FINDINGS_FILE}\""
 
 if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
     echo "ERROR: Failed to launch tmux session '${SESSION_NAME}'" >&2


### PR DESCRIPTION
## Summary

- When `command -v gemini` fails, checks common install paths: nvm global bins, `~/.local/bin`, `~/.npm-global/bin`, `/usr/local/bin`
- Logs PATH and checked locations on failure so the user can diagnose
- Uses resolved absolute path (`$GEMINI_BIN`) in the tmux session launch instead of bare `gemini`

Closes #82

## Test plan

- [ ] With gemini in PATH: script finds it normally (no change in behavior)
- [ ] With gemini NOT in PATH but installed via nvm: script finds it via fallback and logs `INFO`
- [ ] With gemini not installed at all: script exits 1 with PATH and checked locations in warning
- [ ] shellcheck passes (verified by pre-commit)

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
