### PR TITLE
[PLAN] Scripts and skills bypass git-bug for issue reads (ADR-0010 compliance)

### DIFF
--- a/.agent/knowledge/principles_review_guide.md
+++ b/.agent/knowledge/principles_review_guide.md
@@ -32,7 +32,7 @@ humans use it as a checklist.
 | 0006 — Shared AGENTS.md | Changing agent instructions | Shared rules in `AGENTS.md`; framework adapters are thin wrappers |
 | 0007 — Retain Make with Dependency Tracking | Changing the Makefile or proposing a different task runner | Keep Make; use stamp-file dependencies for incremental setup and build |
 | 0009 — Python package management | Installing Python packages or modifying `.venv` | Use .venv for dev tools; never bare pip install |
-| 0010 — git-bug for local issue tracking | Adding or modifying issue lookup scripts, bootstrap, or sync | git-bug is optional; scripts try git-bug first, fall back to `gh`; graceful degradation required |
+| 0010 — git-bug installed by default | Adding or modifying issue lookup scripts, bootstrap, or sync | git-bug installed by default; scripts use `_issue_helpers.sh` (git-bug first with sync-on-miss, fall back to `gh`); graceful degradation required |
 
 ## Consequences Map
 

--- a/.agent/scripts/_issue_helpers.sh
+++ b/.agent/scripts/_issue_helpers.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# .agent/scripts/_issue_helpers.sh
+# Shared helper functions for git-bug-first issue lookups with sync-on-miss.
+#
+# Source this file from other scripts:
+#   source "$SCRIPT_DIR/_issue_helpers.sh"
+#
+# Requires: jq (for JSON parsing)
+# Optional: git-bug v0.10+ with GitHub bridge configured
+#
+# Pattern: try git-bug first (offline-capable), pull on cache miss,
+# fall back to gh CLI. See ADR-0010 and AGENTS.md "git-bug-first Pattern".
+
+# --- Single-issue lookup ---
+# Fetch title, state, and body for a GitHub issue number.
+#
+# Usage:
+#   issue_lookup <N> --repo <owner/repo> [--root <dir>]
+#
+# Sets these variables in the caller's scope:
+#   ISSUE_TITLE  — issue title (empty string if not found)
+#   ISSUE_STATE  — OPEN or CLOSED (empty string if not found)
+#   ISSUE_BODY   — issue body text (empty string if not found)
+#
+# Returns 0 on success, 1 if issue not found via any source.
+issue_lookup() {
+    local issue_num="" repo_slug="" root_dir=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --repo) repo_slug="$2"; shift 2 ;;
+            --root) root_dir="$2"; shift 2 ;;
+            *)
+                if [[ -z "$issue_num" ]]; then
+                    issue_num="$1"; shift
+                else
+                    echo "ERROR: issue_lookup: unexpected argument: $1" >&2
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -z "$issue_num" ]]; then
+        echo "ERROR: issue_lookup: issue number required" >&2
+        return 1
+    fi
+    if [[ -z "$repo_slug" ]]; then
+        echo "ERROR: issue_lookup: --repo <owner/repo> required" >&2
+        return 1
+    fi
+
+    # Default root to script's workspace root
+    if [[ -z "$root_dir" ]]; then
+        root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    fi
+
+    ISSUE_TITLE=""
+    ISSUE_STATE=""
+    ISSUE_BODY=""
+
+    # --- Try git-bug ---
+    if command -v git-bug &>/dev/null && command -v jq &>/dev/null; then
+        local github_url="https://github.com/${repo_slug}/issues/${issue_num}"
+
+        _issue_lookup_gitbug "$root_dir" "$github_url"
+
+        # Sync-on-miss: if not found locally, pull and retry
+        if [[ -z "$ISSUE_TITLE" ]]; then
+            local has_bridge
+            has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
+            if [[ "$has_bridge" -gt 0 ]]; then
+                echo "  git-bug: cache miss for #${issue_num}, pulling from GitHub..." >&2
+                git -C "$root_dir" bug bridge pull github &>/dev/null || true
+                _issue_lookup_gitbug "$root_dir" "$github_url"
+            fi
+        fi
+    fi
+
+    # --- Fall back to gh ---
+    if [[ -z "$ISSUE_TITLE" ]] && command -v gh &>/dev/null; then
+        local gh_json
+        gh_json=$(gh issue view "$issue_num" --repo "$repo_slug" \
+            --json title,state,body 2>/dev/null || echo "")
+        if [[ -n "$gh_json" ]]; then
+            ISSUE_TITLE=$(echo "$gh_json" | jq -r '.title // empty')
+            ISSUE_STATE=$(echo "$gh_json" | jq -r '.state // empty')
+            ISSUE_BODY=$(echo "$gh_json" | jq -r '.body // empty')
+        fi
+    fi
+
+    [[ -n "$ISSUE_TITLE" ]]
+}
+
+# Internal: query git-bug by GitHub URL metadata.
+# Sets ISSUE_TITLE, ISSUE_STATE, ISSUE_BODY in caller's scope.
+# shellcheck disable=SC2034 # Variables are set for the caller's use
+_issue_lookup_gitbug() {
+    local root_dir="$1" github_url="$2"
+
+    local list_json bug_id
+    list_json=$(git -C "$root_dir" bug bug \
+        -m "github-url=${github_url}" --format json 2>/dev/null || echo "")
+
+    if [[ -z "$list_json" ]] || [[ "$list_json" == "[]" ]] || [[ "$list_json" == "null" ]]; then
+        return
+    fi
+
+    bug_id=$(echo "$list_json" | jq -r '.[0].human_id // empty' 2>/dev/null)
+    if [[ -z "$bug_id" ]]; then
+        return
+    fi
+
+    local show_json
+    show_json=$(git -C "$root_dir" bug bug show "$bug_id" --format json 2>/dev/null || echo "")
+    if [[ -z "$show_json" ]]; then
+        return
+    fi
+
+    ISSUE_TITLE=$(echo "$show_json" | jq -r '.title // empty')
+    local raw_state
+    raw_state=$(echo "$show_json" | jq -r '.status // empty')
+    case "${raw_state,,}" in
+        open) ISSUE_STATE="OPEN" ;;
+        closed) ISSUE_STATE="CLOSED" ;;
+        *) ISSUE_STATE="$raw_state" ;;
+    esac
+    # Body is the first comment's message
+    ISSUE_BODY=$(echo "$show_json" | jq -r '.comments[0].message // empty')
+}
+
+# --- List open issues ---
+# List open issues from git-bug or gh.
+#
+# Usage:
+#   issue_list_open [--repo <owner/repo>] [--root <dir>]
+#
+# Outputs one line per issue: <human_id_or_number>\t<title>
+# Returns 0 on success, 1 if no source available.
+issue_list_open() {
+    local repo_slug="" root_dir=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --repo) repo_slug="$2"; shift 2 ;;
+            --root) root_dir="$2"; shift 2 ;;
+            *) echo "ERROR: issue_list_open: unexpected argument: $1" >&2; return 1 ;;
+        esac
+    done
+
+    if [[ -z "$root_dir" ]]; then
+        root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    fi
+
+    # --- Try git-bug ---
+    if command -v git-bug &>/dev/null; then
+        local has_bridge
+        has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
+        if [[ "$has_bridge" -gt 0 ]]; then
+            local list_output
+            list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null)
+            if [[ $? -eq 0 && -n "$list_output" ]]; then
+                # Output format: <short_id>\t<status>\t<title>
+                # Reformat to: <short_id>\t<title>
+                echo "$list_output" | awk -F'\t' '{print $1 "\t" $3}'
+                return 0
+            fi
+        fi
+    fi
+
+    # --- Fall back to gh ---
+    if command -v gh &>/dev/null && [[ -n "$repo_slug" ]]; then
+        gh issue list --repo "$repo_slug" --state open \
+            --json number,title --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null
+        return $?
+    fi
+
+    return 1
+}
+
+# --- Count open issues ---
+# Count open issues from git-bug or gh.
+#
+# Usage:
+#   issue_count_open [--repo <owner/repo>] [--root <dir>]
+#
+# Outputs a single integer. Returns 0 on success, 1 if no source available.
+issue_count_open() {
+    local repo_slug="" root_dir=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --repo) repo_slug="$2"; shift 2 ;;
+            --root) root_dir="$2"; shift 2 ;;
+            *) echo "ERROR: issue_count_open: unexpected argument: $1" >&2; return 1 ;;
+        esac
+    done
+
+    if [[ -z "$root_dir" ]]; then
+        root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    fi
+
+    # --- Try git-bug ---
+    if command -v git-bug &>/dev/null; then
+        local has_bridge
+        has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
+        if [[ "$has_bridge" -gt 0 ]]; then
+            local list_output
+            if list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null); then
+                if [[ -z "$list_output" ]]; then
+                    echo "0"
+                else
+                    echo "$list_output" | grep -c .
+                fi
+                return 0
+            fi
+        fi
+    fi
+
+    # --- Fall back to gh ---
+    if command -v gh &>/dev/null && [[ -n "$repo_slug" ]]; then
+        gh api -X GET search/issues \
+            -f q="repo:${repo_slug} is:issue is:open" \
+            --jq '.total_count' 2>/dev/null || echo "0"
+        return 0
+    fi
+
+    return 1
+}

--- a/.agent/scripts/_issue_helpers.sh
+++ b/.agent/scripts/_issue_helpers.sh
@@ -173,17 +173,25 @@ issue_list_open() {
     fi
 
     # --- Try git-bug ---
+    # git-bug's local store contains issues for the repo at $root_dir.
+    # Only use it when $repo_slug matches that repo's remote to avoid
+    # returning issues for the wrong repo.
     if command -v git-bug &>/dev/null; then
-        local has_bridge
-        has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
-        if [[ "$has_bridge" -gt 0 ]]; then
-            local list_output
-            if list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null) \
-                && [[ -n "$list_output" ]]; then
-                # Output format: <short_id>\t<status>\t<title>
-                # Reformat to: <short_id>\t<title>
-                echo "$list_output" | awk -F'\t' '{print $1 "\t" $3}'
-                return 0
+        local ws_remote ws_slug
+        ws_remote=$(git -C "$root_dir" remote get-url origin 2>/dev/null || echo "")
+        ws_slug=$(extract_gh_slug "$ws_remote")
+        if [[ -n "$ws_slug" && "$ws_slug" == "$repo_slug" ]]; then
+            local has_bridge
+            has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
+            if [[ "$has_bridge" -gt 0 ]]; then
+                local list_output
+                if list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null) \
+                    && [[ -n "$list_output" ]]; then
+                    # Output format: <short_id>\t<status>\t<title>
+                    # Reformat to: <short_id>\t<title>
+                    echo "$list_output" | awk -F'\t' '{print $1 "\t" $3}'
+                    return 0
+                fi
             fi
         fi
     fi

