### PR TITLE
fix: remove stray local_porcelain in worktree_list.sh

### DIFF
--- a/.agent/scripts/worktree_list.sh
+++ b/.agent/scripts/worktree_list.sh
@@ -240,7 +240,6 @@ _scan_project_worktrees() {
         # Check dirty status and count changed files
         local_status="clean"
         local_changed=0
-        local_porcelain
         local_porcelain="$(git -C "$proj_wt" status --porcelain 2>/dev/null || true)"
         if [ -n "$local_porcelain" ]; then
             local_status="dirty"


### PR DESCRIPTION
## Summary

- Remove stray `local_porcelain` on line 243 of `worktree_list.sh` that bash executes as a command, producing `command not found`

Closes #134

## Test plan

- [x] `worktree_list.sh` runs without errors
- [x] All pre-commit hooks pass

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
