### PR TITLE
docs: document gh pr merge --delete-branch worktree issue

### DIFF
--- a/.agent/WORKTREE_GUIDE.md
+++ b/.agent/WORKTREE_GUIDE.md
@@ -138,6 +138,10 @@ cd ~/agent_workspace
 **"No worktree found"**: Check `worktree_list.sh` to see what exists. The slug
 may differ from what you expect — use `--repo-slug` to disambiguate.
 
+**`gh pr merge --delete-branch` fails with "main is already used by worktree"**:
+`gh` tries to checkout `main` after merging, but the main tree already has it.
+Use `make merge-pr PR=<N>` or `gh pr merge <N> --merge` (without `--delete-branch`).
+
 **Branch already exists**: The script reuses an existing local branch, or tracks
 the remote branch if one exists.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,21 @@ gh pr view <N> --json url --jq '.url'
 gh repo view --json url --jq '.url'
 ```
 
+### Merging PRs from Worktrees
+
+Never use `gh pr merge --delete-branch` from a worktree — `gh` tries to
+checkout `main` locally, which fails because the main tree already has it
+checked out. Use `--merge` without `--delete-branch` and let worktree
+cleanup handle branch deletion:
+
+```bash
+# Preferred: use the merge script (handles worktree removal + sync)
+make merge-pr PR=<N>
+
+# Manual alternative:
+gh pr merge <N> --merge          # no --delete-branch
+```
+
 ## Build & Test
 
 Build and test commands are project-specific. Configure them in `.agent/project_config.sh`


### PR DESCRIPTION
## Summary

Documents the `gh pr merge --delete-branch` worktree failure and the correct pattern:

- **AGENTS.md**: new "Merging PRs from Worktrees" subsection under GitHub CLI Patterns
- **WORKTREE_GUIDE.md**: new troubleshooting entry for the error

The fix is to use `make merge-pr PR=<N>` or `gh pr merge --merge` (without `--delete-branch`), which avoids the `main` checkout conflict.

Closes #84

## Test plan

- [ ] Verify AGENTS.md renders correctly with new subsection
- [ ] Verify WORKTREE_GUIDE.md troubleshooting entry is clear

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
