### PR TITLE
Fix resolver rule-3 echo concat and set -u unbound-var (#151)

### DIFF
--- a/.agent/scripts/_resolve_work_plans_dir.sh
+++ b/.agent/scripts/_resolve_work_plans_dir.sh
@@ -30,7 +30,10 @@
 # instead.
 
 resolve_work_plans_dir() {
-    local issue="$1"
+    # Use "${1:-}" so callers running under `set -u` (e.g.
+    # cross_model_review.sh runs with set -euo pipefail) don't trigger
+    # "unbound variable" before the explicit empty-string check below.
+    local issue="${1:-}"
 
     if [ -z "$issue" ]; then
         echo "ERROR: resolve_work_plans_dir: issue number required" >&2
@@ -56,7 +59,8 @@ resolve_work_plans_dir() {
 
     # Rule 3: abort.
     {
-        echo "ERROR: refusing to resolve work-plans dir for issue #${issue} outside its worktree."        echo ""
+        echo "ERROR: refusing to resolve work-plans dir for issue #${issue} outside its worktree."
+        echo ""
         if [ -n "${WORKTREE_ISSUE:-}" ]; then
             echo "  Current \$WORKTREE_ISSUE is '${WORKTREE_ISSUE}', not '${issue}'."
         else

--- a/.agent/scripts/tests/test_resolve_work_plans_dir.sh
+++ b/.agent/scripts/tests/test_resolve_work_plans_dir.sh
@@ -97,7 +97,9 @@ test_no_args_under_set_u() {
         source "${HELPER}"
         resolve_work_plans_dir 2>&1 || echo "__RC__=$?"
     )
-    rc=$(printf '%s\n' "$out" | grep -oE '__RC__=[0-9]+$' | tail -n1 | cut -d= -f2)
+    # `|| true` so a missing __RC__ match (regression: function stopped
+    # returning non-zero) doesn't crash the whole test run via pipefail.
+    rc=$(printf '%s\n' "$out" | grep -oE '__RC__=[0-9]+$' | tail -n1 | cut -d= -f2 || true)
 
     assert_eq "returns 1" "1" "$rc"
     assert_contains "intended error surfaced" \

--- a/.agent/scripts/tests/test_resolve_work_plans_dir.sh
+++ b/.agent/scripts/tests/test_resolve_work_plans_dir.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Tests for .agent/scripts/_resolve_work_plans_dir.sh
+#
+# Run: bash .agent/scripts/tests/test_resolve_work_plans_dir.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../_resolve_work_plans_dir.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected: ${expected}"
+        echo "    actual:   ${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    needle:   ${needle}"
+        echo "    haystack: ${haystack}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    unexpected needle: ${needle}"
+        echo "    haystack:          ${haystack}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: rule-3 error output is clean (issue #151 bug 1) ----
+#
+# Before the fix, line 59 had two echo statements concatenated:
+#   echo "ERROR: ..."        echo ""
+# …which parses as one echo command with multiple arguments and leaks
+# the literal word "echo" into the error output. Regression test pins
+# the error message shape.
+test_rule3_output_is_clean() {
+    echo "TEST: rule-3 output has no literal 'echo' leaked"
+
+    local out
+    out=$(
+        unset WORK_PLANS_DIR_OVERRIDE WORKTREE_ISSUE
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 999 2>&1 || true
+    )
+
+    assert_contains "error header present" \
+        "ERROR: refusing to resolve work-plans dir for issue #999 outside its worktree." \
+        "$out"
+    assert_not_contains "no literal 'echo' leaked into output" \
+        "worktree. echo" "$out"
+    # First line should end at "worktree." followed by newline, not " echo".
+    local first_line
+    first_line=$(printf '%s\n' "$out" | head -n1)
+    assert_eq "first line ends cleanly at 'worktree.'" \
+        "ERROR: refusing to resolve work-plans dir for issue #999 outside its worktree." \
+        "$first_line"
+}
+
+# ---- Test: no-args call under set -u returns 1 cleanly (issue #151 bug 2) ----
+#
+# cross_model_review.sh runs under `set -euo pipefail`. Before the fix,
+# `local issue="$1"` triggered bash's unbound-variable error before the
+# explicit check on line 35 could run. Regression test exercises the
+# same set-u context as the real caller.
+test_no_args_under_set_u() {
+    echo "TEST: resolve_work_plans_dir with no args under set -u"
+
+    local out rc
+    out=$(
+        set -u
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 2>&1 || echo "__RC__=$?"
+    )
+    rc=$(printf '%s\n' "$out" | grep -oE '__RC__=[0-9]+$' | tail -n1 | cut -d= -f2)
+
+    assert_eq "returns 1" "1" "$rc"
+    assert_contains "intended error surfaced" \
+        "issue number required" "$out"
+    assert_not_contains "no bash unbound-variable leak" \
+        "unbound variable" "$out"
+}
+
+# ---- Test: rule-1 override returned verbatim ----
+test_rule1_override() {
+    echo "TEST: WORK_PLANS_DIR_OVERRIDE returned verbatim"
+
+    local out
+    out=$(
+        WORK_PLANS_DIR_OVERRIDE=/tmp/custom/path
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 42
+    )
+    assert_eq "override echoed as-is" "/tmp/custom/path" "$out"
+
+    # Even a relative path is returned verbatim — that's the documented
+    # contract post-#148.
+    out=$(
+        export WORK_PLANS_DIR_OVERRIDE=./relative/path
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 42
+    )
+    assert_eq "relative override echoed verbatim" "./relative/path" "$out"
+}
+
+# ---- Test: rule-2 WORKTREE_ISSUE match returns toplevel-anchored path ----
+test_rule2_worktree_match() {
+    echo "TEST: WORKTREE_ISSUE match returns toplevel-anchored path"
+
+    local out toplevel
+    toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    [[ -z "$toplevel" ]] && { echo "  SKIP: not in a git repo"; return; }
+
+    out=$(
+        unset WORK_PLANS_DIR_OVERRIDE
+        WORKTREE_ISSUE=42
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 42
+    )
+    assert_eq "path under toplevel" \
+        "${toplevel}/.agent/work-plans/issue-42" "$out"
+}
+
+# ---- Test: rule-3 mismatch message names both issues ----
+test_rule3_mismatch_message() {
+    echo "TEST: mismatch message names both WORKTREE_ISSUE and requested issue"
+
+    local out
+    out=$(
+        unset WORK_PLANS_DIR_OVERRIDE
+        export WORKTREE_ISSUE=100
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 42 2>&1 || true
+    )
+    assert_contains "mentions current WORKTREE_ISSUE" "'100', not '42'" "$out"
+}
+
+# ---- Test: direct execution errors out ----
+test_direct_execution_refused() {
+    echo "TEST: running the helper directly errors out"
+
+    local rc=0
+    local stderr
+    stderr=$(bash "${HELPER}" 2>&1) || rc=$?
+    assert_eq "exits 1" "1" "$rc"
+    assert_contains "error mentions 'must be sourced'" "must be sourced" "$stderr"
+}
+
+# ---- Run all tests ----
+echo "=== _resolve_work_plans_dir.sh tests ==="
+echo ""
+
+test_rule3_output_is_clean
+test_no_args_under_set_u
+test_rule1_override
+test_rule2_worktree_match
+test_rule3_mismatch_message
+test_direct_execution_refused
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[[ $FAIL -eq 0 ]]

--- a/.agent/work-plans/issue-151/progress.md
+++ b/.agent/work-plans/issue-151/progress.md
@@ -1,0 +1,16 @@
+---
+issue: 151
+---
+
+# Issue #151 — _resolve_work_plans_dir.sh: mangled rule-3 error output and set -u unbound-variable check
+
+## External Review
+**Status**: complete
+**When**: 2026-04-19
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #152 — 1 review (Copilot), 1 valid, 0 false positives
+**CI**: all 8 checks pass
+
+### Actions
+- [ ] Add `|| true` to `rc=` extraction (defensive; avoid pipeline failure killing the test suite) — `.agent/scripts/tests/test_resolve_work_plans_dir.sh:100`

--- a/.agent/work-plans/issue-151/progress.md
+++ b/.agent/work-plans/issue-151/progress.md
@@ -13,4 +13,4 @@ issue: 151
 **CI**: all 8 checks pass
 
 ### Actions
-- [ ] Add `|| true` to `rc=` extraction (defensive; avoid pipeline failure killing the test suite) — `.agent/scripts/tests/test_resolve_work_plans_dir.sh:100`
+- [x] Add `|| true` to `rc=` extraction (defensive; avoid pipeline failure killing the test suite) — `.agent/scripts/tests/test_resolve_work_plans_dir.sh:100`


### PR DESCRIPTION
Closes #151

## Summary

Two small but real bugs in `_resolve_work_plans_dir.sh` (from PR #148)
surfaced by Copilot's post-merge review:

1. **Line 59** — two `echo` statements concatenated from a botched
   hand-edit. `bash -n` accepted it because `echo A echo B` is
   syntactically valid. Every rule-3 abort leaked the literal word
   `echo` into the error output and lost the blank-line separator.
2. **Line 33** — `local issue="$1"` fired `$1: unbound variable` under
   `set -u` when called with no args (which `cross_model_review.sh`
   runs with). The explicit empty-string check below was unreachable.

## Changes

- **Fix 1**: Split the concatenated echoes back to two lines.
- **Fix 2**: `local issue="${1:-}"` so the intended check runs first.
- **Tests**: New dedicated `tests/test_resolve_work_plans_dir.sh` with
  12 assertions across 6 test cases. Includes regression tests for both
  bugs plus coverage of all three resolver rules, the source-only
  guard, and the mismatch-message shape.

Existing `test_cross_model_review.sh` still passes unchanged (27/27).

## Test plan

- [x] `bash .agent/scripts/tests/test_resolve_work_plans_dir.sh` — 12/12 pass
- [x] `bash .agent/scripts/tests/test_cross_model_review.sh` — 27/27 pass
- [x] `pre-commit run shellcheck --files ...` — passes
- [x] Reproduce both bugs on main HEAD (pre-fix) to confirm the
      regression tests would have failed before the fix

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
