### PR TITLE
Fix: refuse to write work-plans outside matching worktree (#147)

### DIFF
--- a/.agent/scripts/_resolve_work_plans_dir.sh
+++ b/.agent/scripts/_resolve_work_plans_dir.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# .agent/scripts/_resolve_work_plans_dir.sh
+# Shared helper for resolving the per-issue work-plans directory.
+#
+# Source this file from other scripts:
+#   source "$SCRIPT_DIR/_resolve_work_plans_dir.sh"
+#
+# Exposes: resolve_work_plans_dir <issue-number>
+#   On success: echoes absolute path to .agent/work-plans/issue-<N>/ on stdout.
+#   On failure: prints error to stderr and returns 1.
+#
+# Resolution rules (in order):
+#   1. If $WORK_PLANS_DIR_OVERRIDE is set (callers export this after parsing
+#      --work-plans-dir), return it verbatim.
+#   2. Else if $WORKTREE_ISSUE equals the requested issue number, return
+#      "$(git rev-parse --show-toplevel)/.agent/work-plans/issue-<N>".
+#   3. Else abort with remediation guidance pointing at worktree_enter.sh.
+#
+# Rationale: see issue #147. Using `git rev-parse --show-toplevel` without a
+# worktree check lets scripts silently write per-issue artifacts into `main`
+# when invoked from the wrong tree. Callers source this helper to fail loudly
+# instead.
+
+resolve_work_plans_dir() {
+    local issue="$1"
+
+    if [ -z "$issue" ]; then
+        echo "ERROR: resolve_work_plans_dir: issue number required" >&2
+        return 1
+    fi
+
+    # Rule 1: explicit override wins.
+    if [ -n "${WORK_PLANS_DIR_OVERRIDE:-}" ]; then
+        echo "$WORK_PLANS_DIR_OVERRIDE"
+        return 0
+    fi
+
+    # Rule 2: WORKTREE_ISSUE must match.
+    if [ -n "${WORKTREE_ISSUE:-}" ] && [ "$WORKTREE_ISSUE" = "$issue" ]; then
+        local toplevel
+        toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+            echo "ERROR: resolve_work_plans_dir: not inside a git repository" >&2
+            return 1
+        }
+        echo "${toplevel}/.agent/work-plans/issue-${issue}"
+        return 0
+    fi
+
+    # Rule 3: abort.
+    {
+        echo "ERROR: refusing to resolve work-plans dir for issue #${issue} outside its worktree."
+        echo ""
+        if [ -n "${WORKTREE_ISSUE:-}" ]; then
+            echo "  Current \$WORKTREE_ISSUE is '${WORKTREE_ISSUE}', not '${issue}'."
+        else
+            echo "  \$WORKTREE_ISSUE is not set — you're likely in the main tree or a shell"
+            echo "  that didn't source worktree_enter.sh."
+        fi
+        echo ""
+        echo "  Enter the matching worktree first (pick workspace or project by issue):"
+        echo "    source .agent/scripts/worktree_enter.sh --issue ${issue} --type workspace"
+        echo "    source .agent/scripts/worktree_enter.sh --issue ${issue} --type project"
+        echo ""
+        echo "  Or pass --work-plans-dir <path> (sets \$WORK_PLANS_DIR_OVERRIDE) to"
+        echo "  override explicitly."
+    } >&2
+    return 1
+}

--- a/.agent/scripts/_resolve_work_plans_dir.sh
+++ b/.agent/scripts/_resolve_work_plans_dir.sh
@@ -6,15 +6,23 @@
 #   source "$SCRIPT_DIR/_resolve_work_plans_dir.sh"
 #
 # Exposes: resolve_work_plans_dir <issue-number>
-#   On success: echoes absolute path to .agent/work-plans/issue-<N>/ on stdout.
+#   On success: echoes the resolved work-plans directory path on stdout.
+#               If $WORK_PLANS_DIR_OVERRIDE is set, that value is echoed
+#               as-is (may be relative, not normalized). Otherwise the
+#               returned path is absolute. No trailing slash either way.
 #   On failure: prints error to stderr and returns 1.
 #
 # Resolution rules (in order):
 #   1. If $WORK_PLANS_DIR_OVERRIDE is set (callers export this after parsing
