### PR TITLE
fix: detect stale venv/hooks after workspace rename, add make repair

### DIFF
--- a/.agent/scripts/validate_workspace.py
+++ b/.agent/scripts/validate_workspace.py
@@ -81,11 +81,16 @@ def validate_workspace(verbose=False):
     if venv_pip.exists():
         try:
             shebang = venv_pip.read_text().split("\n", 1)[0]
-            if shebang.startswith("#!") and str(workspace_root) not in shebang:
-                issues.append("venv has stale shebangs (workspace was renamed/moved)")
-                issues.append("  Run: make repair")
+            if shebang.startswith("#!"):
+                interpreter = shebang[2:].strip().split()[0]
+                expected_prefix = str(workspace_root / ".venv" / "bin" / "python")
+                if not interpreter.startswith(expected_prefix):
+                    issues.append("venv has stale shebangs (workspace was renamed/moved)")
+                    issues.append("  Run: make repair")
+                elif verbose:
+                    print("  venv shebangs: OK")
             elif verbose:
-                print("  venv shebangs: OK")
+                print("  venv shebangs: OK (no shebang found)")
         except OSError:
             pass
     elif verbose:
@@ -99,8 +104,10 @@ def validate_workspace(verbose=False):
             for line in hook_content.split("\n"):
                 if line.startswith("INSTALL_PYTHON="):
                     hook_python = line.split("=", 1)[1].strip().strip("'\"")
-                    if not Path(hook_python).exists():
-                        issues.append(f"pre-commit hook points to stale path: {hook_python}")
+                    expected_hook = str(workspace_root / ".venv" / "bin" / "python3")
+                    if hook_python != expected_hook:
+                        issues.append(f"pre-commit hook points to wrong path: {hook_python}")
+                        issues.append(f"  Expected: {expected_hook}")
                         issues.append("  Run: make repair")
                     elif verbose:
                         print("  pre-commit hook: OK")

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ validate:
 
 repair:
 	@echo "--- Repairing venv and pre-commit hook ---"
-	$(MAIN_ROOT)/.venv/bin/python3 -m pip install --quiet --force-reinstall -r $(MAIN_ROOT)/requirements.txt
-	$(PRE_COMMIT) install
+	$(VENV_BIN)/python3 -m pip install --quiet --force-reinstall -r $(MAIN_ROOT)/requirements.txt
+	cd $(MAIN_ROOT) && $(PRE_COMMIT) install
 	@rm -f $(STAMP)/setup-dev.done
 	@$(MAKE) --no-print-directory $(STAMP)/setup-dev.done
 	@echo "✅ Repair complete. Run 'make validate' to verify."


### PR DESCRIPTION
## Summary

- `validate_workspace.py` now detects stale venv shebangs and pre-commit hook paths after a workspace rename/move
- New `make repair` target reinstalls venv packages (fixing shebangs) and re-runs `pre-commit install`
- Claude memory migration remains documented as manual (path is derived externally by Claude Code, not under workspace control)

Closes #13

## Test plan

- [ ] `make validate` on a clean workspace shows "venv shebangs: OK" and "pre-commit hook: OK"
- [ ] Simulating a rename (editing a shebang in `.venv/bin/pip` to a wrong path) causes `make validate` to fail with repair instructions
- [ ] `make repair` fixes the stale shebangs and hook
- [ ] `make validate` passes after repair

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
