### PR TITLE
[PLAN] cross_model_review.sh fails when invoked outside target repo worktree

### DIFF
--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -170,6 +170,10 @@ fi
 
 # Resolve repo slug for explicit -R targeting (prevents misrouting in nested repos)
 if [[ -n "$EXPLICIT_REPO" ]]; then
+    if [[ ! "$EXPLICIT_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+        echo "ERROR: --repo value '${EXPLICIT_REPO}' is not a valid owner/repo slug" >&2
+        exit 2
+    fi
     GH_REPO_SLUG="$EXPLICIT_REPO"
 else
     GH_REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//' || echo "")

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -15,9 +15,11 @@
 # with --sync.
 #
 # Usage:
-#   .agent/scripts/cross_model_review.sh --pr <N>                       # gemini (default)
-#   .agent/scripts/cross_model_review.sh --pr <N> --agent codex         # specific agent
-#   .agent/scripts/cross_model_review.sh --pr <N> --agent claude --sync # force sync
+#   .agent/scripts/cross_model_review.sh --pr <N>                              # gemini (default)
+#   .agent/scripts/cross_model_review.sh --pr <N> --agent codex                # specific agent
+#   .agent/scripts/cross_model_review.sh --pr <N> --agent claude --sync        # force sync
+#   .agent/scripts/cross_model_review.sh --pr <N> --repo owner/repo            # explicit repo target
+#   .agent/scripts/cross_model_review.sh --pr <N> --work-dir /path/to/worktree # explicit artifact dir
 #
 # The script runs in whichever repo worktree it's invoked from.
 # Workspace issues run in workspace worktrees, project issues in project worktrees.
@@ -93,13 +95,16 @@ run_agent_sync() {
 PR_NUMBER=""
 FORCE_SYNC=false
 TARGET_AGENT="gemini"
+EXPLICIT_REPO=""
+EXPLICIT_WORK_DIR=""
+USAGE="Usage: $0 --pr <N> [--agent <name>] [--repo owner/repo] [--work-dir <path>] [--sync]"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pr)
             if [[ $# -lt 2 ]]; then
                 echo "ERROR: Missing value for --pr" >&2
-                echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+                echo "$USAGE" >&2
                 exit 2
             fi
             PR_NUMBER="$2"
@@ -108,10 +113,28 @@ while [[ $# -gt 0 ]]; do
         --agent)
             if [[ $# -lt 2 ]]; then
                 echo "ERROR: Missing value for --agent" >&2
-                echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+                echo "$USAGE" >&2
                 exit 2
             fi
             TARGET_AGENT="${2,,}"  # lowercase
+            shift 2
+            ;;
+        --repo|-R)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: Missing value for --repo" >&2
+                echo "$USAGE" >&2
+                exit 2
+            fi
+            EXPLICIT_REPO="$2"
+            shift 2
+            ;;
+        --work-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: Missing value for --work-dir" >&2
+                echo "$USAGE" >&2
+                exit 2
+            fi
+            EXPLICIT_WORK_DIR="$2"
             shift 2
             ;;
         --sync)
@@ -120,7 +143,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "ERROR: Unknown argument: $1" >&2
-            echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+            echo "$USAGE" >&2
             exit 2
             ;;
     esac
@@ -128,7 +151,7 @@ done
 
 if [[ -z "$PR_NUMBER" ]]; then
     echo "ERROR: --pr <N> is required" >&2
-    echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+    echo "$USAGE" >&2
     exit 2
 fi
 
@@ -146,7 +169,11 @@ if ! command -v gh &>/dev/null; then
 fi
 
 # Resolve repo slug for explicit -R targeting (prevents misrouting in nested repos)
-GH_REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//' || echo "")
+if [[ -n "$EXPLICIT_REPO" ]]; then
+    GH_REPO_SLUG="$EXPLICIT_REPO"
+else
+    GH_REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//' || echo "")
+fi
 GH_REPO_ARGS=()
 if [[ -n "$GH_REPO_SLUG" && "$GH_REPO_SLUG" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
     GH_REPO_ARGS=("-R" "$GH_REPO_SLUG")
@@ -194,21 +221,27 @@ fi
 ISSUE_NUMBER=""
 PR_BODY=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null || echo "")
 if [[ -n "$PR_BODY" ]]; then
-    # Look for "Closes #N", "Fixes #N", or "Resolves #N" first (portable, no PCRE)
-    ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | sed -nE 's/.*(Closes|Fixes|Resolves)[[:space:]]+#([0-9]+).*/\2/p' | head -n1)
+    # Look for GitHub close keywords (case-insensitive): Closes #N, Fixes #N, Resolves #N
+    # Also handles cross-repo form: Closes owner/repo#N (extracts just N)
+    ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
     if [[ -z "$ISSUE_NUMBER" ]]; then
-        # Fallback: first occurrence of "#N" anywhere in the body
-        ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | sed -nE 's/.*#([0-9]+).*/\1/p' | head -n1)
+        # Fallback: first standalone #N (not part of a URL path or hex color)
+        ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+')
     fi
 fi
 
 # Fall back to PR number if no issue found
 if [[ -z "$ISSUE_NUMBER" ]]; then
+    echo "INFO: Could not extract issue number from PR body — using PR number" >&2
     ISSUE_NUMBER="$PR_NUMBER"
 fi
 
 # --- Set up artifact directory (absolute paths for tmux session) ---
-WORK_PLANS_DIR="$(git rev-parse --show-toplevel)/.agent/work-plans/issue-${ISSUE_NUMBER}"
+if [[ -n "$EXPLICIT_WORK_DIR" ]]; then
+    WORK_PLANS_DIR="${EXPLICIT_WORK_DIR}/.agent/work-plans/issue-${ISSUE_NUMBER}"
+else
+    WORK_PLANS_DIR="$(git rev-parse --show-toplevel)/.agent/work-plans/issue-${ISSUE_NUMBER}"
+fi
 mkdir -p "$WORK_PLANS_DIR"
 
 PROMPT_FILE="${WORK_PLANS_DIR}/review-${TARGET_AGENT}-prompt.md"
@@ -251,8 +284,21 @@ printf '**Title**: %s\n**URL**: %s\n**PR Number**: #%s\n\n' \
 
 # Stream diff directly into the prompt file
 printf '## Diff\n\n```diff\n' >> "$PROMPT_FILE"
+DIFF_START_LINE=$(wc -l < "$PROMPT_FILE")
 if ! gh pr diff "$PR_NUMBER" "${GH_REPO_ARGS[@]}" >> "$PROMPT_FILE" 2>/dev/null; then
     echo "ERROR: Could not retrieve diff for PR #${PR_NUMBER}" >&2
+    echo '--- Review error: failed to retrieve diff ---' > "$FINDINGS_FILE"
+    exit 3
+fi
+DIFF_END_LINE=$(wc -l < "$PROMPT_FILE")
+
+# Guard: if diff is empty, abort with a clear error instead of launching an
+# agent with no content to review
+if [[ "$DIFF_END_LINE" -le "$DIFF_START_LINE" ]]; then
+    echo "ERROR: PR #${PR_NUMBER} diff is empty — nothing to review" >&2
+    echo "  This usually means the PR was not found in the target repo." >&2
+    echo "  Try passing --repo <owner/repo> explicitly." >&2
+    echo '--- Review error: diff was empty (PR not found or no changes) ---' > "$FINDINGS_FILE"
     exit 3
 fi
 printf '```\n\n' >> "$PROMPT_FILE"

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -162,6 +162,12 @@ if [[ -z "${AGENT_BINS[$TARGET_AGENT]+x}" ]]; then
     exit 2
 fi
 
+# Validate --repo slug (before dependency checks so bad input always exits 2)
+if [[ -n "$EXPLICIT_REPO" && ! "$EXPLICIT_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+    echo "ERROR: --repo value '${EXPLICIT_REPO}' is not a valid owner/repo slug" >&2
+    exit 2
+fi
+
 # --- Dependency checks ---
 if ! command -v gh &>/dev/null; then
     echo "WARNING: GitHub CLI (gh) not installed — required for PR metadata" >&2
@@ -170,10 +176,6 @@ fi
 
 # Resolve repo slug for explicit -R targeting (prevents misrouting in nested repos)
 if [[ -n "$EXPLICIT_REPO" ]]; then
-    if [[ ! "$EXPLICIT_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-        echo "ERROR: --repo value '${EXPLICIT_REPO}' is not a valid owner/repo slug" >&2
-        exit 2
-    fi
     GH_REPO_SLUG="$EXPLICIT_REPO"
 else
     GH_REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//' || echo "")

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -228,8 +228,10 @@ ISSUE_NUMBER=""
 PR_BODY=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null || echo "")
 if [[ -n "$PR_BODY" ]]; then
     # Look for GitHub close keywords (case-insensitive): Closes #N, Fixes #N, Resolves #N
+    # Requires word boundary before keyword to avoid "encloses", "prefixes", etc.
     # Also handles cross-repo form: Closes owner/repo#N (extracts just N)
-    ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
+    ISSUE_REF=$(printf '%s\n' "$PR_BODY" | grep -ioE '(^|[^[:alnum:]_])(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 || true)
+    ISSUE_NUMBER=$(printf '%s\n' "$ISSUE_REF" | grep -oE '[0-9]+$' || true)
     if [[ -z "$ISSUE_NUMBER" ]]; then
         # Fallback: first standalone #N (not part of a URL path or hex color)
         ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+')
@@ -244,6 +246,8 @@ fi
 
 # --- Set up artifact directory (absolute paths for tmux session) ---
 if [[ -n "$EXPLICIT_WORK_DIR" ]]; then
+    # Resolve to absolute path so tmux sessions find the directory
+    EXPLICIT_WORK_DIR=$(cd "$EXPLICIT_WORK_DIR" && pwd)
     WORK_PLANS_DIR="${EXPLICIT_WORK_DIR}/.agent/work-plans/issue-${ISSUE_NUMBER}"
 else
     WORK_PLANS_DIR="$(git rev-parse --show-toplevel)/.agent/work-plans/issue-${ISSUE_NUMBER}"

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -234,7 +234,7 @@ if [[ -n "$PR_BODY" ]]; then
     ISSUE_NUMBER=$(printf '%s\n' "$ISSUE_REF" | grep -oE '[0-9]+$' || true)
     if [[ -z "$ISSUE_NUMBER" ]]; then
         # Fallback: first standalone #N (not part of a URL path or hex color)
-        ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+')
+        ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
     fi
 fi
 
@@ -246,6 +246,10 @@ fi
 
 # --- Set up artifact directory (absolute paths for tmux session) ---
 if [[ -n "$EXPLICIT_WORK_DIR" ]]; then
+    if [[ ! -d "$EXPLICIT_WORK_DIR" ]]; then
+        echo "ERROR: --work-dir is not an existing directory: ${EXPLICIT_WORK_DIR}" >&2
+        exit 2
+    fi
     # Resolve to absolute path so tmux sessions find the directory
     EXPLICIT_WORK_DIR=$(cd "$EXPLICIT_WORK_DIR" && pwd)
     WORK_PLANS_DIR="${EXPLICIT_WORK_DIR}/.agent/work-plans/issue-${ISSUE_NUMBER}"

--- a/.agent/scripts/tests/test_cross_model_review.sh
+++ b/.agent/scripts/tests/test_cross_model_review.sh
@@ -86,46 +86,8 @@ test_repo_flag_accepted() {
     echo "TEST: --repo flag is accepted"
     setup
 
-    # Mock gh that records the -R argument it received
-    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
-#!/usr/bin/env bash
-# Record all args for inspection
-echo "$@" >> "${MOCK_GH_LOG}"
-case "$1" in
-    pr)
-        case "$3" in
-            --json)
-                if [[ "$4" == "body" ]]; then
-                    echo '{"body": "Closes #42"}'
-                    # jq emulation: if --jq is present, extract .body
-                    exit 0
-                elif [[ "$4" == "title" ]]; then
-                    echo "Test PR"
-                    exit 0
-                elif [[ "$4" == "url" ]]; then
-                    echo "https://github.com/test/repo/pull/99"
-                    exit 0
-                fi
-                ;;
-            *)
-                # gh pr diff — output a non-empty diff
-                echo "diff --git a/file.txt b/file.txt"
-                echo "--- a/file.txt"
-                echo "+++ b/file.txt"
-                echo "@@ -1 +1 @@"
-                echo "-old"
-                echo "+new"
-                exit 0
-                ;;
-        esac
-        ;;
-esac
-exit 0
-GH_EOF
-    chmod +x "${MOCK_BIN}/gh"
-
-    # gh outputs raw text; we need it to handle --jq itself. Simplify: make
-    # gh return the value directly for --jq queries.
+    # Mock gh that records arguments and returns direct values for --jq-style
+    # queries used by the test.
     cat > "${MOCK_BIN}/gh" << 'GH_EOF'
 #!/usr/bin/env bash
 echo "$@" >> "${MOCK_GH_LOG}"
@@ -322,7 +284,7 @@ GH_EOF
     cd "${MOCK_REPO}"
     local exit_code=0
     STDERR=$(PATH="${MOCK_BIN}:${PATH}" bash "${SCRIPT_UNDER_TEST}" \
-        --pr 99 --sync 2>&1 >/dev/null) || exit_code=$?
+        --pr 99 --sync 2>&1) || exit_code=$?
 
     assert_exit_code "empty diff exits 3" "3" "$exit_code"
     assert_contains "error message mentions empty diff" "diff is empty" "$STDERR"
@@ -359,12 +321,23 @@ test_unknown_argument() {
     assert_exit_code "unknown arg exits 2" "2" "$exit_code"
 }
 
+# ---- Test: --repo with invalid slug ----
+test_invalid_repo_slug() {
+    echo "TEST: --repo with invalid slug exits 2"
+
+    local exit_code=0
+    STDERR=$(bash "${SCRIPT_UNDER_TEST}" --pr 1 --repo "not-a-slug" 2>&1) || exit_code=$?
+    assert_exit_code "invalid slug exits 2" "2" "$exit_code"
+    assert_contains "error mentions invalid slug" "not a valid owner/repo" "$STDERR"
+}
+
 # ---- Run all tests ----
 echo "=== cross_model_review.sh tests ==="
 echo ""
 
 test_missing_pr_flag
 test_unknown_argument
+test_invalid_repo_slug
 test_issue_extraction
 test_repo_flag_accepted
 test_work_dir_flag

--- a/.agent/scripts/tests/test_cross_model_review.sh
+++ b/.agent/scripts/tests/test_cross_model_review.sh
@@ -151,48 +151,36 @@ GH_EOF
 }
 
 # ---- Test: issue extraction from PR body ----
+# Helper: mirrors the extraction logic from cross_model_review.sh
+extract_issue() {
+    local body="$1"
+    local ref num
+    ref=$(printf '%s\n' "$body" | grep -ioE '(^|[^[:alnum:]_])(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 || true)
+    num=$(printf '%s\n' "$ref" | grep -oE '[0-9]+$' || true)
+    if [[ -z "$num" ]]; then
+        num=$(printf '%s\n' "$body" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
+    fi
+    printf '%s' "${num:-}"
+}
+
 test_issue_extraction() {
     echo "TEST: issue number extraction"
 
-    # Test cases: input body text -> expected issue number
-    # We'll test the grep logic directly rather than running the full script
+    # Positive cases
+    assert_eq "Closes #42 -> 42" "42" "$(extract_issue 'Some text\nCloses #42\nMore text')"
+    assert_eq "fixes #123 -> 123" "123" "$(extract_issue 'fixes #123')"
+    assert_eq "Resolves owner/repo#77 -> 77" "77" "$(extract_issue 'Resolves owner/repo#77')"
+    assert_eq "CLOSES #5 -> 5" "5" "$(extract_issue 'CLOSES #5')"
 
-    # Case 1: "Closes #42"
-    local body="Some text\nCloses #42\nMore text"
-    local result
-    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
-    assert_eq "Closes #42 -> 42" "42" "$result"
+    # Negative: substring false positives should NOT match as close keywords
+    assert_eq "encloses #42 -> fallback 42" "42" "$(extract_issue 'encloses #42')"
+    assert_eq "prefixes #7 -> fallback 7" "7" "$(extract_issue 'prefixes #7')"
+    # But with a real close keyword elsewhere, it should pick the right one
+    assert_eq "encloses #42, Closes #99 -> 99" "99" "$(extract_issue 'encloses #42 but Closes #99')"
 
-    # Case 2: "fixes #123" (lowercase)
-    body="fixes #123"
-    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
-    assert_eq "fixes #123 -> 123" "123" "$result"
-
-    # Case 3: "Resolves owner/repo#77" (cross-repo)
-    body="Resolves owner/repo#77"
-    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
-    assert_eq "Resolves owner/repo#77 -> 77" "77" "$result"
-
-    # Case 4: "CLOSES #5" (all caps)
-    body="CLOSES #5"
-    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
-    assert_eq "CLOSES #5 -> 5" "5" "$result"
-
-    # Case 5: No close keyword, but has "#10" -> fallback
-    body="Related to #10 and #20"
-    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$' || true)
-    if [[ -z "$result" ]]; then
-        result=$(printf '%s\n' "$body" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+')
-    fi
-    assert_eq "Fallback #10 -> 10" "10" "$result"
-
-    # Case 6: No issue reference at all -> empty (caller uses PR number)
-    body="No issue reference here"
-    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$' || true)
-    if [[ -z "$result" ]]; then
-        result=$(printf '%s\n' "$body" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
-    fi
-    assert_eq "No issue ref -> empty" "" "${result:-}"
+    # Fallback cases
+    assert_eq "Fallback #10 -> 10" "10" "$(extract_issue 'Related to #10 and #20')"
+    assert_eq "No issue ref -> empty" "" "$(extract_issue 'No issue reference here')"
 }
 
 # ---- Test: --work-dir controls artifact placement ----

--- a/.agent/scripts/tests/test_cross_model_review.sh
+++ b/.agent/scripts/tests/test_cross_model_review.sh
@@ -324,11 +324,14 @@ test_unknown_argument() {
 # ---- Test: --repo with invalid slug ----
 test_invalid_repo_slug() {
     echo "TEST: --repo with invalid slug exits 2"
+    setup
 
     local exit_code=0
-    STDERR=$(bash "${SCRIPT_UNDER_TEST}" --pr 1 --repo "not-a-slug" 2>&1) || exit_code=$?
+    STDERR=$(PATH="${MOCK_BIN}:${PATH}" bash "${SCRIPT_UNDER_TEST}" --pr 1 --repo "not-a-slug" 2>&1) || exit_code=$?
     assert_exit_code "invalid slug exits 2" "2" "$exit_code"
     assert_contains "error mentions invalid slug" "not a valid owner/repo" "$STDERR"
+
+    teardown
 }
 
 # ---- Run all tests ----

--- a/.agent/scripts/tests/test_cross_model_review.sh
+++ b/.agent/scripts/tests/test_cross_model_review.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Tests for cross_model_review.sh
+#
+# Tests argument parsing, issue extraction, artifact path resolution, and
+# empty diff guard. Uses mock gh/agent binaries to avoid real API calls.
+#
+# Run: bash .agent/scripts/tests/test_cross_model_review.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="${SCRIPT_DIR}/../cross_model_review.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_BASE=""
+
+setup() {
+    TMPDIR_BASE=$(mktemp -d /tmp/test_cmr.XXXXXX)
+
+    # Create a mock git repo so git rev-parse works
+    MOCK_REPO="${TMPDIR_BASE}/repo"
+    mkdir -p "${MOCK_REPO}"
+    git -C "${MOCK_REPO}" init -q
+    git -C "${MOCK_REPO}" -c user.name="Test" -c user.email="test@test" commit --allow-empty -m "init" -q
+
+    # Create mock bin directory
+    MOCK_BIN="${TMPDIR_BASE}/bin"
+    mkdir -p "${MOCK_BIN}"
+
+    # Mock gemini CLI that just writes "mock review" to the findings file
+    cat > "${MOCK_BIN}/gemini" << 'MOCK_EOF'
+#!/usr/bin/env bash
+# Mock gemini: copy stdin to stdout (findings file via redirect)
+cat
+MOCK_EOF
+    chmod +x "${MOCK_BIN}/gemini"
+}
+
+teardown() {
+    [[ -n "$TMPDIR_BASE" ]] && rm -rf "$TMPDIR_BASE"
+}
+trap teardown EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" pattern="$2" text="$3"
+    if echo "$text" | grep -qE "$pattern"; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    pattern not found: $pattern"
+        echo "    in: $text"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_code() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label (exit $actual)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected exit: $expected"
+        echo "    actual exit:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: --repo flag is accepted and overrides auto-detection ----
+test_repo_flag_accepted() {
+    echo "TEST: --repo flag is accepted"
+    setup
+
+    # Mock gh that records the -R argument it received
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+# Record all args for inspection
+echo "$@" >> "${MOCK_GH_LOG}"
+case "$1" in
+    pr)
+        case "$3" in
+            --json)
+                if [[ "$4" == "body" ]]; then
+                    echo '{"body": "Closes #42"}'
+                    # jq emulation: if --jq is present, extract .body
+                    exit 0
+                elif [[ "$4" == "title" ]]; then
+                    echo "Test PR"
+                    exit 0
+                elif [[ "$4" == "url" ]]; then
+                    echo "https://github.com/test/repo/pull/99"
+                    exit 0
+                fi
+                ;;
+            *)
+                # gh pr diff — output a non-empty diff
+                echo "diff --git a/file.txt b/file.txt"
+                echo "--- a/file.txt"
+                echo "+++ b/file.txt"
+                echo "@@ -1 +1 @@"
+                echo "-old"
+                echo "+new"
+                exit 0
+                ;;
+        esac
+        ;;
+esac
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    # gh outputs raw text; we need it to handle --jq itself. Simplify: make
+    # gh return the value directly for --jq queries.
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${MOCK_GH_LOG}"
+# Detect which gh subcommand
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    shift 2  # consume "pr view"
+    PR_NUM="$1"; shift
+    # Consume -R flag if present
+    if [[ "${1:-}" == "-R" ]]; then
+        echo "REPO_FLAG=$2" >> "${MOCK_GH_LOG}"
+        shift 2
+    fi
+    if [[ "$1" == "--json" && "$2" == "body" ]]; then
+        echo "Closes #42"
+        exit 0
+    elif [[ "$1" == "--json" && "$2" == "title" ]]; then
+        echo "Test PR"
+        exit 0
+    elif [[ "$1" == "--json" && "$2" == "url" ]]; then
+        echo "https://github.com/test/repo/pull/99"
+        exit 0
+    fi
+elif [[ "$1" == "pr" && "$2" == "diff" ]]; then
+    shift 2
+    PR_NUM="$1"; shift
+    if [[ "${1:-}" == "-R" ]]; then
+        echo "REPO_FLAG=$2" >> "${MOCK_GH_LOG}"
+        shift 2
+    fi
+    echo "diff --git a/file.txt b/file.txt"
+    echo "--- a/file.txt"
+    echo "+++ b/file.txt"
+    echo "@@ -1 +1 @@"
+    echo "-old"
+    echo "+new"
+    exit 0
+fi
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    export MOCK_GH_LOG="${TMPDIR_BASE}/gh_calls.log"
+    true > "$MOCK_GH_LOG"
+
+    # Run the script with --repo and --sync (to avoid tmux)
+    cd "${MOCK_REPO}"
+    PATH="${MOCK_BIN}:${PATH}" bash "${SCRIPT_UNDER_TEST}" \
+        --pr 99 --repo test/repo --sync >/dev/null 2>&1 || true
+
+    # Verify gh was called with -R test/repo
+    if grep -q "REPO_FLAG=test/repo" "$MOCK_GH_LOG"; then
+        echo "  PASS: --repo flag passed through to gh as -R"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: --repo flag not passed through to gh"
+        echo "    gh log: $(cat "$MOCK_GH_LOG")"
+        FAIL=$((FAIL + 1))
+    fi
+
+    teardown
+}
+
+# ---- Test: issue extraction from PR body ----
+test_issue_extraction() {
+    echo "TEST: issue number extraction"
+
+    # Test cases: input body text -> expected issue number
+    # We'll test the grep logic directly rather than running the full script
+
+    # Case 1: "Closes #42"
+    local body="Some text\nCloses #42\nMore text"
+    local result
+    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
+    assert_eq "Closes #42 -> 42" "42" "$result"
+
+    # Case 2: "fixes #123" (lowercase)
+    body="fixes #123"
+    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
+    assert_eq "fixes #123 -> 123" "123" "$result"
+
+    # Case 3: "Resolves owner/repo#77" (cross-repo)
+    body="Resolves owner/repo#77"
+    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
+    assert_eq "Resolves owner/repo#77 -> 77" "77" "$result"
+
+    # Case 4: "CLOSES #5" (all caps)
+    body="CLOSES #5"
+    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$')
+    assert_eq "CLOSES #5 -> 5" "5" "$result"
+
+    # Case 5: No close keyword, but has "#10" -> fallback
+    body="Related to #10 and #20"
+    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$' || true)
+    if [[ -z "$result" ]]; then
+        result=$(printf '%s\n' "$body" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+')
+    fi
+    assert_eq "Fallback #10 -> 10" "10" "$result"
+
+    # Case 6: No issue reference at all -> empty (caller uses PR number)
+    body="No issue reference here"
+    result=$(printf '%s\n' "$body" | grep -ioE '(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 | grep -oE '[0-9]+$' || true)
+    if [[ -z "$result" ]]; then
+        result=$(printf '%s\n' "$body" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
+    fi
+    assert_eq "No issue ref -> empty" "" "${result:-}"
+}
+
+# ---- Test: --work-dir controls artifact placement ----
+test_work_dir_flag() {
+    echo "TEST: --work-dir controls artifact placement"
+    setup
+
+    local custom_dir="${TMPDIR_BASE}/custom_workdir"
+    mkdir -p "$custom_dir"
+
+    # Mock gh
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    shift 2; PR="$1"; shift
+    [[ "${1:-}" == "-R" ]] && shift 2
+    if [[ "$1" == "--json" && "$2" == "body" ]]; then
+        echo "Closes #42"
+    elif [[ "$1" == "--json" && "$2" == "title" ]]; then
+        echo "Test PR"
+    elif [[ "$1" == "--json" && "$2" == "url" ]]; then
+        echo "https://github.com/test/repo/pull/99"
+    fi
+elif [[ "$1" == "pr" && "$2" == "diff" ]]; then
+    echo "diff --git a/file.txt b/file.txt"
+    echo "--- a/file.txt"
+    echo "+++ b/file.txt"
+    echo "@@ -1 +1 @@"
+    echo "-old"
+    echo "+new"
+fi
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    cd "${MOCK_REPO}"
+    PATH="${MOCK_BIN}:${PATH}" bash "${SCRIPT_UNDER_TEST}" \
+        --pr 99 --work-dir "${custom_dir}" --sync >/dev/null 2>&1 || true
+
+    # Check that artifacts were written under custom_dir, not repo root
+    if [[ -d "${custom_dir}/.agent/work-plans/issue-42" ]]; then
+        echo "  PASS: artifacts written under --work-dir"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: artifacts not found under --work-dir"
+        echo "    expected dir: ${custom_dir}/.agent/work-plans/issue-42"
+        echo "    ls custom_dir: $(find "${custom_dir}" -type f 2>/dev/null || echo 'empty')"
+        FAIL=$((FAIL + 1))
+    fi
+
+    # Also verify artifacts are NOT under the repo root
+    if [[ -d "${MOCK_REPO}/.agent/work-plans/issue-42" ]]; then
+        echo "  FAIL: artifacts leaked to repo root despite --work-dir"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: no artifacts in repo root"
+        PASS=$((PASS + 1))
+    fi
+
+    teardown
+}
+
+# ---- Test: empty diff guard ----
+test_empty_diff_guard() {
+    echo "TEST: empty diff guard exits with error"
+    setup
+
+    # Mock gh that returns empty diff
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    shift 2; PR="$1"; shift
+    [[ "${1:-}" == "-R" ]] && shift 2
+    if [[ "$1" == "--json" && "$2" == "body" ]]; then
+        echo "Closes #42"
+    elif [[ "$1" == "--json" && "$2" == "title" ]]; then
+        echo "Test PR"
+    elif [[ "$1" == "--json" && "$2" == "url" ]]; then
+        echo "https://github.com/test/repo/pull/99"
+    fi
+elif [[ "$1" == "pr" && "$2" == "diff" ]]; then
+    # Return empty diff (no output)
+    true
+fi
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    cd "${MOCK_REPO}"
+    local exit_code=0
+    STDERR=$(PATH="${MOCK_BIN}:${PATH}" bash "${SCRIPT_UNDER_TEST}" \
+        --pr 99 --sync 2>&1 >/dev/null) || exit_code=$?
+
+    assert_exit_code "empty diff exits 3" "3" "$exit_code"
+    assert_contains "error message mentions empty diff" "diff is empty" "$STDERR"
+
+    # Check that an error marker was written to findings file
+    local findings_file="${MOCK_REPO}/.agent/work-plans/issue-42/review-gemini-findings.md"
+    if [[ -f "$findings_file" ]]; then
+        local content
+        content=$(cat "$findings_file")
+        assert_contains "findings file has error marker" "Review error" "$content"
+    else
+        echo "  FAIL: findings file not created for error marker"
+        FAIL=$((FAIL + 1))
+    fi
+
+    teardown
+}
+
+# ---- Test: missing --pr flag ----
+test_missing_pr_flag() {
+    echo "TEST: missing --pr flag exits 2"
+
+    local exit_code=0
+    bash "${SCRIPT_UNDER_TEST}" --agent gemini 2>/dev/null || exit_code=$?
+    assert_exit_code "missing --pr exits 2" "2" "$exit_code"
+}
+
+# ---- Test: unknown argument ----
+test_unknown_argument() {
+    echo "TEST: unknown argument exits 2"
+
+    local exit_code=0
+    bash "${SCRIPT_UNDER_TEST}" --pr 1 --bogus 2>/dev/null || exit_code=$?
+    assert_exit_code "unknown arg exits 2" "2" "$exit_code"
+}
+
+# ---- Run all tests ----
+echo "=== cross_model_review.sh tests ==="
+echo ""
+
+test_missing_pr_flag
+test_unknown_argument
+test_issue_extraction
+test_repo_flag_accepted
+test_work_dir_flag
+test_empty_diff_guard
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi

--- a/.agent/work-plans/issue-133/plan.md
+++ b/.agent/work-plans/issue-133/plan.md
@@ -1,0 +1,92 @@
+# Plan: cross_model_review.sh fails when invoked outside target repo worktree
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/133
+
+## Context
+
+`cross_model_review.sh` silently produces empty reviews when invoked from
+outside the target repo's worktree. Four root causes identified: (1) `gh`
+commands use the current directory's remote instead of the PR's repo, (2)
+issue number extraction uses a fragile regex, (3) artifact directory resolves
+to main tree instead of the issue's worktree, (4) empty diffs are not
+detected, so agents launch with no content.
+
+The script already derives `GH_REPO_SLUG` from `git remote get-url origin`
+(line 149) and passes it via `GH_REPO_ARGS`. This works when invoked from
+the correct repo but fails when invoked from the workspace repo for a
+project PR.
+
+## Approach
+
+1. **Add `--repo` flag** — Accept `-R <owner/repo>` to override the
+   auto-detected repo slug. When provided, use it for all `gh` commands.
+   When omitted, keep the existing `git remote` auto-detection as fallback.
+
+2. **Add `--work-dir` flag** — Accept an explicit directory for artifact
+   placement. When provided, use `<work-dir>/.agent/work-plans/issue-<N>/`
+   instead of `$(git rev-parse --show-toplevel)/...`. When omitted, keep
+   the existing `git rev-parse` behavior.
+
+3. **Fix issue number extraction** — Replace the fragile `#[0-9]*` grep
+   with explicit parsing of GitHub close keywords (`Closes`, `Fixes`,
+   `Resolves`) with case-insensitive matching. Keep the `#N` fallback but
+   make it more precise. Handle cross-repo references
+   (`Closes owner/repo#N`).
+
+4. **Add empty diff guard** — After writing the diff into the prompt file,
+   check that it contains actual diff content (not just the markdown
+   fences). If empty, write an error marker to the findings file and exit
+   with code 3 instead of launching the agent.
+
+5. **Update review-code skill invocation** — Update the example in
+   `SKILL.md` to show the `--repo` flag usage, since the caller knows
+   which repo the PR belongs to.
+
+6. **Update AGENTS.md script reference** — Add note about new flags.
+
+7. **Add tests** — Create `.agent/scripts/tests/test_cross_model_review.sh`
+   with unit tests for: repo flag passthrough, issue extraction from PR
+   body, empty diff guard, artifact path with `--work-dir`.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/cross_model_review.sh` | Add `--repo`, `--work-dir` flags; fix issue extraction; add empty diff guard |
+| `.claude/skills/review-code/SKILL.md` | Update invocation examples to pass `--repo` |
+| `AGENTS.md` | Update script reference table description |
+| `.agent/scripts/tests/test_cross_model_review.sh` | New: unit tests for the four fixes |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Empty diff guard surfaces errors instead of silently failing — directly improves transparency |
+| A change includes its consequences | Plan includes SKILL.md and AGENTS.md updates alongside the script fix |
+| Only what's needed | Four targeted fixes, no refactoring beyond the bug scope |
+| Test what breaks | Tests target the specific failure modes that caused silent failures in production use |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | `--work-dir` flag allows callers to point artifacts at the correct worktree |
+| 0003 — Project-agnostic workspace | Yes | `--repo` flag makes the script work for any project repo, not just the one matching the current directory |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `.agent/scripts/cross_model_review.sh` | Script reference in `AGENTS.md` | Yes (step 6) |
+| `.agent/scripts/cross_model_review.sh` | `review-code` SKILL.md invocation | Yes (step 5) |
+| Script interface (new flags) | Makefile targets | N/A — no Makefile target wraps this script |
+
+## Open Questions
+
+None — the issue is well-specified and the fixes are straightforward.
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-133/progress.md
+++ b/.agent/work-plans/issue-133/progress.md
@@ -58,3 +58,15 @@ All four fixes applied to `cross_model_review.sh`. Updated `review-code` SKILL.m
 - [x] Add word boundary to close keyword regex (prevents "encloses"/"prefixes" false matches)
 - [x] Resolve --work-dir to absolute path via cd/pwd
 - [x] Add substring false-positive test cases (19 tests total)
+
+## External Review (round 4)
+**Status**: complete
+**When**: 2026-04-05 22:00
+**By**: Claude Code Agent (claude-opus-4-6)
+
+**PR**: #145 — 4 review(s), 2 valid (Copilot round 4), 7 stale (already addressed)
+**CI**: all-pass
+
+### Actions
+- [x] Add || true to fallback grep pipeline (pipefail abort on no-match)
+- [x] Validate --work-dir existence before cd (clear error instead of cryptic cd failure)

--- a/.agent/work-plans/issue-133/progress.md
+++ b/.agent/work-plans/issue-133/progress.md
@@ -19,3 +19,17 @@ Four targeted fixes: add `--repo` and `--work-dir` flags for explicit repo/artif
 **By**: Claude Code Agent (claude-opus-4-6)
 
 All four fixes applied to `cross_model_review.sh`. Updated `review-code` SKILL.md invocation examples and AGENTS.md script reference. Added 14-test suite in `tests/test_cross_model_review.sh` covering argument parsing, issue extraction, artifact placement, and empty diff guard.
+
+## External Review
+**Status**: complete
+**When**: 2026-04-05 21:20
+**By**: Claude Code Agent (claude-opus-4-6)
+
+**PR**: #145 — 1 review(s), 3 valid (all Copilot), 0 false positives
+**CI**: all-pass
+
+### Actions
+- [x] Remove dead first mock `gh` heredoc in test_repo_flag_accepted
+- [x] Fix stderr capture redirection in test_empty_diff_guard
+- [x] Add --repo slug validation (exit 2 on invalid pattern)
+- [x] Add test for invalid --repo slug (16 tests total now)

--- a/.agent/work-plans/issue-133/progress.md
+++ b/.agent/work-plans/issue-133/progress.md
@@ -1,0 +1,14 @@
+---
+issue: 133
+---
+
+# Issue #133 — cross_model_review.sh fails when invoked outside target repo worktree
+
+## Plan
+**Status**: complete
+**When**: 2026-04-05 20:45
+**By**: Claude Code Agent (claude-opus-4-6)
+
+Plan file: `.agent/work-plans/issue-133/plan.md`.
+
+Four targeted fixes: add `--repo` and `--work-dir` flags for explicit repo/artifact targeting, fix issue number extraction regex, and add empty diff guard with error surfacing.

--- a/.agent/work-plans/issue-133/progress.md
+++ b/.agent/work-plans/issue-133/progress.md
@@ -12,3 +12,10 @@ issue: 133
 Plan file: `.agent/work-plans/issue-133/plan.md`.
 
 Four targeted fixes: add `--repo` and `--work-dir` flags for explicit repo/artifact targeting, fix issue number extraction regex, and add empty diff guard with error surfacing.
+
+## Implementation
+**Status**: complete
+**When**: 2026-04-05 21:00
+**By**: Claude Code Agent (claude-opus-4-6)
+
+All four fixes applied to `cross_model_review.sh`. Updated `review-code` SKILL.md invocation examples and AGENTS.md script reference. Added 14-test suite in `tests/test_cross_model_review.sh` covering argument parsing, issue extraction, artifact placement, and empty diff guard.

--- a/.agent/work-plans/issue-133/progress.md
+++ b/.agent/work-plans/issue-133/progress.md
@@ -33,3 +33,15 @@ All four fixes applied to `cross_model_review.sh`. Updated `review-code` SKILL.m
 - [x] Fix stderr capture redirection in test_empty_diff_guard
 - [x] Add --repo slug validation (exit 2 on invalid pattern)
 - [x] Add test for invalid --repo slug (16 tests total now)
+
+## External Review (round 2)
+**Status**: complete
+**When**: 2026-04-05 21:30
+**By**: Claude Code Agent (claude-opus-4-6)
+
+**PR**: #145 — 2 review(s), 2 valid (Copilot round 2), 2 stale (already addressed)
+**CI**: all-pass
+
+### Actions
+- [x] Move --repo slug validation before gh dependency check (deterministic exit codes)
+- [x] Make test_invalid_repo_slug hermetic with setup/mock PATH

--- a/.agent/work-plans/issue-133/progress.md
+++ b/.agent/work-plans/issue-133/progress.md
@@ -45,3 +45,16 @@ All four fixes applied to `cross_model_review.sh`. Updated `review-code` SKILL.m
 ### Actions
 - [x] Move --repo slug validation before gh dependency check (deterministic exit codes)
 - [x] Make test_invalid_repo_slug hermetic with setup/mock PATH
+
+## External Review (round 3)
+**Status**: complete
+**When**: 2026-04-05 21:45
+**By**: Claude Code Agent (claude-opus-4-6)
+
+**PR**: #145 — 3 review(s), 3 valid (Copilot round 3), 4 stale (already addressed)
+**CI**: all-pass
+
+### Actions
+- [x] Add word boundary to close keyword regex (prevents "encloses"/"prefixes" false matches)
+- [x] Resolve --work-dir to absolute path via cd/pwd
+- [x] Add substring false-positive test cases (19 tests total)

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -238,10 +238,16 @@ For each non-caller agent, launch the cross-model review script:
 
 ```bash
 # Example: Claude is the caller, dispatch gemini, codex, and copilot
-.agent/scripts/cross_model_review.sh --pr <N> --agent gemini
-.agent/scripts/cross_model_review.sh --pr <N> --agent codex
-.agent/scripts/cross_model_review.sh --pr <N> --agent copilot
+# Use --repo when the PR is in a different repo than the current directory
+.agent/scripts/cross_model_review.sh --pr <N> --agent gemini --repo owner/repo
+.agent/scripts/cross_model_review.sh --pr <N> --agent codex --repo owner/repo
+.agent/scripts/cross_model_review.sh --pr <N> --agent copilot --repo owner/repo
 ```
+
+Pass `--repo <owner/repo>` when the PR lives in a different repo than the
+current working directory (e.g., reviewing a project PR from the workspace
+tree). Pass `--work-dir <path>` to place artifacts in a specific worktree
+instead of the current `git rev-parse --show-toplevel`.
 
 The script auto-detects the execution mode: tmux (background) when available,
 sync (blocking) when tmux is unavailable or in sandboxed environments. Use

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,7 +325,7 @@ Scripts marked **(source)** must be sourced; all others should be executed.
 | `.agent/scripts/validate_workspace.py` | Validate project/ configuration |
 | `.agent/scripts/detect_agent_identity.sh` | Auto-detect agent framework + model |
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |
-| `.agent/scripts/cross_model_review.sh` | Cross-model adversarial review (gemini/codex/claude/copilot, tmux or sync) |
+| `.agent/scripts/cross_model_review.sh` | Cross-model adversarial review (`--repo`, `--work-dir` for cross-repo use) |
 
 ## References (Read When Needed, Not Upfront)
 


### PR DESCRIPTION
Closes #133

# Plan: cross_model_review.sh fails when invoked outside target repo worktree

## Issue

https://github.com/rolker/agent_workspace/issues/133

## Context

`cross_model_review.sh` silently produces empty reviews when invoked from
outside the target repo's worktree. Four root causes identified: (1) `gh`
commands use the current directory's remote instead of the PR's repo, (2)
issue number extraction uses a fragile regex, (3) artifact directory resolves
to main tree instead of the issue's worktree, (4) empty diffs are not
detected, so agents launch with no content.

The script already derives `GH_REPO_SLUG` from `git remote get-url origin`
(line 149) and passes it via `GH_REPO_ARGS`. This works when invoked from
the correct repo but fails when invoked from the workspace repo for a
project PR.

## Approach

1. **Add `--repo` flag** — Accept `-R <owner/repo>` to override the
   auto-detected repo slug. When provided, use it for all `gh` commands.
   When omitted, keep the existing `git remote` auto-detection as fallback.

2. **Add `--work-dir` flag** — Accept an explicit directory for artifact
   placement. When provided, use `<work-dir>/.agent/work-plans/issue-<N>/`
   instead of `$(git rev-parse --show-toplevel)/...`. When omitted, keep
   the existing `git rev-parse` behavior.

3. **Fix issue number extraction** — Replace the fragile `#[0-9]*` grep
   with explicit parsing of GitHub close keywords (`Closes`, `Fixes`,
   `Resolves`) with case-insensitive matching. Keep the `#N` fallback but
   make it more precise. Handle cross-repo references
   (`Closes owner/repo#N`).

4. **Add empty diff guard** — After writing the diff into the prompt file,
   check that it contains actual diff content (not just the markdown
   fences). If empty, write an error marker to the findings file and exit
   with code 3 instead of launching the agent.

5. **Update review-code skill invocation** — Update the example in
   `SKILL.md` to show the `--repo` flag usage, since the caller knows
   which repo the PR belongs to.

6. **Update AGENTS.md script reference** — Add note about new flags.

7. **Add tests** — Create `.agent/scripts/tests/test_cross_model_review.sh`
   with unit tests for: repo flag passthrough, issue extraction from PR
   body, empty diff guard, artifact path with `--work-dir`.

## Files to Change

| File | Change |
|------|--------|
| `.agent/scripts/cross_model_review.sh` | Add `--repo`, `--work-dir` flags; fix issue extraction; add empty diff guard |
| `.claude/skills/review-code/SKILL.md` | Update invocation examples to pass `--repo` |
| `AGENTS.md` | Update script reference table description |
| `.agent/scripts/tests/test_cross_model_review.sh` | New: unit tests for the four fixes |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | Empty diff guard surfaces errors instead of silently failing — directly improves transparency |
| A change includes its consequences | Plan includes SKILL.md and AGENTS.md updates alongside the script fix |
| Only what's needed | Four targeted fixes, no refactoring beyond the bug scope |
| Test what breaks | Tests target the specific failure modes that caused silent failures in production use |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | `--work-dir` flag allows callers to point artifacts at the correct worktree |
| 0003 — Project-agnostic workspace | Yes | `--repo` flag makes the script work for any project repo, not just the one matching the current directory |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `.agent/scripts/cross_model_review.sh` | Script reference in `AGENTS.md` | Yes (step 6) |
| `.agent/scripts/cross_model_review.sh` | `review-code` SKILL.md invocation | Yes (step 5) |
| Script interface (new flags) | Makefile targets | N/A — no Makefile target wraps this script |

## Open Questions

None — the issue is well-specified and the fixes are straightforward.

## Estimated Scope

Single PR.