-#      --work-plans-dir), return it verbatim.
+#      --work-plans-dir), return it verbatim (no normalization).
 #   2. Else if $WORKTREE_ISSUE equals the requested issue number, return
 #      "$(git rev-parse --show-toplevel)/.agent/work-plans/issue-<N>".
 #   3. Else abort with remediation guidance pointing at worktree_enter.sh.
+#
+# Caller-gotcha: prefer a bare assignment (`WORK_PLANS_DIR=$(resolve ... )
+# || exit 4`) over `local WORK_PLANS_DIR=$(resolve ... )`. The `local`
+# builtin's own exit status masks the command substitution's, so the
+# `|| exit` never fires on failure.
 #
 # Rationale: see issue #147. Using `git rev-parse --show-toplevel` without a
 # worktree check lets scripts silently write per-issue artifacts into `main`
@@ -48,8 +56,7 @@ resolve_work_plans_dir() {
 
     # Rule 3: abort.
     {
-        echo "ERROR: refusing to resolve work-plans dir for issue #${issue} outside its worktree."
-        echo ""
+        echo "ERROR: refusing to resolve work-plans dir for issue #${issue} outside its worktree."        echo ""
         if [ -n "${WORKTREE_ISSUE:-}" ]; then
             echo "  Current \$WORKTREE_ISSUE is '${WORKTREE_ISSUE}', not '${issue}'."
         else
@@ -66,3 +73,11 @@ resolve_work_plans_dir() {
     } >&2
     return 1
 }
+
+# Warn if the file is executed directly — it only defines a function and
+# must be sourced.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    echo "ERROR: _resolve_work_plans_dir.sh must be sourced, not executed directly." >&2
+    echo "Usage: source .agent/scripts/_resolve_work_plans_dir.sh" >&2
+    exit 1
+fi

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -93,13 +93,16 @@ run_agent_sync() {
 PR_NUMBER=""
 FORCE_SYNC=false
 TARGET_AGENT="gemini"
+CLI_WORK_PLANS_DIR=""
+
+USAGE="Usage: $0 --pr <N> [--agent <name>] [--sync] [--work-plans-dir <path>]"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pr)
             if [[ $# -lt 2 ]]; then
                 echo "ERROR: Missing value for --pr" >&2
-                echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+                echo "$USAGE" >&2
                 exit 2
             fi
             PR_NUMBER="$2"
@@ -108,7 +111,7 @@ while [[ $# -gt 0 ]]; do
         --agent)
             if [[ $# -lt 2 ]]; then
                 echo "ERROR: Missing value for --agent" >&2
-                echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+                echo "$USAGE" >&2
                 exit 2
             fi
             TARGET_AGENT="${2,,}"  # lowercase
@@ -118,9 +121,18 @@ while [[ $# -gt 0 ]]; do
             FORCE_SYNC=true
             shift
             ;;
+        --work-plans-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: Missing value for --work-plans-dir" >&2
+                echo "$USAGE" >&2
+                exit 2
+            fi
+            CLI_WORK_PLANS_DIR="$2"
+            shift 2
+            ;;
         *)
             echo "ERROR: Unknown argument: $1" >&2
-            echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+            echo "$USAGE" >&2
             exit 2
             ;;
     esac
@@ -128,7 +140,7 @@ done
 
 if [[ -z "$PR_NUMBER" ]]; then
     echo "ERROR: --pr <N> is required" >&2
-    echo "Usage: $0 --pr <N> [--agent <name>] [--sync]" >&2
+    echo "$USAGE" >&2
     exit 2
 fi
 
@@ -208,7 +220,18 @@ if [[ -z "$ISSUE_NUMBER" ]]; then
 fi
 
 # --- Set up artifact directory (absolute paths for tmux session) ---
-WORK_PLANS_DIR="$(git rev-parse --show-toplevel)/.agent/work-plans/issue-${ISSUE_NUMBER}"
+# Refuse to run outside the matching worktree (issue #147) — otherwise
+# files land as untracked artifacts in main. Callers can override with
+# --work-plans-dir for ad-hoc invocations.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_resolve_work_plans_dir.sh
+source "${SCRIPT_DIR}/_resolve_work_plans_dir.sh"
+
+if [[ -n "$CLI_WORK_PLANS_DIR" ]]; then
+    export WORK_PLANS_DIR_OVERRIDE="$CLI_WORK_PLANS_DIR"
+fi
+
+WORK_PLANS_DIR=$(resolve_work_plans_dir "$ISSUE_NUMBER") || exit 2
 mkdir -p "$WORK_PLANS_DIR"
 
 PROMPT_FILE="${WORK_PLANS_DIR}/review-${TARGET_AGENT}-prompt.md"

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -34,6 +34,7 @@
 #   1 — missing dependencies (gh or target agent CLI)
 #   2 — invalid arguments
 #   3 — failed to create prompt or launch session
+#   4 — wrong worktree / invalid environment (see _resolve_work_plans_dir.sh)
 
 set -euo pipefail
 
@@ -97,23 +98,28 @@ CLI_WORK_PLANS_DIR=""
 
 USAGE="Usage: $0 --pr <N> [--agent <name>] [--sync] [--work-plans-dir <path>]"
 
+# Helper: treat a missing value OR a value that starts with '-' (i.e. the
+# user supplied another flag instead of a value) as "missing value."
+# Consistent with how other scripts in this repo validate flag arguments.
+require_value() {
+    local flag="$1"
+    local value="$2"
+    if [[ -z "$value" || "$value" == -* ]]; then
+        echo "ERROR: Missing value for $flag" >&2
+        echo "$USAGE" >&2
+        exit 2
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pr)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: Missing value for --pr" >&2
-                echo "$USAGE" >&2
-                exit 2
-            fi
+            require_value "--pr" "${2:-}"
             PR_NUMBER="$2"
             shift 2
             ;;
         --agent)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: Missing value for --agent" >&2
-                echo "$USAGE" >&2
-                exit 2
-            fi
+            require_value "--agent" "${2:-}"
             TARGET_AGENT="${2,,}"  # lowercase
             shift 2
             ;;
@@ -122,11 +128,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --work-plans-dir)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: Missing value for --work-plans-dir" >&2
-                echo "$USAGE" >&2
-                exit 2
-            fi
+            require_value "--work-plans-dir" "${2:-}"
             CLI_WORK_PLANS_DIR="$2"
             shift 2
             ;;
@@ -231,7 +233,7 @@ if [[ -n "$CLI_WORK_PLANS_DIR" ]]; then
     export WORK_PLANS_DIR_OVERRIDE="$CLI_WORK_PLANS_DIR"
 fi
 
-WORK_PLANS_DIR=$(resolve_work_plans_dir "$ISSUE_NUMBER") || exit 2
+WORK_PLANS_DIR=$(resolve_work_plans_dir "$ISSUE_NUMBER") || exit 4
 mkdir -p "$WORK_PLANS_DIR"
 
 PROMPT_FILE="${WORK_PLANS_DIR}/review-${TARGET_AGENT}-prompt.md"

--- a/.agent/work-plans/issue-147/plan.md
+++ b/.agent/work-plans/issue-147/plan.md
@@ -1,0 +1,94 @@
+# Plan: Stop writing work-plans into main when invoked outside issue worktree
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/147
+
+## Context
+
+Two consumers resolve their work-plans output directory from `git rev-parse
+--show-toplevel`, so when invoked from the main checkout instead of the
+matching `feature/issue-<N>` worktree, files land as untracked artifacts in
+`main` rather than on the feature branch:
+
+- `.agent/scripts/cross_model_review.sh:211` — `WORK_PLANS_DIR=$(git rev-parse
+  --show-toplevel)/.agent/work-plans/issue-${ISSUE_NUMBER}`
+- `.claude/skills/plan-task/SKILL.md` Step 4 — soft instruction ("check
+  `$WORKTREE_ISSUE`"), not enforcement; Step 5 then writes the plan to the
+  CWD's toplevel.
+
+Seven stranded files exist today under `.agent/work-plans/issue-{52,58,142}/`
+on the main tree — confirmed on no branch via `git log --all`.
+
+The issue's own proposal suggests combining option (1) "refuse to run outside
+the matching worktree" with option (4) "make the output path explicit". That's
+the approach here.
+
+## Approach
+
+1. **Add a shared resolver helper** — `.agent/scripts/_resolve_work_plans_dir.sh`,
+   sourceable. Exposes one function `resolve_work_plans_dir <issue-N>` that
+   echoes the resolved absolute path on stdout, or exits non-zero with a
+   clear error on stderr. Resolution rules:
+   - If `$WORK_PLANS_DIR_OVERRIDE` is set (exported by callers that parsed
+     `--work-plans-dir`) → use it verbatim.
+   - Elif `$WORKTREE_ISSUE` matches the requested issue number → return
+     `$(git rev-parse --show-toplevel)/.agent/work-plans/issue-<N>`.
+   - Else → emit an error pointing to `worktree_enter.sh` and return 1.
+
+2. **Wire `cross_model_review.sh`** — Add `--work-plans-dir <path>` flag
+   parsing, source the helper, replace line 211 with a call that honours the
+   flag or `$WORKTREE_ISSUE`. Abort with the helper's error if neither is
+   satisfied.
+
+3. **Update `plan-task` SKILL.md Step 4** — Replace soft instruction with a
+   hard check: call the helper early (before step 5 writes anything), abort
+   with the same message if the worktree doesn't match. Keep the existing
+   create-or-enter-worktree guidance as remediation text in the error.
+
+4. **Defer**:
+   - The secondary 767-byte prompt-file bug (separable; out of scope).
+   - Cleanup of the seven stranded files (one-line `rm` once the fix is in;
+     ask the user before running it).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/_resolve_work_plans_dir.sh` | New sourceable helper with `resolve_work_plans_dir` function |
+| `.agent/scripts/cross_model_review.sh` | Add `--work-plans-dir` flag; source helper; replace line 211 |
+| `.claude/skills/plan-task/SKILL.md` | Step 4 becomes a hard check that aborts; remediation guidance preserved in error |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Fail loudly, not silently | Current behaviour silently writes to main — fix replaces it with an abort-with-guidance. |
+| No premature abstraction | Helper is small (<30 lines) and has two current consumers. Justified shared surface, not speculative. |
+| Caller responsibility at boundaries | Resolver validates once at the script/skill boundary; internals trust the resolved path. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0010 (git-bug-first) | No | Fix doesn't touch issue reads. |
+| Worktree-per-issue workflow | Yes | Fix reinforces it — invalid states now abort instead of polluting main. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Work-plans-dir resolution contract | Any future consumer of `.agent/work-plans/issue-<N>/` | Yes — helper is the single place to adopt |
+| `cross_model_review.sh` invocation surface | `AGENTS.md` script reference | No — new flag is optional; existing description still accurate |
+| plan-task skill step numbering | — | No — step 4 keeps the same number, body changes |
+
+## Open Questions
+
+- Should the helper create the directory (`mkdir -p`) or leave that to
+  callers? Plan: leave to callers — resolver only resolves.
+- Error message wording — include `--type workspace` vs `--type project`
+  hint? Plan: yes, print both options and let the user pick based on issue.
+
+## Estimated Scope
+
+Single PR. ~40 LOC new + ~10 LOC changed.

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -16,3 +16,25 @@ enforces option 1+4 from the issue (refuse outside matching worktree, explicit
 override via `--work-plans-dir`/`$WORK_PLANS_DIR_OVERRIDE`). Wire it into
 `cross_model_review.sh` and into `plan-task` SKILL.md Step 4 so both fail
 loudly instead of silently writing into the main tree.
+
+## Local Review
+**Status**: complete
+**When**: 2026-04-19
+**By**: Claude Code Agent (claude-opus-4-7)
+**Verdict**: approved
+
+**PR**: #148 at `1e4846a`
+**Depth**: Standard (reason: touches skill governance + shared infra script)
+**Must-fix**: 0 | **Suggestions**: 6
+
+### Findings
+- [ ] (suggestion) Add source-only guard — `.agent/scripts/_resolve_work_plans_dir.sh:end-of-file`
+- [ ] (suggestion) Validate/normalize `$WORK_PLANS_DIR_OVERRIDE` (reject `..`) — `.agent/scripts/_resolve_work_plans_dir.sh:33`
+- [ ] (suggestion) Header comment re: `local VAR=$(...)` masking exit status — `.agent/scripts/_resolve_work_plans_dir.sh:header`
+- [ ] (suggestion) Replace `return 1 2>/dev/null || exit 1` with plain `exit 1` — `.claude/skills/plan-task/SKILL.md:104`
+- [ ] (suggestion) Move resolver call earlier in script — `.agent/scripts/cross_model_review.sh:~226`
+- [ ] (suggestion) Document integer-only contract for issue arg — `.agent/scripts/_resolve_work_plans_dir.sh:39`
+
+### Out-of-scope follow-ups
+- Loose `#N` fallback routes artifacts to wrong issue when no `Closes/Fixes/Resolves` — `.agent/scripts/cross_model_review.sh:199-202`
+- `GH_REPO_SLUG` extraction brittle for SSH aliases / Enterprise GitHub — `.agent/scripts/cross_model_review.sh:149`

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -38,3 +38,16 @@ loudly instead of silently writing into the main tree.
 ### Out-of-scope follow-ups
 - Loose `#N` fallback routes artifacts to wrong issue when no `Closes/Fixes/Resolves` — `.agent/scripts/cross_model_review.sh:199-202`
 - `GH_REPO_SLUG` extraction brittle for SSH aliases / Enterprise GitHub — `.agent/scripts/cross_model_review.sh:149`
+
+## External Review
+**Status**: complete
+**When**: 2026-04-19
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #148 — 1 review (Copilot), 3 valid, 0 false positives
+**CI**: all 6 checks pass
+
+### Actions
+- [ ] Reject leading-`-` values in `--work-plans-dir` (+ apply to `--pr`, `--agent`) — `.agent/scripts/cross_model_review.sh:~99-132`
+- [ ] Use distinct exit code (4) for wrong-worktree; update script header doc — `.agent/scripts/cross_model_review.sh:36,235`
+- [ ] Update helper header to reflect override returned verbatim (may be relative) — `.agent/scripts/_resolve_work_plans_dir.sh:9-14`

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 147
+---
+
+# Issue #147 — cross_model_review.sh and plan-task skill write work-plans into main when invoked outside issue worktree
+
+## Plan
+**Status**: complete
+**When**: 2026-04-19 (current session)
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Plan file: `.agent/work-plans/issue-147/plan.md`.
+
+Approach: add a shared sourceable helper `_resolve_work_plans_dir.sh` that
+enforces option 1+4 from the issue (refuse outside matching worktree, explicit
+override via `--work-plans-dir`/`$WORK_PLANS_DIR_OVERRIDE`). Wire it into
+`cross_model_review.sh` and into `plan-task` SKILL.md Step 4 so both fail
+loudly instead of silently writing into the main tree.

--- a/.agent/work-plans/issue-147/progress.md
+++ b/.agent/work-plans/issue-147/progress.md
@@ -28,10 +28,10 @@ loudly instead of silently writing into the main tree.
 **Must-fix**: 0 | **Suggestions**: 6
 
 ### Findings
-- [ ] (suggestion) Add source-only guard — `.agent/scripts/_resolve_work_plans_dir.sh:end-of-file`
+- [x] (suggestion) Add source-only guard — `.agent/scripts/_resolve_work_plans_dir.sh:end-of-file`
 - [ ] (suggestion) Validate/normalize `$WORK_PLANS_DIR_OVERRIDE` (reject `..`) — `.agent/scripts/_resolve_work_plans_dir.sh:33`
-- [ ] (suggestion) Header comment re: `local VAR=$(...)` masking exit status — `.agent/scripts/_resolve_work_plans_dir.sh:header`
-- [ ] (suggestion) Replace `return 1 2>/dev/null || exit 1` with plain `exit 1` — `.claude/skills/plan-task/SKILL.md:104`
+- [x] (suggestion) Header comment re: `local VAR=$(...)` masking exit status — `.agent/scripts/_resolve_work_plans_dir.sh:header`
+- [x] (suggestion) Replace `return 1 2>/dev/null || exit 1` with plain `exit 1` — `.claude/skills/plan-task/SKILL.md:104`
 - [ ] (suggestion) Move resolver call earlier in script — `.agent/scripts/cross_model_review.sh:~226`
 - [ ] (suggestion) Document integer-only contract for issue arg — `.agent/scripts/_resolve_work_plans_dir.sh:39`
 
@@ -48,6 +48,6 @@ loudly instead of silently writing into the main tree.
 **CI**: all 6 checks pass
 
 ### Actions
-- [ ] Reject leading-`-` values in `--work-plans-dir` (+ apply to `--pr`, `--agent`) — `.agent/scripts/cross_model_review.sh:~99-132`
-- [ ] Use distinct exit code (4) for wrong-worktree; update script header doc — `.agent/scripts/cross_model_review.sh:36,235`
-- [ ] Update helper header to reflect override returned verbatim (may be relative) — `.agent/scripts/_resolve_work_plans_dir.sh:9-14`
+- [x] Reject leading-`-` values in `--work-plans-dir` (+ apply to `--pr`, `--agent`) — `.agent/scripts/cross_model_review.sh:~99-132`
+- [x] Use distinct exit code (4) for wrong-worktree; update script header doc — `.agent/scripts/cross_model_review.sh:36,235`
+- [x] Update helper header to reflect override returned verbatim (may be relative) — `.agent/scripts/_resolve_work_plans_dir.sh:9-14`

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -91,14 +91,25 @@ Read relevant files to understand the current state:
 - Documentation that references them
 - Use the consequences map to identify what else may be affected
 
-### 4. Ensure correct worktree
+### 4. Ensure correct worktree (hard check)
 
-Before writing or committing the plan, verify you are in a worktree for the
-target issue. If the plan is committed from a different worktree, it ends up
-on the wrong branch.
+Before writing or committing the plan, resolve the work-plans directory
+using the shared helper. It refuses to return a path when you're outside
+the matching worktree — this is deliberate (issue #147): silent writes
+into the main tree were stranding per-issue artifacts on no branch.
 
-Check `$WORKTREE_ISSUE` (set by `worktree_enter.sh`). If it does not match
-`<N>`, or is unset, create and enter the correct worktree:
+```bash
+# shellcheck source=../../../.agent/scripts/_resolve_work_plans_dir.sh
+source .agent/scripts/_resolve_work_plans_dir.sh
+WORK_PLANS_DIR=$(resolve_work_plans_dir <N>) || {
+    # Resolver printed remediation guidance to stderr — surface it to the
+    # user and stop. Do not write plan.md / progress.md anywhere else.
+    return 1 2>/dev/null || exit 1
+}
+```
+
+If the resolver aborts, the message tells the user to create or enter the
+matching worktree. Typical remediation:
 
 **Workspace issues** (changes to `.agent/`, `docs/`, configs, skills):
 
@@ -114,24 +125,19 @@ source .agent/scripts/worktree_enter.sh --issue <N> --type workspace
 source .agent/scripts/worktree_enter.sh --issue <N> --type project
 ```
 
-To determine the worktree type and parameters:
+To determine the type, run `gh issue view <N> --json url` and compare
+against the workspace repo URL — use `--type project` when the issue is
+in a project repo. If a worktree for the issue already exists, just enter
+it.
 
-1. Check which GitHub repo the issue belongs to — use `gh issue view <N>
-   --json url` and compare against the workspace repo URL. If the issue is
-   in a project repo, use `--type layer`.
-2. Infer the layer and package from the issue body, labels, or the repo
-   name. Project repos live under `layers/main/<layer>_ws/src/<project_repo>/`
-   — use `ls` to find the matching layer.
-3. If the layer or package cannot be determined, ask the user.
-
-If a worktree for the issue already exists, just enter it.
+Use `$WORK_PLANS_DIR` (from the resolver) as the base path in step 5 and
+step 7 — do not construct `.agent/work-plans/issue-<N>/` by hand.
 
 ### 5. Generate the plan
 
-Write a plan to `.agent/work-plans/issue-<N>/plan.md` (relative to the current
-repo — workspace repo for workspace issues, project repo for project issues).
-Create the `issue-<N>/` directory if it doesn't exist — this directory also
-holds review artifacts (Gemini prompts/findings) alongside the plan:
+Write a plan to `${WORK_PLANS_DIR}/plan.md` (resolved in step 4). Create
+the directory if it doesn't exist — it also holds review artifacts (Gemini
+prompts/findings) alongside the plan:
 
 ```markdown
 # Plan: <issue-title>
@@ -187,8 +193,8 @@ holds review artifacts (Gemini prompts/findings) alongside the plan:
 ### 6. Update progress.md
 
 Before committing, append a "Plan" step entry to
-`.agent/work-plans/issue-<N>/progress.md`. If progress.md does not exist,
-create it with frontmatter (use the issue title from step 1):
+`${WORK_PLANS_DIR}/progress.md`. If progress.md does not exist, create it
+with frontmatter (use the issue title from step 1):
 
 ```yaml
 ---
@@ -207,7 +213,7 @@ Then append the step entry:
 **When**: <YYYY-MM-DD HH:MM>
 **By**: <agent name> (<model>)
 
-Plan file: `.agent/work-plans/issue-<N>/plan.md`.
+Plan file: `${WORK_PLANS_DIR}/plan.md`.
 
 <1-2 sentence summary of the approach>
 ```
@@ -217,8 +223,8 @@ Plan file: `.agent/work-plans/issue-<N>/plan.md`.
 Stage both files and commit together:
 
 ```bash
-mkdir -p .agent/work-plans/issue-<N>
-git add .agent/work-plans/issue-<N>/plan.md .agent/work-plans/issue-<N>/progress.md
+mkdir -p "$WORK_PLANS_DIR"
+git add "$WORK_PLANS_DIR/plan.md" "$WORK_PLANS_DIR/progress.md"
 git commit -m "Add work plan for #<N>
 
 <one-line summary of the approach>"
@@ -250,7 +256,7 @@ EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json url --jq '.[0].url // "
 # Build PR body: prepend Closes reference, then plan content
 BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
 printf 'Closes #<N>\n\n' > "$BODY_FILE"
-cat .agent/work-plans/issue-<N>/plan.md >> "$BODY_FILE"
+cat "$WORK_PLANS_DIR/plan.md" >> "$BODY_FILE"
 
 if [ -n "$EXISTING_PR" ]; then
     # Update existing PR title and body

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -104,7 +104,7 @@ source .agent/scripts/_resolve_work_plans_dir.sh
 WORK_PLANS_DIR=$(resolve_work_plans_dir <N>) || {
     # Resolver printed remediation guidance to stderr — surface it to the
     # user and stop. Do not write plan.md / progress.md anywhere else.
-    return 1 2>/dev/null || exit 1
+    exit 1
 }
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,7 @@ Scripts marked **(source)** must be sourced; all others should be executed.
 | Script | Purpose |
 |--------|---------|
 | `.agent/scripts/_issue_helpers.sh` | Shared git-bug-first issue lookup with sync-on-miss **(source)** |
+| `.agent/scripts/_resolve_work_plans_dir.sh` | Resolve per-issue work-plans dir; refuses outside matching worktree (issue #147) **(source)** |
 | `.agent/scripts/set_git_identity_env.sh` | Ephemeral git identity (session-only) **(source)** |
 | `.agent/scripts/worktree_create.sh` | Create isolated worktree |
 | `.agent/scripts/worktree_enter.sh` | Enter worktree **(source)** |


### PR DESCRIPTION
Closes #147

## Summary

Stops `cross_model_review.sh` and the `plan-task` skill from silently
writing per-issue work-plans into the main tree when invoked outside the
matching feature worktree. Implements option 1+4 from the issue: refuse
outside the matching worktree; explicit `--work-plans-dir` override.

## Changes

- **New** `.agent/scripts/_resolve_work_plans_dir.sh` — sourceable helper
  exposing `resolve_work_plans_dir <N>`. Rules:
  1. `$WORK_PLANS_DIR_OVERRIDE` (from callers parsing `--work-plans-dir`).
  2. `$WORKTREE_ISSUE` must equal the requested issue → path under
     current worktree's toplevel.
  3. Otherwise abort with remediation pointing at `worktree_enter.sh`.
- **Wired** `.agent/scripts/cross_model_review.sh` — new
  `--work-plans-dir` flag; line 211 replaced with a helper call that
  aborts (exit 2) on mismatch.
- **Hardened** `.claude/skills/plan-task/SKILL.md` Step 4 — sources the
  helper and exports `$WORK_PLANS_DIR`; steps 5/6/7/8 now use the
  resolved variable instead of hand-constructed paths.
- **Indexed** the helper in the AGENTS.md script reference table.

## Deliberately out of scope

- The secondary 767-byte prompt-file bug from failed `gh` calls
  (separable per the issue).
- Cleanup of the seven existing stranded files in the main tree
  (`.agent/work-plans/issue-{52,58,142}/`) — one-line `rm` once merged;
  will ask before running.

## Test plan

Resolver unit cases (all verified in this branch):

- [x] No `$WORKTREE_ISSUE`, no override → abort with "not set" message
- [x] `$WORKTREE_ISSUE` matches requested issue → path under current
      worktree toplevel
- [x] `$WORKTREE_ISSUE` mismatched → abort with "X, not Y" message
- [x] `$WORK_PLANS_DIR_OVERRIDE` set → returned verbatim, wins over
      `$WORKTREE_ISSUE`
- [x] Missing issue argument → "issue number required"

`cross_model_review.sh` integration:

- [x] Script syntax clean (`bash -n`)
- [x] Unknown flag still rejected with usage
- [x] `--work-plans-dir` missing-value handled
- [x] Mismatched `$WORKTREE_ISSUE` triggers resolver abort before
      diff fetch
- [x] Explicit `--work-plans-dir` override plumbs through

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
