### PR TITLE
Ignore repo-root .codex runtime artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ worktrees/
 # IDE settings
 .vscode/
 *.code-workspace
+.codex
 
 # Generated Claude Code skills (regenerate with: make generate-skills)
 .claude/skills/make_*/


### PR DESCRIPTION
## Summary

Ignore the repo-root `.codex` runtime artifact created by Codex CLI sessions so it does not show up as an untracked file in the workspace.

## Changes

- add `.codex` to the root `.gitignore`

Closes #116

---
**Authored-By**: `Codex CLI Agent`
**Model**: `gpt-5.4`
