### PR TITLE
docs: add principle — the workspace serves the product

### DIFF
--- a/.agent/knowledge/principles_review_guide.md
+++ b/.agent/knowledge/principles_review_guide.md
@@ -18,6 +18,7 @@ humans use it as a checklist.
 | Workspace vs. project separation | Workspace infra is project-agnostic; project content in project repos | Project-specific config leaking into workspace; workspace depending on a project |
 | Workspace improvements cascade to projects | New workflow pattern is portable; workspace is the reference implementation | Improvements locked to one repo; patterns that can't be adopted downstream |
 | Primary framework first, portability where free | Full use of active framework; rules naturally portable are expressed portably | Hobbling the primary tool for hypothetical frameworks; framework lock-in where avoidable |
+| The workspace serves the product | Infrastructure investment tied to concrete product acceleration; operational friction fixes justified by product impact | Sustained workspace-heavy PR ratio without product delivery; tooling that solves problems the product doesn't have; infrastructure built for its own sake |
 
 ## ADR Applicability
 

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -61,3 +61,12 @@ Design improvements to be portable across repos from the start.
 Use the full capabilities of the active framework (currently Claude Code). Where rules
 are naturally framework-agnostic — build commands, coding conventions, architecture —
 express them portably.
+
+## The workspace serves the product
+
+Infrastructure investment pays off when it makes the next product change faster, safer,
+or more reliable. When workspace work consistently outpaces product delivery, treat that
+as a signal — the tooling may be solving problems the product doesn't have, or solving
+them at a scale that isn't justified yet. Operational friction (reactive fixes,
+workarounds, repeated mistakes) is a valid input to workspace improvement, but the
+measure of success is product shipped, not infrastructure built.


### PR DESCRIPTION
## Summary

- Add 11th guiding principle to `docs/PRINCIPLES.md`: **The workspace serves the product**
- Add corresponding row to `.agent/knowledge/principles_review_guide.md` quick-reference table

The existing 10 principles all govern *how* work is done but none anchor to *what the
work is for*. This principle provides:
- A proportionality check for infrastructure vs. product investment
- Legitimacy for operational-friction-driven improvements (while tying them to product value)
- A review criterion for pushing back on workspace scope creep

Closes #135

## Test plan

- [x] Principle text reviewed in conversation before implementation
- [ ] Review guide table renders correctly with new row
- [ ] Principle is actionable as a review criterion on future workspace PRs

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