--- a/.agent/scripts/_issue_helpers.sh
+++ b/.agent/scripts/_issue_helpers.sh
@@ -74,19 +74,26 @@ issue_lookup() {
     ISSUE_BODY=""
 
     # --- Try git-bug ---
+    # Only use git-bug when --repo matches the repo at --root (git-bug's bridge
+    # only has issues for that repo). Skip to gh fallback for other repos.
     if command -v git-bug &>/dev/null && command -v jq &>/dev/null; then
-        local github_url="https://github.com/${repo_slug}/issues/${issue_num}"
+        local ws_remote ws_slug
+        ws_remote=$(git -C "$root_dir" remote get-url origin 2>/dev/null || echo "")
+        ws_slug=$(extract_gh_slug "$ws_remote")
+        if [[ -n "$ws_slug" && "$ws_slug" == "$repo_slug" ]]; then
+            local github_url="https://github.com/${repo_slug}/issues/${issue_num}"
 
-        _issue_lookup_gitbug "$root_dir" "$github_url"
+            _issue_lookup_gitbug "$root_dir" "$github_url"
 
-        # Sync-on-miss: if not found locally, pull and retry
-        if [[ -z "$ISSUE_TITLE" ]]; then
-            local has_bridge
-            has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
-            if [[ "$has_bridge" -gt 0 ]]; then
-                echo "  git-bug: cache miss for #${issue_num}, pulling from GitHub..." >&2
-                git -C "$root_dir" bug bridge pull github &>/dev/null || true
-                _issue_lookup_gitbug "$root_dir" "$github_url"
+            # Sync-on-miss: if not found locally, pull and retry
+            if [[ -z "$ISSUE_TITLE" ]]; then
+                local has_bridge
+                has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
+                if [[ "$has_bridge" -gt 0 ]]; then
+                    echo "  git-bug: cache miss for #${issue_num}, pulling from GitHub..." >&2
+                    git -C "$root_dir" bug bridge pull github &>/dev/null || true
+                    _issue_lookup_gitbug "$root_dir" "$github_url"
+                fi
             fi
         fi
     fi
@@ -150,7 +157,7 @@ _issue_lookup_gitbug() {
 # List open issues from git-bug or gh.
 #
 # Usage:
-#   issue_list_open [--repo <owner/repo>] [--root <dir>]
+#   issue_list_open --repo <owner/repo> [--root <dir>]
 #
 # Outputs one line per issue: <id>\t<title>
 # Note: <id> is a git-bug short ID (hex prefix) when served from git-bug,
@@ -210,7 +217,7 @@ issue_list_open() {
 # Count open issues from git-bug or gh.
 #
 # Usage:
-#   issue_count_open [--repo <owner/repo>] [--root <dir>]
+#   issue_count_open --repo <owner/repo> [--root <dir>]
 #
 # Outputs a single integer. Returns 0 on success, 1 if no source available.
 issue_count_open() {

--- a/.agent/scripts/_issue_helpers.sh
+++ b/.agent/scripts/_issue_helpers.sh
@@ -5,11 +5,25 @@
 # Source this file from other scripts:
 #   source "$SCRIPT_DIR/_issue_helpers.sh"
 #
-# Requires: jq (for JSON parsing)
+# Requires: jq (for git-bug JSON parsing)
 # Optional: git-bug v0.10+ with GitHub bridge configured
+#
+# The gh fallback uses gh's built-in --jq flag and does NOT require jq.
+# jq is only needed for the git-bug path.
 #
 # Pattern: try git-bug first (offline-capable), pull on cache miss,
 # fall back to gh CLI. See ADR-0010 and AGENTS.md "git-bug-first Pattern".
+
+# --- Utility: extract validated GitHub slug from remote URL ---
+# Returns the slug on stdout, empty if not a valid GitHub URL.
+extract_gh_slug() {
+    local url="$1"
+    local slug
+    slug=$(echo "$url" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+    if [[ "$slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+        echo "$slug"
+    fi
+}
 
 # --- Single-issue lookup ---
 # Fetch title, state, and body for a GitHub issue number.
@@ -77,15 +91,18 @@ issue_lookup() {
         fi
     fi
 
-    # --- Fall back to gh ---
+    # --- Fall back to gh (no jq required — uses gh's built-in --jq) ---
     if [[ -z "$ISSUE_TITLE" ]] && command -v gh &>/dev/null; then
-        local gh_json
-        gh_json=$(gh issue view "$issue_num" --repo "$repo_slug" \
-            --json title,state,body 2>/dev/null || echo "")
-        if [[ -n "$gh_json" ]]; then
-            ISSUE_TITLE=$(echo "$gh_json" | jq -r '.title // empty')
-            ISSUE_STATE=$(echo "$gh_json" | jq -r '.state // empty')
-            ISSUE_BODY=$(echo "$gh_json" | jq -r '.body // empty')
+        # Single API call; parse title and state with gh's --jq, fetch body separately
+        # (body can contain arbitrary text including our delimiter)
+        local gh_meta
+        gh_meta=$(gh issue view "$issue_num" --repo "$repo_slug" \
+            --json title,state --jq '.title + "||GH_SEP||" + .state' 2>/dev/null || echo "")
+        if [[ -n "$gh_meta" && "$gh_meta" == *"||GH_SEP||"* ]]; then
+            ISSUE_TITLE="${gh_meta%%||GH_SEP||*}"
+            ISSUE_STATE="${gh_meta#*||GH_SEP||}"
+            ISSUE_BODY=$(gh issue view "$issue_num" --repo "$repo_slug" \
+                --json body --jq '.body' 2>/dev/null || echo "")
         fi
     fi
 
@@ -135,7 +152,10 @@ _issue_lookup_gitbug() {
 # Usage:
 #   issue_list_open [--repo <owner/repo>] [--root <dir>]
 #
-# Outputs one line per issue: <human_id_or_number>\t<title>
+# Outputs one line per issue: <id>\t<title>
+# Note: <id> is a git-bug short ID (hex prefix) when served from git-bug,
+# or a GitHub issue number when served from gh. Callers that need GitHub
+# issue numbers should use the gh fallback explicitly.
 # Returns 0 on success, 1 if no source available.
 issue_list_open() {
     local repo_slug="" root_dir=""
@@ -158,8 +178,8 @@ issue_list_open() {
         has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
         if [[ "$has_bridge" -gt 0 ]]; then
             local list_output
-            list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null)
-            if [[ $? -eq 0 && -n "$list_output" ]]; then
+            if list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null) \
+                && [[ -n "$list_output" ]]; then
                 # Output format: <short_id>\t<status>\t<title>
                 # Reformat to: <short_id>\t<title>
                 echo "$list_output" | awk -F'\t' '{print $1 "\t" $3}'
@@ -168,7 +188,7 @@ issue_list_open() {
         fi
     fi
 
-    # --- Fall back to gh ---
+    # --- Fall back to gh (no jq required) ---
     if command -v gh &>/dev/null && [[ -n "$repo_slug" ]]; then
         gh issue list --repo "$repo_slug" --state open \
             --json number,title --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null
@@ -201,23 +221,31 @@ issue_count_open() {
     fi
 
     # --- Try git-bug ---
+    # git-bug's local store contains issues for the repo at $root_dir.
+    # Only use it when $repo_slug matches that repo's remote to avoid
+    # returning the wrong count when iterating over multiple repos.
     if command -v git-bug &>/dev/null; then
-        local has_bridge
-        has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
-        if [[ "$has_bridge" -gt 0 ]]; then
-            local list_output
-            if list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null); then
-                if [[ -z "$list_output" ]]; then
-                    echo "0"
-                else
-                    echo "$list_output" | grep -c .
+        local ws_remote ws_slug
+        ws_remote=$(git -C "$root_dir" remote get-url origin 2>/dev/null || echo "")
+        ws_slug=$(extract_gh_slug "$ws_remote")
+        if [[ -n "$ws_slug" && "$ws_slug" == "$repo_slug" ]]; then
+            local has_bridge
+            has_bridge=$(git -C "$root_dir" bug bridge 2>/dev/null | grep -c "github" || true)
+            if [[ "$has_bridge" -gt 0 ]]; then
+                local list_output
+                if list_output=$(git -C "$root_dir" bug bug status:open 2>/dev/null); then
+                    if [[ -z "$list_output" ]]; then
+                        echo "0"
+                    else
+                        echo "$list_output" | grep -c .
+                    fi
+                    return 0
                 fi
-                return 0
             fi
         fi
     fi
 
-    # --- Fall back to gh ---
+    # --- Fall back to gh (no jq required) ---
     if command -v gh &>/dev/null && [[ -n "$repo_slug" ]]; then
         gh api -X GET search/issues \
             -f q="repo:${repo_slug} is:issue is:open" \

--- a/.agent/scripts/dashboard.sh
+++ b/.agent/scripts/dashboard.sh
@@ -27,6 +27,9 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
+# shellcheck source=_issue_helpers.sh
+source "$SCRIPT_DIR/_issue_helpers.sh"
+
 # --- Parse arguments ---
 SKIP_SYNC=false
 SKIP_GITHUB=false
@@ -375,20 +378,7 @@ if [ "$SKIP_GITHUB" = false ]; then
         ISSUE_OUTPUT=""
         for repo in $REPOS; do
             [ -z "$repo" ] && continue
-            count=""
-            # Try git-bug for the workspace repo (where a bridge is configured)
-            if [ "$repo" = "$WS_REMOTE" ] && command -v git-bug &>/dev/null \
-                && git -C "$MAIN_ROOT" bug bridge list &>/dev/null 2>&1; then
-                _gb_output=$(git -C "$MAIN_ROOT" bug ls status:open 2>/dev/null)
-                _gb_rc=$?
-                if [ $_gb_rc -eq 0 ]; then
-                    count=$(printf '%s\n' "$_gb_output" | grep -c . || true)
-                fi
-            fi
-            # Fall back to gh API
-            if [ -z "$count" ] || ! [[ "$count" =~ ^[0-9]+$ ]]; then
-                count=$(gh api -X GET search/issues -f q="repo:$repo is:issue is:open" --jq '.total_count' 2>/dev/null || echo "0")
-            fi
+            count=$(issue_count_open --repo "$repo" --root "$MAIN_ROOT")
             [[ "$count" =~ ^[0-9]+$ ]] || count=0
             if [ "$count" -gt 0 ]; then
                 repo_name=$(basename "$repo")

--- a/.agent/scripts/merge_pr.sh
+++ b/.agent/scripts/merge_pr.sh
@@ -30,6 +30,9 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=_issue_helpers.sh
+source "$SCRIPT_DIR/_issue_helpers.sh"
+
 PR_NUMBER=""
 WORKTREE_TYPE=""
 
@@ -168,7 +171,20 @@ fi
 
 # --- Step 5: Roadmap reminder ---
 # Soft check: does the merged issue relate to a roadmap item?
-ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" "${GH_REPO_ARGS[@]}" --json title --jq '.title' 2>/dev/null || echo "")
+# Resolve repo slug for git-bug-first lookup
+_REPO_SLUG=""
+if [[ ${#GH_REPO_ARGS[@]} -gt 0 ]]; then
+    _REMOTE_URL="${GH_REPO_ARGS[1]:-}"
+else
+    _REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
+fi
+if [[ -n "$_REMOTE_URL" && "$_REMOTE_URL" == *"github.com"* ]]; then
+    _REPO_SLUG=$(echo "$_REMOTE_URL" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+fi
+ISSUE_TITLE=""
+if [[ -n "$_REPO_SLUG" ]]; then
+    issue_lookup "$ISSUE_NUM" --repo "$_REPO_SLUG" --root "$ROOT_DIR" || true
+fi
 if [[ -n "$ISSUE_TITLE" ]]; then
     ROADMAP_MATCHES=()
     # Extract significant keywords (3+ chars, skip common words)

--- a/.agent/scripts/merge_pr.sh
+++ b/.agent/scripts/merge_pr.sh
@@ -174,16 +174,19 @@ fi
 # Resolve repo slug for git-bug-first lookup
 _REPO_SLUG=""
 if [[ ${#GH_REPO_ARGS[@]} -gt 0 ]]; then
-    _REMOTE_URL="${GH_REPO_ARGS[1]:-}"
-else
-    _REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
+    _REPO_SLUG=$(extract_gh_slug "${GH_REPO_ARGS[1]:-}")
 fi
-if [[ -n "$_REMOTE_URL" && "$_REMOTE_URL" == *"github.com"* ]]; then
-    _REPO_SLUG=$(echo "$_REMOTE_URL" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+if [[ -z "$_REPO_SLUG" ]]; then
+    _REPO_SLUG=$(extract_gh_slug "$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null)")
 fi
 ISSUE_TITLE=""
 if [[ -n "$_REPO_SLUG" ]]; then
     issue_lookup "$ISSUE_NUM" --repo "$_REPO_SLUG" --root "$ROOT_DIR" || true
+fi
+# Fallback: if slug extraction failed (non-GitHub remote), try gh directly
+if [[ -z "$ISSUE_TITLE" ]] && [[ -z "$_REPO_SLUG" ]] && command -v gh &>/dev/null; then
+    ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" "${GH_REPO_ARGS[@]}" \
+        --json title --jq '.title' 2>/dev/null || echo "")
 fi
 if [[ -n "$ISSUE_TITLE" ]]; then
     ROADMAP_MATCHES=()

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -270,6 +270,11 @@ if [ -n "$ISSUE_NUM" ]; then
     if [ -n "$_LOOKUP_REPO" ]; then
         issue_lookup "$ISSUE_NUM" --repo "$_LOOKUP_REPO" --root "$ROOT_DIR" || true
     fi
+    # Fallback: if slug extraction failed (non-GitHub remote), try gh without --repo
+    if [ -z "$ISSUE_TITLE" ] && [ -z "$_LOOKUP_REPO" ] && command -v gh &>/dev/null; then
+        ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
+        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null || echo "")
+    fi
 
     # PR check stays gh-only — git-bug doesn't track PRs
     if command -v gh &>/dev/null; then

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -31,15 +31,7 @@ fetch_remote_branch() {
     git -C "$git_path" fetch --quiet origin -- "$branch" 2>/dev/null
 }
 
-# Extract a validated owner/repo slug from a GitHub remote URL.
-extract_gh_slug() {
-    local url="$1"
-    local slug
-    slug=$(echo "$url" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
-    if [[ "$slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-        echo "$slug"
-    fi
-}
+# extract_gh_slug is provided by _issue_helpers.sh (sourced above)
 
 # Defaults
 ISSUE_NUM=""

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -22,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 source "$SCRIPT_DIR/_worktree_helpers.sh"
+source "$SCRIPT_DIR/_issue_helpers.sh"
 
 # Try to fetch a specific branch from origin.
 fetch_remote_branch() {
@@ -267,24 +268,19 @@ fi
 ISSUE_TITLE=""
 ISSUE_STATE=""
 if [ -n "$ISSUE_NUM" ]; then
-    # Try git-bug first for issue title and state (offline-capable)
-    if command -v git-bug &>/dev/null; then
-        _BUG_OUTPUT=$(git -C "$ROOT_DIR" bug select "$ISSUE_NUM" 2>/dev/null \
-            && git -C "$ROOT_DIR" bug show 2>/dev/null || echo "")
-        if [ -n "$_BUG_OUTPUT" ]; then
-            _BUG_TITLE=$(echo "$_BUG_OUTPUT" | head -1 | sed 's/^[^ ]* //')
-            _BUG_STATE=$(echo "$_BUG_OUTPUT" | grep -i '^status:' | awk '{print $2}' || echo "")
-            if [ -n "$_BUG_TITLE" ]; then
-                ISSUE_TITLE="$_BUG_TITLE"
-                [[ "${_BUG_STATE,,}" == "closed" ]] && ISSUE_STATE="CLOSED"
-                [[ "${_BUG_STATE,,}" == "open" ]] && ISSUE_STATE="OPEN"
-            fi
-        fi
-        git -C "$ROOT_DIR" bug deselect 2>/dev/null || true
+    # Look up issue via git-bug (with sync-on-miss) then gh fallback
+    _LOOKUP_REPO="${GH_REPO_SLUG:-}"
+    if [ -z "$_LOOKUP_REPO" ]; then
+        # Best-effort: extract from workspace remote
+        _WS_URL=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
+        _LOOKUP_REPO=$(extract_gh_slug "$_WS_URL")
+    fi
+    if [ -n "$_LOOKUP_REPO" ]; then
+        issue_lookup "$ISSUE_NUM" --repo "$_LOOKUP_REPO" --root "$ROOT_DIR" || true
     fi
 
+    # PR check stays gh-only — git-bug doesn't track PRs
     if command -v gh &>/dev/null; then
-        # PR check stays gh-only — git-bug doesn't track PRs
         _PR_CHECK=""
         if [ -n "$GH_REPO_SLUG" ]; then
             _PR_CHECK=$(gh pr view "$ISSUE_NUM" --repo "$GH_REPO_SLUG" --json state --jq '.state' 2>/dev/null || echo "")
@@ -295,19 +291,6 @@ if [ -n "$ISSUE_NUM" ]; then
             echo "Error: #$ISSUE_NUM is a pull request, not an issue."
             echo "Use the original issue number instead."
             exit 1
-        fi
-
-        # Fall back to gh for title/state individually if git-bug didn't provide them
-        if [ -z "$ISSUE_TITLE" ] || [ -z "$ISSUE_STATE" ]; then
-            if [ -n "$GH_REPO_SLUG" ]; then
-                _ISSUE_INFO=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO_SLUG" --json title,state --jq '.title + "||" + .state' 2>/dev/null || echo "")
-            else
-                _ISSUE_INFO=$(gh issue view "$ISSUE_NUM" --json title,state --jq '.title + "||" + .state' 2>/dev/null || echo "")
-            fi
-            if [[ "$_ISSUE_INFO" == *"||"* ]]; then
-                [ -z "$ISSUE_TITLE" ] && ISSUE_TITLE="${_ISSUE_INFO%||*}"
-                [ -z "$ISSUE_STATE" ] && ISSUE_STATE="${_ISSUE_INFO##*||}"
-            fi
         fi
     fi
 

--- a/.agent/scripts/worktree_enter.sh
+++ b/.agent/scripts/worktree_enter.sh
@@ -250,17 +250,20 @@ fi
 if [ -z "$SKILL_NAME" ] && [ "$SHELL_SNIPPET" != true ]; then
 
     # Fetch and display issue title (git-bug first, then gh fallback)
+    # Try workspace repo first, then project repo for project-type worktrees
     _ISSUE_TITLE=""
-    _WS_REMOTE=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
-    _WS_SLUG=""
-    if [[ -n "$_WS_REMOTE" && "$_WS_REMOTE" == *"github.com"* ]]; then
-        _WS_SLUG=$(echo "$_WS_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
-        [[ "$_WS_SLUG" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || _WS_SLUG=""
-    fi
-
+    _WS_SLUG=$(extract_gh_slug "$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null)")
     if [ -n "$_WS_SLUG" ]; then
         issue_lookup "$ISSUE_NUM" --repo "$_WS_SLUG" --root "$ROOT_DIR" || true
         _ISSUE_TITLE="$ISSUE_TITLE"
+    fi
+    # If not found in workspace repo, try project repo
+    if [ -z "$_ISSUE_TITLE" ] && [ -d "$ROOT_DIR/project/.git" ]; then
+        _PJ_SLUG=$(extract_gh_slug "$(git -C "$ROOT_DIR/project" remote get-url origin 2>/dev/null)")
+        if [ -n "$_PJ_SLUG" ] && [ "$_PJ_SLUG" != "$_WS_SLUG" ]; then
+            issue_lookup "$ISSUE_NUM" --repo "$_PJ_SLUG" --root "$ROOT_DIR" || true
+            _ISSUE_TITLE="$ISSUE_TITLE"
+        fi
     fi
     WORKTREE_ISSUE_TITLE_VALUE="$_ISSUE_TITLE"
 fi

--- a/.agent/scripts/worktree_enter.sh
+++ b/.agent/scripts/worktree_enter.sh
@@ -25,6 +25,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 source "$SCRIPT_DIR/_worktree_helpers.sh"
+source "$SCRIPT_DIR/_issue_helpers.sh"
 
 ISSUE_NUM=""
 SKILL_NAME=""
@@ -248,21 +249,18 @@ fi
 
 if [ -z "$SKILL_NAME" ] && [ "$SHELL_SNIPPET" != true ]; then
 
-    # Fetch and display issue title
+    # Fetch and display issue title (git-bug first, then gh fallback)
     _ISSUE_TITLE=""
+    _WS_REMOTE=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
+    _WS_SLUG=""
+    if [[ -n "$_WS_REMOTE" && "$_WS_REMOTE" == *"github.com"* ]]; then
+        _WS_SLUG=$(echo "$_WS_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+        [[ "$_WS_SLUG" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || _WS_SLUG=""
+    fi
 
-    if command -v gh &>/dev/null; then
-        _ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
-        # Retry with workspace repo if needed
-        if [ -z "$_ISSUE_TITLE" ]; then
-            _WS_REMOTE=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
-            if [[ -n "$_WS_REMOTE" && "$_WS_REMOTE" == *"github.com"* ]]; then
-                _WS_SLUG=$(echo "$_WS_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
-                if [[ "$_WS_SLUG" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-                    _ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --repo "$_WS_SLUG" --json title --jq '.title' 2>/dev/null || echo "")
-                fi
-            fi
-        fi
+    if [ -n "$_WS_SLUG" ]; then
+        issue_lookup "$ISSUE_NUM" --repo "$_WS_SLUG" --root "$ROOT_DIR" || true
+        _ISSUE_TITLE="$ISSUE_TITLE"
     fi
     WORKTREE_ISSUE_TITLE_VALUE="$_ISSUE_TITLE"
 fi

--- a/.agent/scripts/worktree_enter.sh
+++ b/.agent/scripts/worktree_enter.sh
@@ -265,6 +265,10 @@ if [ -z "$SKILL_NAME" ] && [ "$SHELL_SNIPPET" != true ]; then
             _ISSUE_TITLE="$ISSUE_TITLE"
         fi
     fi
+    # Fallback: if slug extraction failed (non-GitHub remote), try gh without --repo
+    if [ -z "$_ISSUE_TITLE" ] && [ -z "$_WS_SLUG" ] && command -v gh &>/dev/null; then
+        _ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
+    fi
     WORKTREE_ISSUE_TITLE_VALUE="$_ISSUE_TITLE"
 fi
 

--- a/.agent/work-plans/issue-142/plan.md
+++ b/.agent/work-plans/issue-142/plan.md
@@ -7,62 +7,93 @@ https://github.com/rolker/agent_workspace/issues/142
 ## Context
 
 ADR-0010 requires trying git-bug first for issue reads, falling back to `gh`.
-Some scripts and skills comply (`worktree_create.sh`, `plan-task`, `review-plan`,
-`dashboard.sh`), but each reinvents the pattern inline. Other scripts and skills
-skip git-bug entirely. Discussion on the issue refined the pattern to include
-sync-on-miss reads and push-on-write semantics.
+Some scripts and skills attempt compliance (`worktree_create.sh`, `plan-task`,
+`review-plan`, `dashboard.sh`), but each reinvents the pattern inline. Other
+scripts and skills skip git-bug entirely. Discussion on the issue refined the
+pattern to include sync-on-miss reads and push-on-write semantics.
 
-Two distinct API patterns exist in compliant code:
-- **Text parsing** (`worktree_create.sh`): `git bug select/show` + sed/awk
-- **JSON parsing** (skills): `git-bug bug show --format json` + jq
+### Critical finding: existing "compliant" code is broken
 
-The existing `_worktree_helpers.sh` provides shared functions for worktree
-operations but has no issue lookup helpers.
+Investigation revealed that the existing git-bug code in `worktree_create.sh`
+uses `git bug select` — a command that **does not exist** in git-bug v0.10.1.
+The correct invocation is `git bug bug select`. This means all "compliant"
+single-issue lookups silently fail and fall back to `gh` every time.
+
+### git-bug CLI patterns (verified on v0.10.1)
+
+**Lookup by GitHub issue number** (two-step via metadata filter):
+```bash
+# Step 1: Find git-bug ID via bridge metadata
+BUG_ID=$(git -C "$ROOT" bug bug \
+  -m "github-url=https://github.com/OWNER/REPO/issues/N" \
+  --format json | jq -r '.[0].human_id // empty')
+
+# Step 2: Get full details
+git -C "$ROOT" bug bug show "$BUG_ID" --format json
+```
+
+The bridge stores `github-url` metadata on each synced bug. The list command
+(`git bug bug`) supports `-m key=value` filtering; the show command does not
+expose metadata. So lookup requires: list-with-filter to get the ID, then
+show for full details.
+
+**List open issues**: `git -C "$ROOT" bug bug status:open`
+
+**Key facts**:
+- `git -C` works with all `git bug` subcommands (repo targeting)
+- `--format json` works on both list and show
+- `show --format json` includes title, status, comments, but NOT metadata
+- `select`/`deselect` exist as `git bug bug select`/`deselect` (not `git bug select`)
+- The metadata filter requires the full GitHub URL, so the helper needs the repo slug
+
+### Existing utility infrastructure
+
+`_worktree_helpers.sh` provides shared functions for worktree operations.
+The new `_issue_helpers.sh` follows the same naming convention.
 
 ## Approach
 
 ### 1. Create shared helper: `.agent/scripts/_issue_helpers.sh`
 
-A sourced utility file (matching `_worktree_helpers.sh` naming convention) with
-these functions:
+A sourced utility file with these functions:
 
-- **`issue_lookup <N> [--repo <slug>] [--root <dir>]`** — single-issue lookup
+- **`issue_lookup <N> --repo <slug> [--root <dir>]`** — single-issue lookup
   returning title, state, and body. Implements the sync-on-miss pattern:
-  1. `git bug show` locally (cache hit = done, no network)
-  2. Cache miss: `git bug bridge pull github`, retry `git bug show`
+  1. Query git-bug via metadata filter:
+     `git bug bug -m "github-url=https://github.com/$REPO/issues/$N" --format json`
+  2. Cache miss: `git bug bridge pull github`, log it, retry the query
   3. Still missing: fall back to `gh issue view`
-  4. Log sync operations for transparency ("git-bug: pulling #N from GitHub...")
   
   Output: sets `ISSUE_TITLE`, `ISSUE_STATE`, `ISSUE_BODY` variables (caller
   sources the function). Returns 0 on success, 1 if neither source found the
   issue.
 
 - **`issue_list_open [--repo <slug>] [--root <dir>]`** — list open issues.
-  Tries `git bug ls status:open` first, falls back to `gh issue list`. Returns
-  one issue per line in `<number>\t<title>` format.
+  Tries `git bug bug status:open --format json` first, falls back to
+  `gh issue list`. Returns JSON array with number, title, status.
 
 - **`issue_count_open [--repo <slug>] [--root <dir>]`** — count open issues.
-  Thin wrapper around `issue_list_open | wc -l` or dedicated `git bug ls`
-  count.
+  Uses `git bug bug status:open` line count, falls back to `gh api`.
 
 Design decisions:
-- Use the **text parsing** approach for the shared helper (matches existing
-  script conventions; avoids jq dependency for scripts that don't already use it)
+- Use **JSON output** (`--format json`) for structured parsing — avoids fragile
+  text parsing with sed/awk, and jq is already a workspace dependency
+- `--repo` is required for single-issue lookup (needed to construct the GitHub
+  URL for metadata matching); optional for list/count (git-bug lists from the
+  local repo's bridge)
 - Skills will reference the canonical pattern in `AGENTS.md` rather than
   sourcing the helper (skills are instruction text, not executable code)
 - The `--root` flag defaults to the workspace root (needed for `git -C` context)
-- Always call `git bug deselect` after `select/show` (follows `worktree_create.sh`)
 
-### 2. Refactor compliant scripts to use the shared helper
+### 2. Fix and refactor existing git-bug callers
 
-Replace inline git-bug-first implementations with sourced helper calls:
+Replace broken inline implementations with sourced helper calls:
 
-- **`worktree_create.sh`** (lines 270-311): Replace ~40 lines with
-  `source _issue_helpers.sh` + `issue_lookup "$ISSUE_NUM"`
-- **`dashboard.sh`** (lines 379-391): Replace with `issue_count_open`
-
-This validates the helper against known-working behavior before applying it
-to new callers.
+- **`worktree_create.sh`** (lines 270-311): Currently uses `git bug select`
+  (wrong command — silently fails every time). Replace ~40 lines with
+  `source _issue_helpers.sh` + `issue_lookup "$ISSUE_NUM"`.
+- **`dashboard.sh`** (lines 379-391): Working (`git bug bug` list path is
+  correct here). Replace with `issue_count_open` for consistency.
 
 ### 3. Update non-compliant scripts
 
@@ -153,15 +184,12 @@ Add `_issue_helpers.sh` to the script reference table with purpose:
 
 ## Open Questions
 
-1. **Should existing compliant callers be refactored in this PR or a follow-up?**
-   The plan includes refactoring `worktree_create.sh` and `dashboard.sh` to
-   validate the helper, but this adds scope. Could defer to a separate PR if
-   preferred.
-
-2. **`git-bug` CLI invocation style**: `worktree_create.sh` uses
-   `git -C "$ROOT_DIR" bug select/show` while skills use `git-bug bug show --format json`.
-   The helper should pick one. Text parsing via `git -C` is more portable
-   (works with `--root` param) — confirm this is preferred over JSON+jq.
+None — resolved during planning:
+- Existing callers will be refactored in this PR (confirmed by Roland)
+- CLI style: use `git -C "$ROOT" bug bug` with `--format json` (combines
+  `-C` repo targeting with structured output; verified working on v0.10.1)
+- The `worktree_create.sh` git-bug code is broken (`git bug select` doesn't
+  exist) — this PR fixes it, not just adds compliance
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-142/plan.md
+++ b/.agent/work-plans/issue-142/plan.md
@@ -1,0 +1,170 @@
+# Plan: Scripts and skills bypass git-bug for issue reads (ADR-0010 compliance)
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/142
+
+## Context
+
+ADR-0010 requires trying git-bug first for issue reads, falling back to `gh`.
+Some scripts and skills comply (`worktree_create.sh`, `plan-task`, `review-plan`,
+`dashboard.sh`), but each reinvents the pattern inline. Other scripts and skills
+skip git-bug entirely. Discussion on the issue refined the pattern to include
+sync-on-miss reads and push-on-write semantics.
+
+Two distinct API patterns exist in compliant code:
+- **Text parsing** (`worktree_create.sh`): `git bug select/show` + sed/awk
+- **JSON parsing** (skills): `git-bug bug show --format json` + jq
+
+The existing `_worktree_helpers.sh` provides shared functions for worktree
+operations but has no issue lookup helpers.
+
+## Approach
+
+### 1. Create shared helper: `.agent/scripts/_issue_helpers.sh`
+
+A sourced utility file (matching `_worktree_helpers.sh` naming convention) with
+these functions:
+
+- **`issue_lookup <N> [--repo <slug>] [--root <dir>]`** — single-issue lookup
+  returning title, state, and body. Implements the sync-on-miss pattern:
+  1. `git bug show` locally (cache hit = done, no network)
+  2. Cache miss: `git bug bridge pull github`, retry `git bug show`
+  3. Still missing: fall back to `gh issue view`
+  4. Log sync operations for transparency ("git-bug: pulling #N from GitHub...")
+  
+  Output: sets `ISSUE_TITLE`, `ISSUE_STATE`, `ISSUE_BODY` variables (caller
+  sources the function). Returns 0 on success, 1 if neither source found the
+  issue.
+
+- **`issue_list_open [--repo <slug>] [--root <dir>]`** — list open issues.
+  Tries `git bug ls status:open` first, falls back to `gh issue list`. Returns
+  one issue per line in `<number>\t<title>` format.
+
+- **`issue_count_open [--repo <slug>] [--root <dir>]`** — count open issues.
+  Thin wrapper around `issue_list_open | wc -l` or dedicated `git bug ls`
+  count.
+
+Design decisions:
+- Use the **text parsing** approach for the shared helper (matches existing
+  script conventions; avoids jq dependency for scripts that don't already use it)
+- Skills will reference the canonical pattern in `AGENTS.md` rather than
+  sourcing the helper (skills are instruction text, not executable code)
+- The `--root` flag defaults to the workspace root (needed for `git -C` context)
+- Always call `git bug deselect` after `select/show` (follows `worktree_create.sh`)
+
+### 2. Refactor compliant scripts to use the shared helper
+
+Replace inline git-bug-first implementations with sourced helper calls:
+
+- **`worktree_create.sh`** (lines 270-311): Replace ~40 lines with
+  `source _issue_helpers.sh` + `issue_lookup "$ISSUE_NUM"`
+- **`dashboard.sh`** (lines 379-391): Replace with `issue_count_open`
+
+This validates the helper against known-working behavior before applying it
+to new callers.
+
+### 3. Update non-compliant scripts
+
+- **`worktree_enter.sh`** (lines 249-268): Replace gh-only title fetch with
+  `source _issue_helpers.sh` + `issue_lookup "$ISSUE_NUM"`. Keep the
+  multi-repo retry logic (workspace slug fallback).
+- **`merge_pr.sh`** (line 171): Replace gh-only title fetch with
+  `issue_lookup "$ISSUE_NUM"`. Only title is needed here (for roadmap matching).
+
+### 4. Update non-compliant skill instructions
+
+Update the git-bug-first pattern text in skill SKILL.md files. These are
+instruction text (not executable), so they reference the canonical pattern
+rather than sourcing the helper:
+
+- **`review-issue`** step 1: Add git-bug-first lookup before `gh issue view`
+- **`what-next`** step 3: Add git-bug list alternative for bridged repos
+- **`issue-triage`** step 2: Add git-bug list alternative for bridged repos
+
+For `onboard-project` — skip. `gh issue create` is a write to GitHub;
+git-bug create + push is lower value here and the issue review flagged
+this as a likely false positive.
+
+### 5. Document canonical pattern in `AGENTS.md`
+
+Add a "git-bug-first Pattern" subsection under "GitHub CLI Patterns":
+
+- When to use git-bug vs `gh` (reads vs writes vs PR ops)
+- Sync-on-miss behavior for reads
+- Push-on-write behavior for writes
+- Reference to `_issue_helpers.sh` for scripts
+- Code snippet for skills to copy
+
+### 6. Update ADR-0010 with sync strategy
+
+Append a "Sync Strategy" section documenting:
+- Pull-on-miss for reads
+- Push-on-write for writes
+- `make sync` for bulk reconciliation
+- Rationale: avoid always-sync overhead while covering stale-cache case
+
+### 7. Update script reference table in `AGENTS.md`
+
+Add `_issue_helpers.sh` to the script reference table with purpose:
+"Shared git-bug-first issue lookup with sync-on-miss (source)".
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/_issue_helpers.sh` | **New** — shared helper with `issue_lookup`, `issue_list_open`, `issue_count_open` |
+| `.agent/scripts/worktree_create.sh` | Refactor: replace inline git-bug code with sourced helper |
+| `.agent/scripts/dashboard.sh` | Refactor: replace inline git-bug code with sourced helper |
+| `.agent/scripts/worktree_enter.sh` | Fix: add git-bug-first via sourced helper |
+| `.agent/scripts/merge_pr.sh` | Fix: add git-bug-first via sourced helper |
+| `.claude/skills/review-issue/SKILL.md` | Fix: add git-bug-first instruction pattern |
+| `.claude/skills/what-next/SKILL.md` | Fix: add git-bug list instruction pattern |
+| `.claude/skills/issue-triage/SKILL.md` | Fix: add git-bug list instruction pattern |
+| `AGENTS.md` | Add git-bug-first pattern docs + script reference entry |
+| `docs/decisions/0010-git-bug-is-optional.md` | Append sync strategy section |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Enforcement over documentation | Shared helper enforces the pattern in scripts; skill text is advisory but backed by `AGENTS.md` docs |
+| A change includes its consequences | `AGENTS.md` docs, ADR update, and script reference table all included in scope |
+| Only what's needed | Helper has 3 functions matching 3 observed use cases; no speculative API |
+| Improve incrementally | Single PR, mechanical changes; refactors existing compliant code first to validate helper |
+| Human control and transparency | Helper logs sync operations so pull-on-miss is visible |
+| Workspace improvements cascade to projects | Helper is project-agnostic; any repo with git-bug bridge benefits |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0010 — git-bug installed by default | Yes | This is the ADR being enforced; sync strategy appended to it |
+| 0006 — Shared AGENTS.md | Yes | Pattern documented in AGENTS.md; framework adapters checked |
+| 0003 — Project-agnostic workspace | Yes | Helper uses `--repo`/`--root` params, not hardcoded repos |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Scripts in `.agent/scripts/` | Script reference table in `AGENTS.md` | Yes (step 7) |
+| `AGENTS.md` | Framework adapters (`.github/copilot-instructions.md`, etc.) | Yes — check if adapters reference gh CLI patterns |
+| ADR in `docs/decisions/` | Principles review guide ADR table | Yes — verify 0010 description still matches |
+
+## Open Questions
+
+1. **Should existing compliant callers be refactored in this PR or a follow-up?**
+   The plan includes refactoring `worktree_create.sh` and `dashboard.sh` to
+   validate the helper, but this adds scope. Could defer to a separate PR if
+   preferred.
+
+2. **`git-bug` CLI invocation style**: `worktree_create.sh` uses
+   `git -C "$ROOT_DIR" bug select/show` while skills use `git-bug bug show --format json`.
+   The helper should pick one. Text parsing via `git -C` is more portable
+   (works with `--root` param) — confirm this is preferred over JSON+jq.
+
+## Estimated Scope
+
+Single PR. ~10 files changed, but most changes are mechanical (replace inline
+pattern with helper call or add instruction text). The shared helper is the
+only net-new code (~60-80 lines).

--- a/.agent/work-plans/issue-142/progress.md
+++ b/.agent/work-plans/issue-142/progress.md
@@ -49,3 +49,16 @@ Major plan revision after discovering:
 - [ ] (suggestion) issue_list_open uses fragile $? pattern vs idiomatic if-assignment in issue_count_open — `_issue_helpers.sh:180-181`
 - [ ] (suggestion) issue_list_open returns different ID types (git-bug short_id vs GitHub number) — `_issue_helpers.sh:182-184`
 - [ ] (suggestion) Duplicated slug extraction in merge_pr.sh and worktree_enter.sh — consider sharing extract_gh_slug — `merge_pr.sh:174-187`
+
+## External Review
+**Status**: complete
+**When**: 2026-04-06 01:30
+**By**: Claude Code Agent (claude-opus-4-6)
+
+**PR**: #143 — 2 review(s), 3 valid, 3 false positives
+**CI**: all-pass
+
+### Actions
+- [ ] Guard git-bug path in issue_list_open/issue_count_open — only use when --repo matches bridged repo
+- [ ] Add direct gh fallback in worktree_create.sh when slug extraction fails
+- [ ] Rewrite what-next and issue-triage skill snippets — git-bug is count-only, gh is primary for cross-referencing

--- a/.agent/work-plans/issue-142/progress.md
+++ b/.agent/work-plans/issue-142/progress.md
@@ -12,6 +12,21 @@ issue: 142
 Plan file: `.agent/work-plans/issue-142/plan.md`.
 
 Create a shared `_issue_helpers.sh` with sync-on-miss reads (git-bug first,
-pull on cache miss, fall back to gh). Refactor existing compliant scripts to
-validate the helper, then update non-compliant scripts and skill instructions.
-Document the canonical pattern in AGENTS.md and append sync strategy to ADR-0010.
+pull on cache miss, fall back to gh). Refactor existing callers (including
+fixing broken `git bug select` invocations in worktree_create.sh) and update
+non-compliant scripts and skill instructions. Document the canonical pattern
+in AGENTS.md and append sync strategy to ADR-0010.
+
+## Plan update
+**Status**: complete
+**When**: 2026-04-05 23:50
+**By**: Claude Code Agent (claude-opus-4-6)
+
+Major plan revision after discovering:
+1. `git bug select` doesn't exist in v0.10.1 — existing "compliant" code is
+   broken (silently falls back to gh every time)
+2. Correct invocation is `git bug bug select/show/etc.`
+3. GitHub issue number lookup requires metadata filter:
+   `git bug bug -m "github-url=https://github.com/OWNER/REPO/issues/N"`
+4. Switched from text parsing to JSON output (`--format json`) since the
+   metadata lookup inherently needs structured parsing

--- a/.agent/work-plans/issue-142/progress.md
+++ b/.agent/work-plans/issue-142/progress.md
@@ -59,6 +59,19 @@ Major plan revision after discovering:
 **CI**: all-pass
 
 ### Actions
-- [ ] Guard git-bug path in issue_list_open/issue_count_open — only use when --repo matches bridged repo
-- [ ] Add direct gh fallback in worktree_create.sh when slug extraction fails
-- [ ] Rewrite what-next and issue-triage skill snippets — git-bug is count-only, gh is primary for cross-referencing
+- [x] Guard git-bug path in issue_list_open/issue_count_open — only use when --repo matches bridged repo
+- [x] Add direct gh fallback in worktree_create.sh when slug extraction fails
+- [x] Rewrite what-next and issue-triage skill snippets — git-bug is count-only, gh is primary for cross-referencing
+
+## External Review (round 2)
+**Status**: complete
+**When**: 2026-04-06 02:00
+**By**: Claude Code Agent (claude-opus-4-6)
+
+**PR**: #143 — 3 review(s), 3 valid, 2 false positives
+**CI**: all-pass
+
+### Actions
+- [ ] Add repo-slug guard to issue_lookup git-bug path — skip git-bug when --repo doesn't match --root's remote
+- [ ] Update what-next and issue-triage skill snippets — add `| wc -l` to git-bug "count only" line
+- [ ] Update --repo documentation in _issue_helpers.sh and AGENTS.md — mark as required for list/count

--- a/.agent/work-plans/issue-142/progress.md
+++ b/.agent/work-plans/issue-142/progress.md
@@ -30,3 +30,22 @@ Major plan revision after discovering:
    `git bug bug -m "github-url=https://github.com/OWNER/REPO/issues/N"`
 4. Switched from text parsing to JSON output (`--format json`) since the
    metadata lookup inherently needs structured parsing
+
+## Local Review
+**Status**: complete
+**When**: 2026-04-06 00:45
+**By**: Claude Code Agent (claude-opus-4-6)
+**Verdict**: changes-requested
+
+**PR**: #143 at `8c8b9ab`
+**Depth**: Deep (reason: 671 lines, 13 files, governance files modified)
+**Must-fix**: 3 | **Suggestions**: 4
+
+### Findings
+- [ ] (must-fix) jq dependency unguarded on gh fallback path in issue_lookup — `_issue_helpers.sh:100-107`
+- [ ] (must-fix) Lost multi-repo fallback in worktree_enter.sh — only tries workspace slug now — `worktree_enter.sh:253-265`
+- [ ] (must-fix) Incomplete sync-on-miss retry in review-issue skill snippet — `review-issue/SKILL.md:722-727`
+- [ ] (suggestion) plan-task and review-plan skills use wrong git-bug lookup pattern (human_id != GitHub issue number)
+- [ ] (suggestion) issue_list_open uses fragile $? pattern vs idiomatic if-assignment in issue_count_open — `_issue_helpers.sh:180-181`
+- [ ] (suggestion) issue_list_open returns different ID types (git-bug short_id vs GitHub number) — `_issue_helpers.sh:182-184`
+- [ ] (suggestion) Duplicated slug extraction in merge_pr.sh and worktree_enter.sh — consider sharing extract_gh_slug — `merge_pr.sh:174-187`

--- a/.agent/work-plans/issue-142/progress.md
+++ b/.agent/work-plans/issue-142/progress.md
@@ -72,6 +72,17 @@ Major plan revision after discovering:
 **CI**: all-pass
 
 ### Actions
-- [ ] Add repo-slug guard to issue_lookup git-bug path — skip git-bug when --repo doesn't match --root's remote
-- [ ] Update what-next and issue-triage skill snippets — add `| wc -l` to git-bug "count only" line
-- [ ] Update --repo documentation in _issue_helpers.sh and AGENTS.md — mark as required for list/count
+- [x] Add repo-slug guard to issue_lookup git-bug path — skip git-bug when --repo doesn't match --root's remote
+- [x] Update what-next and issue-triage skill snippets — add `| wc -l` to git-bug "count only" line
+- [x] Update --repo documentation in _issue_helpers.sh and AGENTS.md — mark as required for list/count
+
+## External Review (round 3)
+**Status**: complete
+**When**: 2026-04-06 02:15
+**By**: Claude Code Agent (claude-opus-4-6)
+
+**PR**: #143 — 4 review(s), 1 valid, 0 false positives
+**CI**: all-pass
+
+### Actions
+- [ ] Add direct gh fallback in worktree_enter.sh when slug extraction fails

--- a/.agent/work-plans/issue-142/progress.md
+++ b/.agent/work-plans/issue-142/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 142
+---
+
+# Issue #142 — Scripts and skills bypass git-bug for issue reads (ADR-0010 compliance)
+
+## Plan
+**Status**: complete
+**When**: 2026-04-05 23:30
+**By**: Claude Code Agent (claude-opus-4-6)
+
+Plan file: `.agent/work-plans/issue-142/plan.md`.
+
+Create a shared `_issue_helpers.sh` with sync-on-miss reads (git-bug first,
+pull on cache miss, fall back to gh). Refactor existing compliant scripts to
+validate the helper, then update non-compliant scripts and skill instructions.
+Document the canonical pattern in AGENTS.md and append sync strategy to ADR-0010.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -39,18 +39,20 @@ If `--repo` was specified, filter to just that repository.
 
 ### 2. Fetch open issues per repo
 
-For each repository, try git-bug first for offline-capable issue listing,
-then fall back to `gh`:
+For each repository, fetch issues via `gh` (needed for labels, timestamps,
+assignees used in categorization). git-bug can provide a quick offline count
+but lacks these fields.
 
 ```bash
-# git-bug first (for repos with a configured bridge)
-if command -v git-bug &>/dev/null \
-    && git bug bridge 2>/dev/null | grep -q github; then
-    git bug bug status:open --format json
-fi
-
-# Fall back to gh
+# Primary: gh (provides number, title, labels, timestamps, assignees, URLs)
 gh issue list --repo <owner/repo> --state open --json number,title,labels,createdAt,updatedAt,url,assignees --limit 100
+
+# Optional: git-bug for offline issue count (when gh is unavailable)
+# Note: git-bug output lacks labels, timestamps, and URLs — use only for counts
+if ! command -v gh &>/dev/null && command -v git-bug &>/dev/null \
+    && git bug bridge 2>/dev/null | grep -q github; then
+    git bug bug status:open   # count only
+fi
 ```
 
 Collect all results into a unified list with the repo name attached.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -39,9 +39,17 @@ If `--repo` was specified, filter to just that repository.
 
 ### 2. Fetch open issues per repo
 
-For each repository:
+For each repository, try git-bug first for offline-capable issue listing,
+then fall back to `gh`:
 
 ```bash
+# git-bug first (for repos with a configured bridge)
+if command -v git-bug &>/dev/null \
+    && git bug bridge 2>/dev/null | grep -q github; then
+    git bug bug status:open --format json
+fi
+
+# Fall back to gh
 gh issue list --repo <owner/repo> --state open --json number,title,labels,createdAt,updatedAt,url,assignees --limit 100
 ```
 

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -51,7 +51,7 @@ gh issue list --repo <owner/repo> --state open --json number,title,labels,create
 # Note: git-bug output lacks labels, timestamps, and URLs — use only for counts
 if ! command -v gh &>/dev/null && command -v git-bug &>/dev/null \
     && git bug bridge 2>/dev/null | grep -q github; then
-    git bug bug status:open   # count only
+    git bug bug status:open | wc -l   # count only
 fi
 ```
 

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -32,14 +32,29 @@ Try git-bug first for offline-capable issue reading, then fall back to `gh`:
 
 ```bash
 # git-bug first (offline-capable) — provides title, body, and status
+# Look up by GitHub URL metadata (git-bug human_id != GitHub issue number)
 ISSUE_TITLE=""
 ISSUE_BODY=""
-if command -v git-bug &>/dev/null; then
-    _BUG_JSON=$(git-bug bug show "<N>" --format json 2>/dev/null || echo "")
-    if [ -n "$_BUG_JSON" ]; then
-        ISSUE_TITLE=$(echo "$_BUG_JSON" | jq -r '.title // empty')
-        # The body is the first comment's message (comment index 0)
-        ISSUE_BODY=$(echo "$_BUG_JSON" | jq -r '.comments[0].message // empty')
+if command -v git-bug &>/dev/null && command -v jq &>/dev/null; then
+    _REPO_SLUG="<owner/repo>"  # resolve from git remote
+    _GITHUB_URL="https://github.com/${_REPO_SLUG}/issues/<N>"
+    _LIST_JSON=$(git bug bug -m "github-url=${_GITHUB_URL}" --format json 2>/dev/null || echo "")
+    _BUG_ID=$(echo "$_LIST_JSON" | jq -r '.[0].human_id // empty' 2>/dev/null)
+    if [ -n "$_BUG_ID" ]; then
+        _SHOW_JSON=$(git bug bug show "$_BUG_ID" --format json 2>/dev/null || echo "")
+        ISSUE_TITLE=$(echo "$_SHOW_JSON" | jq -r '.title // empty')
+        ISSUE_BODY=$(echo "$_SHOW_JSON" | jq -r '.comments[0].message // empty')
+    fi
+    # Sync-on-miss: if not found, pull from GitHub and retry
+    if [ -z "$ISSUE_TITLE" ]; then
+        git bug bridge pull github &>/dev/null || true
+        _LIST_JSON=$(git bug bug -m "github-url=${_GITHUB_URL}" --format json 2>/dev/null || echo "")
+        _BUG_ID=$(echo "$_LIST_JSON" | jq -r '.[0].human_id // empty' 2>/dev/null)
+        if [ -n "$_BUG_ID" ]; then
+            _SHOW_JSON=$(git bug bug show "$_BUG_ID" --format json 2>/dev/null || echo "")
+            ISSUE_TITLE=$(echo "$_SHOW_JSON" | jq -r '.title // empty')
+            ISSUE_BODY=$(echo "$_SHOW_JSON" | jq -r '.comments[0].message // empty')
+        fi
     fi
 fi
 

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -43,10 +43,17 @@ if command -v git-bug &>/dev/null && command -v jq &>/dev/null; then
         ISSUE_TITLE=$(echo "$_SHOW_JSON" | jq -r '.title // empty')
         ISSUE_BODY=$(echo "$_SHOW_JSON" | jq -r '.comments[0].message // empty')
     fi
-    # Sync-on-miss: if not found, pull and retry
+    # Sync-on-miss: if not found, pull from GitHub and retry
     if [ -z "$ISSUE_TITLE" ]; then
+        echo "  git-bug: cache miss, pulling from GitHub..." >&2
         git bug bridge pull github &>/dev/null || true
-        # retry the same lookup...
+        _LIST_JSON=$(git bug bug -m "github-url=${_GITHUB_URL}" --format json 2>/dev/null || echo "")
+        _BUG_ID=$(echo "$_LIST_JSON" | jq -r '.[0].human_id // empty' 2>/dev/null)
+        if [ -n "$_BUG_ID" ]; then
+            _SHOW_JSON=$(git bug bug show "$_BUG_ID" --format json 2>/dev/null || echo "")
+            ISSUE_TITLE=$(echo "$_SHOW_JSON" | jq -r '.title // empty')
+            ISSUE_BODY=$(echo "$_SHOW_JSON" | jq -r '.comments[0].message // empty')
+        fi
     fi
 fi
 

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -27,9 +27,42 @@ repo? conflicting with ADRs?). For evaluating an implementation plan, use
 
 ### 1. Read the issue
 
+Try git-bug first for offline-capable issue reading, then fall back to `gh`:
+
 ```bash
-gh issue view <N> --json title,body,labels,assignees,milestone,comments,url
+# git-bug first (offline-capable) — provides title, body, and comments
+ISSUE_TITLE=""
+ISSUE_BODY=""
+if command -v git-bug &>/dev/null && command -v jq &>/dev/null; then
+    _REPO_SLUG="<owner/repo>"  # resolve from git remote
+    _GITHUB_URL="https://github.com/${_REPO_SLUG}/issues/<N>"
+    _LIST_JSON=$(git bug bug -m "github-url=${_GITHUB_URL}" --format json 2>/dev/null || echo "")
+    _BUG_ID=$(echo "$_LIST_JSON" | jq -r '.[0].human_id // empty' 2>/dev/null)
+    if [ -n "$_BUG_ID" ]; then
+        _SHOW_JSON=$(git bug bug show "$_BUG_ID" --format json 2>/dev/null || echo "")
+        ISSUE_TITLE=$(echo "$_SHOW_JSON" | jq -r '.title // empty')
+        ISSUE_BODY=$(echo "$_SHOW_JSON" | jq -r '.comments[0].message // empty')
+    fi
+    # Sync-on-miss: if not found, pull and retry
+    if [ -z "$ISSUE_TITLE" ]; then
+        git bug bridge pull github &>/dev/null || true
+        # retry the same lookup...
+    fi
+fi
+
+# Fall back to gh if git-bug didn't provide the data
+if [ -z "$ISSUE_TITLE" ] || [ -z "$ISSUE_BODY" ]; then
+    _GH_JSON=$(gh issue view <N> --json title,body,labels,assignees,milestone,comments,url 2>/dev/null || echo "")
+    if [ -n "$_GH_JSON" ]; then
+        [ -z "$ISSUE_TITLE" ] && ISSUE_TITLE=$(echo "$_GH_JSON" | jq -r '.title')
+        [ -z "$ISSUE_BODY" ] && ISSUE_BODY=$(echo "$_GH_JSON" | jq -r '.body')
+    fi
+fi
 ```
+
+Check for review-issue comments — they contain scope assessment, principle
+flags, and ADR notes. Comments are available from `gh` output (`.comments[]`)
+or from git-bug JSON (`.comments[1:]` — index 0 is the issue body).
 
 Identify:
 - What is being proposed?

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -68,14 +68,29 @@ Try git-bug first for offline-capable issue reading, then fall back to `gh`:
 
 ```bash
 # git-bug first (offline-capable) — provides title, body, and comments
+# Look up by GitHub URL metadata (git-bug human_id != GitHub issue number)
 ISSUE_TITLE=""
 ISSUE_BODY=""
-if command -v git-bug &>/dev/null; then
-    _BUG_JSON=$(git-bug bug show "$ISSUE_NUM" --format json 2>/dev/null || echo "")
-    if [ -n "$_BUG_JSON" ]; then
-        ISSUE_TITLE=$(echo "$_BUG_JSON" | jq -r '.title // empty')
-        # The body is the first comment's message (comment index 0)
-        ISSUE_BODY=$(echo "$_BUG_JSON" | jq -r '.comments[0].message // empty')
+if command -v git-bug &>/dev/null && command -v jq &>/dev/null; then
+    _REPO_SLUG="<owner/repo>"  # resolve from git remote
+    _GITHUB_URL="https://github.com/${_REPO_SLUG}/issues/${ISSUE_NUM}"
+    _LIST_JSON=$(git bug bug -m "github-url=${_GITHUB_URL}" --format json 2>/dev/null || echo "")
+    _BUG_ID=$(echo "$_LIST_JSON" | jq -r '.[0].human_id // empty' 2>/dev/null)
+    if [ -n "$_BUG_ID" ]; then
+        _SHOW_JSON=$(git bug bug show "$_BUG_ID" --format json 2>/dev/null || echo "")
+        ISSUE_TITLE=$(echo "$_SHOW_JSON" | jq -r '.title // empty')
+        ISSUE_BODY=$(echo "$_SHOW_JSON" | jq -r '.comments[0].message // empty')
+    fi
+    # Sync-on-miss: if not found, pull from GitHub and retry
+    if [ -z "$ISSUE_TITLE" ]; then
+        git bug bridge pull github &>/dev/null || true
+        _LIST_JSON=$(git bug bug -m "github-url=${_GITHUB_URL}" --format json 2>/dev/null || echo "")
+        _BUG_ID=$(echo "$_LIST_JSON" | jq -r '.[0].human_id // empty' 2>/dev/null)
+        if [ -n "$_BUG_ID" ]; then
+            _SHOW_JSON=$(git bug bug show "$_BUG_ID" --format json 2>/dev/null || echo "")
+            ISSUE_TITLE=$(echo "$_SHOW_JSON" | jq -r '.title // empty')
+            ISSUE_BODY=$(echo "$_SHOW_JSON" | jq -r '.comments[0].message // empty')
+        fi
     fi
 fi
 

--- a/.claude/skills/what-next/SKILL.md
+++ b/.claude/skills/what-next/SKILL.md
@@ -103,7 +103,7 @@ gh issue list --repo <owner/repo> --state closed --json number,title,closedAt,ur
 # Note: git-bug output lacks labels, assignees, and URLs — use only for counts
 if ! command -v gh &>/dev/null && command -v git-bug &>/dev/null \
     && git bug bridge 2>/dev/null | grep -q github; then
-    git bug bug status:open   # count only
+    git bug bug status:open | wc -l   # count only
 fi
 ```
 

--- a/.claude/skills/what-next/SKILL.md
+++ b/.claude/skills/what-next/SKILL.md
@@ -87,25 +87,24 @@ WS_REPO=$(git remote get-url origin 2>/dev/null | sed -nE 's|.*github\.com[:/](.
 PJ_REPO=$(git -C project remote get-url origin 2>/dev/null | sed -nE 's|.*github\.com[:/](.+)(\.git)?$|\1|p')
 ```
 
-For each repo that has a roadmap, try git-bug first for offline-capable
-issue listing, then fall back to `gh`:
+For each repo that has a roadmap, fetch issues via `gh` (needed for labels,
+assignees, URLs used in the cross-reference step). git-bug can provide a
+quick offline count but lacks these fields.
 
 ```bash
-# git-bug first (for repos with a configured bridge)
-if command -v git-bug &>/dev/null \
-    && git bug bridge 2>/dev/null | grep -q github; then
-    # Open issues
-    git bug bug status:open
-    # Closed issues (git-bug lists all by default; filter for closed)
-    git bug bug status:closed
-fi
-
-# Fall back to gh
+# Primary: gh (provides number, title, labels, assignees, URLs)
 # Open issues
 gh issue list --repo <owner/repo> --state open --json number,title,labels,url,assignees --limit 200
 
 # Recently closed (up to 100 most recent, to detect staleness)
 gh issue list --repo <owner/repo> --state closed --json number,title,closedAt,url --limit 100
+
+# Optional: git-bug for offline issue count (when gh is unavailable)
+# Note: git-bug output lacks labels, assignees, and URLs — use only for counts
+if ! command -v gh &>/dev/null && command -v git-bug &>/dev/null \
+    && git bug bridge 2>/dev/null | grep -q github; then
+    git bug bug status:open   # count only
+fi
 ```
 
 ### 4. Cross-reference

--- a/.claude/skills/what-next/SKILL.md
+++ b/.claude/skills/what-next/SKILL.md
@@ -87,9 +87,20 @@ WS_REPO=$(git remote get-url origin 2>/dev/null | sed -nE 's|.*github\.com[:/](.
 PJ_REPO=$(git -C project remote get-url origin 2>/dev/null | sed -nE 's|.*github\.com[:/](.+)(\.git)?$|\1|p')
 ```
 
-For each repo that has a roadmap:
+For each repo that has a roadmap, try git-bug first for offline-capable
+issue listing, then fall back to `gh`:
 
 ```bash
+# git-bug first (for repos with a configured bridge)
+if command -v git-bug &>/dev/null \
+    && git bug bridge 2>/dev/null | grep -q github; then
+    # Open issues
+    git bug bug status:open
+    # Closed issues (git-bug lists all by default; filter for closed)
+    git bug bug status:closed
+fi
+
+# Fall back to gh
 # Open issues
 gh issue list --repo <owner/repo> --state open --json number,title,labels,url,assignees --limit 200
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,30 @@ gh pr view <N> --json url --jq '.url'
 gh repo view --json url --jq '.url'
 ```
 
+### git-bug-first Pattern (ADR-0010)
+
+For issue reads, try git-bug first (offline-capable), then fall back to `gh`.
+PR operations (`gh pr view/merge/create/diff`) stay `gh`-only — git-bug
+doesn't track PRs.
+
+**Scripts**: source `.agent/scripts/_issue_helpers.sh` and use:
+- `issue_lookup <N> --repo <owner/repo> [--root <dir>]` — single issue
+- `issue_list_open [--repo <owner/repo>] [--root <dir>]` — list open issues
+- `issue_count_open [--repo <owner/repo>] [--root <dir>]` — count open issues
+
+**Sync behavior**:
+- **Reads**: local cache first; on miss, `git bug bridge pull github` + retry,
+  then fall back to `gh`
+- **Writes**: local git-bug op, then immediate `git bug bridge push github`
+- **Periodic**: `make sync` for full bidirectional reconciliation
+
+**git-bug CLI notes** (v0.10.1):
+- Use `git bug bug ...` (not `git bug ...`) for issue commands
+- Use `git bug bridge` (no subcommand) to list bridges — `bridge list` doesn't exist
+- Lookup by GitHub issue number uses metadata filter:
+  `git bug bug -m "github-url=https://github.com/OWNER/REPO/issues/N" --format json`
+- `--format json` works on both list (`bug bug`) and show (`bug bug show`)
+
 ### Repo Targeting in Scratchpad Clones
 
 The `gh` CLI resolves the target repo from the current directory's git remote.
@@ -281,6 +305,7 @@ Scripts marked **(source)** must be sourced; all others should be executed.
 
 | Script | Purpose |
 |--------|---------|
+| `.agent/scripts/_issue_helpers.sh` | Shared git-bug-first issue lookup with sync-on-miss **(source)** |
 | `.agent/scripts/set_git_identity_env.sh` | Ephemeral git identity (session-only) **(source)** |
 | `.agent/scripts/worktree_create.sh` | Create isolated worktree |
 | `.agent/scripts/worktree_enter.sh` | Enter worktree **(source)** |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,8 +213,8 @@ doesn't track PRs.
 
 **Scripts**: source `.agent/scripts/_issue_helpers.sh` and use:
 - `issue_lookup <N> --repo <owner/repo> [--root <dir>]` — single issue
-- `issue_list_open [--repo <owner/repo>] [--root <dir>]` — list open issues
-- `issue_count_open [--repo <owner/repo>] [--root <dir>]` — count open issues
+- `issue_list_open --repo <owner/repo> [--root <dir>]` — list open issues
+- `issue_count_open --repo <owner/repo> [--root <dir>]` — count open issues
 
 **Sync behavior**:
 - **Reads**: local cache first; on miss, `git bug bridge pull github` + retry,

--- a/docs/decisions/0010-git-bug-is-optional.md
+++ b/docs/decisions/0010-git-bug-is-optional.md
@@ -47,3 +47,31 @@ git-bug **is installed by default** in this workspace.
 **Opt-out:**
 Run `make skip-git-bug` to mark the stamp without running git-bug setup/configuration.
 The workspace degrades to gh-only (identical to previous behavior).
+
+## Sync Strategy
+
+git-bug's local cache syncs with GitHub at three levels:
+
+| Operation | Sync behavior |
+|-----------|---------------|
+| Issue read (cache hit) | Local only — no network |
+| Issue read (cache miss) | Pull from GitHub (`git bug bridge pull github`), retry locally, then fall back to `gh` |
+| Issue write | Local git-bug op, then immediate push (`git bug bridge push github`) |
+| Periodic | `make sync` runs full bidirectional pull + push |
+
+**Rationale:** Always-sync on every read adds unnecessary latency and API usage.
+Pull-on-miss covers the common stale-cache case (issue just created on GitHub)
+while keeping cache-hit reads instant and offline-capable. Writes push immediately
+so issues and comments are visible to collaborators and GitHub notifications
+without waiting for periodic sync.
+
+The shared helper `.agent/scripts/_issue_helpers.sh` implements the read
+pattern. See `AGENTS.md` "git-bug-first Pattern" for usage.
+
+## CLI Notes (v0.10.1)
+
+- Issue commands use the `bug` subcommand: `git bug bug show`, `git bug bug select`, etc.
+- Bridge listing: `git bug bridge` (bare command lists bridges; `bridge list` does not exist)
+- GitHub issue number lookup: metadata filter
+  `git bug bug -m "github-url=https://github.com/OWNER/REPO/issues/N" --format json`
+- `bug show --format json` includes title, status, and comments but not bridge metadata


### PR DESCRIPTION
Closes #142

# Plan: Scripts and skills bypass git-bug for issue reads (ADR-0010 compliance)

## Issue

https://github.com/rolker/agent_workspace/issues/142

## Context

ADR-0010 requires trying git-bug first for issue reads, falling back to `gh`.
Some scripts and skills comply (`worktree_create.sh`, `plan-task`, `review-plan`,
`dashboard.sh`), but each reinvents the pattern inline. Other scripts and skills
skip git-bug entirely. Discussion on the issue refined the pattern to include
sync-on-miss reads and push-on-write semantics.

Two distinct API patterns exist in compliant code:
- **Text parsing** (`worktree_create.sh`): `git bug select/show` + sed/awk
- **JSON parsing** (skills): `git-bug bug show --format json` + jq

The existing `_worktree_helpers.sh` provides shared functions for worktree
operations but has no issue lookup helpers.

## Approach

### 1. Create shared helper: `.agent/scripts/_issue_helpers.sh`

A sourced utility file (matching `_worktree_helpers.sh` naming convention) with
these functions:

- **`issue_lookup <N> [--repo <slug>] [--root <dir>]`** — single-issue lookup
  returning title, state, and body. Implements the sync-on-miss pattern:
  1. `git bug show` locally (cache hit = done, no network)
  2. Cache miss: `git bug bridge pull github`, retry `git bug show`
  3. Still missing: fall back to `gh issue view`
  4. Log sync operations for transparency ("git-bug: pulling #N from GitHub...")
  
  Output: sets `ISSUE_TITLE`, `ISSUE_STATE`, `ISSUE_BODY` variables (caller
  sources the function). Returns 0 on success, 1 if neither source found the
  issue.

- **`issue_list_open [--repo <slug>] [--root <dir>]`** — list open issues.
  Tries `git bug ls status:open` first, falls back to `gh issue list`. Returns
  one issue per line in `<number>\t<title>` format.

- **`issue_count_open [--repo <slug>] [--root <dir>]`** — count open issues.
  Thin wrapper around `issue_list_open | wc -l` or dedicated `git bug ls`
  count.

Design decisions:
- Use the **text parsing** approach for the shared helper (matches existing
  script conventions; avoids jq dependency for scripts that don't already use it)
- Skills will reference the canonical pattern in `AGENTS.md` rather than
  sourcing the helper (skills are instruction text, not executable code)
- The `--root` flag defaults to the workspace root (needed for `git -C` context)
- Always call `git bug deselect` after `select/show` (follows `worktree_create.sh`)

### 2. Refactor compliant scripts to use the shared helper

Replace inline git-bug-first implementations with sourced helper calls:

- **`worktree_create.sh`** (lines 270-311): Replace ~40 lines with
  `source _issue_helpers.sh` + `issue_lookup "$ISSUE_NUM"`
- **`dashboard.sh`** (lines 379-391): Replace with `issue_count_open`

This validates the helper against known-working behavior before applying it
to new callers.

### 3. Update non-compliant scripts

- **`worktree_enter.sh`** (lines 249-268): Replace gh-only title fetch with
  `source _issue_helpers.sh` + `issue_lookup "$ISSUE_NUM"`. Keep the
  multi-repo retry logic (workspace slug fallback).
- **`merge_pr.sh`** (line 171): Replace gh-only title fetch with
  `issue_lookup "$ISSUE_NUM"`. Only title is needed here (for roadmap matching).

### 4. Update non-compliant skill instructions

Update the git-bug-first pattern text in skill SKILL.md files. These are
instruction text (not executable), so they reference the canonical pattern
rather than sourcing the helper:

- **`review-issue`** step 1: Add git-bug-first lookup before `gh issue view`
- **`what-next`** step 3: Add git-bug list alternative for bridged repos
- **`issue-triage`** step 2: Add git-bug list alternative for bridged repos

For `onboard-project` — skip. `gh issue create` is a write to GitHub;
git-bug create + push is lower value here and the issue review flagged
this as a likely false positive.

### 5. Document canonical pattern in `AGENTS.md`

Add a "git-bug-first Pattern" subsection under "GitHub CLI Patterns":

- When to use git-bug vs `gh` (reads vs writes vs PR ops)
- Sync-on-miss behavior for reads
- Push-on-write behavior for writes
- Reference to `_issue_helpers.sh` for scripts
- Code snippet for skills to copy

### 6. Update ADR-0010 with sync strategy

Append a "Sync Strategy" section documenting:
- Pull-on-miss for reads
- Push-on-write for writes
- `make sync` for bulk reconciliation
- Rationale: avoid always-sync overhead while covering stale-cache case

### 7. Update script reference table in `AGENTS.md`

Add `_issue_helpers.sh` to the script reference table with purpose:
"Shared git-bug-first issue lookup with sync-on-miss (source)".

## Files to Change

| File | Change |
|------|--------|
| `.agent/scripts/_issue_helpers.sh` | **New** — shared helper with `issue_lookup`, `issue_list_open`, `issue_count_open` |
| `.agent/scripts/worktree_create.sh` | Refactor: replace inline git-bug code with sourced helper |
| `.agent/scripts/dashboard.sh` | Refactor: replace inline git-bug code with sourced helper |
| `.agent/scripts/worktree_enter.sh` | Fix: add git-bug-first via sourced helper |
| `.agent/scripts/merge_pr.sh` | Fix: add git-bug-first via sourced helper |
| `.claude/skills/review-issue/SKILL.md` | Fix: add git-bug-first instruction pattern |
| `.claude/skills/what-next/SKILL.md` | Fix: add git-bug list instruction pattern |
| `.claude/skills/issue-triage/SKILL.md` | Fix: add git-bug list instruction pattern |
| `AGENTS.md` | Add git-bug-first pattern docs + script reference entry |
| `docs/decisions/0010-git-bug-is-optional.md` | Append sync strategy section |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Enforcement over documentation | Shared helper enforces the pattern in scripts; skill text is advisory but backed by `AGENTS.md` docs |
| A change includes its consequences | `AGENTS.md` docs, ADR update, and script reference table all included in scope |
| Only what's needed | Helper has 3 functions matching 3 observed use cases; no speculative API |
| Improve incrementally | Single PR, mechanical changes; refactors existing compliant code first to validate helper |
| Human control and transparency | Helper logs sync operations so pull-on-miss is visible |
| Workspace improvements cascade to projects | Helper is project-agnostic; any repo with git-bug bridge benefits |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0010 — git-bug installed by default | Yes | This is the ADR being enforced; sync strategy appended to it |
| 0006 — Shared AGENTS.md | Yes | Pattern documented in AGENTS.md; framework adapters checked |
| 0003 — Project-agnostic workspace | Yes | Helper uses `--repo`/`--root` params, not hardcoded repos |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| Scripts in `.agent/scripts/` | Script reference table in `AGENTS.md` | Yes (step 7) |
| `AGENTS.md` | Framework adapters (`.github/copilot-instructions.md`, etc.) | Yes — check if adapters reference gh CLI patterns |
| ADR in `docs/decisions/` | Principles review guide ADR table | Yes — verify 0010 description still matches |

## Open Questions

1. **Should existing compliant callers be refactored in this PR or a follow-up?**
   The plan includes refactoring `worktree_create.sh` and `dashboard.sh` to
   validate the helper, but this adds scope. Could defer to a separate PR if
   preferred.

2. **`git-bug` CLI invocation style**: `worktree_create.sh` uses
   `git -C "$ROOT_DIR" bug select/show` while skills use `git-bug bug show --format json`.
   The helper should pick one. Text parsing via `git -C` is more portable
   (works with `--root` param) — confirm this is preferred over JSON+jq.

## Estimated Scope

Single PR. ~10 files changed, but most changes are mechanical (replace inline
pattern with helper call or add instruction text). The shared helper is the
only net-new code (~60-80 lines).
