### PR TITLE
feat: add soft roadmap reminder to merge_pr.sh

### DIFF
--- a/.agent/scripts/merge_pr.sh
+++ b/.agent/scripts/merge_pr.sh
@@ -172,7 +172,7 @@ ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" "${GH_REPO_ARGS[@]}" --json title --jq 
 if [[ -n "$ISSUE_TITLE" ]]; then
     ROADMAP_MATCHES=()
     # Extract significant keywords (3+ chars, skip common words)
-    KEYWORDS=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | grep -oE '[a-z]{3,}' \
+    KEYWORDS=$(printf '%s\n' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | grep -oE '[a-z]{3,}' \
         | grep -vxE '(the|and|for|with|from|that|this|into|when|also|not|but|are|was|has|have|will|can|its|all|new|add|use|get|set|fix|run)' \
         | head -5 || true)
     if [[ -n "$KEYWORDS" ]]; then


### PR DESCRIPTION
## Summary

Add a soft roadmap reminder to `merge_pr.sh` (step 6). After merge + sync:
1. Fetches the linked issue title via `gh issue view`
2. Extracts significant keywords, skipping common words
3. Greps against `docs/ROADMAP.md` and `project/ROADMAP.md` (guarded by file-existence checks)
4. Prints an informational reminder if a match is found — not a gate

Part of #121. Closes #129.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
