### PR TITLE
Fix make repair failing on stale venv pip shebangs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,8 @@ $(STAMP):
 $(STAMP)/setup-dev.done: requirements.txt | $(STAMP)
 	@echo "--- Setting up dev tools ---"
 	python3 -m venv $(VENV_DIR)
-	$(VENV_BIN)/pip install --quiet --upgrade pip
-	$(VENV_BIN)/pip install --quiet -r $(MAIN_ROOT)/requirements.txt
+	$(VENV_BIN)/python3 -m pip install --quiet --upgrade pip
+	$(VENV_BIN)/python3 -m pip install --quiet -r $(MAIN_ROOT)/requirements.txt
 	$(PRE_COMMIT) install
 	touch $@
 


### PR DESCRIPTION
Closes #108

## Summary

- Replace `$(VENV_BIN)/pip` with `$(VENV_BIN)/python3 -m pip` in the `setup-dev` Makefile target
- After a workspace move/rename, `.venv/bin/pip` has a stale shebang pointing to the old path, causing `make repair` to fail
- `python3 -m pip` bypasses the wrapper script entirely, making setup resilient to path changes

## Test plan

- [ ] Move/rename the workspace directory
- [ ] Run `make repair` — should succeed without manual intervention

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
