### PR TITLE
Require closure keyword or --issue flag (#149)

### DIFF
--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -94,13 +94,14 @@ run_agent_sync() {
 
 # --- Argument parsing ---
 PR_NUMBER=""
+CLI_ISSUE_NUMBER=""
 FORCE_SYNC=false
 TARGET_AGENT="gemini"
 EXPLICIT_REPO=""
 EXPLICIT_WORK_DIR=""
 CLI_WORK_PLANS_DIR=""
 
-USAGE="Usage: $0 --pr <N> [--agent <name>] [--repo owner/repo] [--work-dir <path>] [--work-plans-dir <path>] [--sync]"
+USAGE="Usage: $0 --pr <N> [--issue <N>] [--agent <name>] [--repo owner/repo] [--work-dir <path>] [--work-plans-dir <path>] [--sync]"
 
 # Helper: treat a missing value OR a value that starts with '-' (i.e. the
 # user supplied another flag instead of a value) as "missing value."
@@ -120,6 +121,11 @@ while [[ $# -gt 0 ]]; do
         --pr)
             require_value "--pr" "${2:-}"
             PR_NUMBER="$2"
+            shift 2
+            ;;
+        --issue)
+            require_value "--issue" "${2:-}"
+            CLI_ISSUE_NUMBER="$2"
             shift 2
             ;;
         --agent)
@@ -170,6 +176,13 @@ fi
 # Validate --repo slug (before dependency checks so bad input always exits 2)
 if [[ -n "$EXPLICIT_REPO" && ! "$EXPLICIT_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
     echo "ERROR: --repo value '${EXPLICIT_REPO}' is not a valid owner/repo slug" >&2
+    exit 2
+fi
+
+# Validate --issue is a bare positive integer (same contract as the
+# per-issue work-plans resolver — see _resolve_work_plans_dir.sh).
+if [[ -n "$CLI_ISSUE_NUMBER" && ! "$CLI_ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: --issue value '${CLI_ISSUE_NUMBER}' is not a positive integer" >&2
     exit 2
 fi
 
@@ -228,25 +241,37 @@ if [[ -z "$AGENT_BIN" ]]; then
     exit 1
 fi
 
-# --- Resolve issue number from PR ---
-ISSUE_NUMBER=""
-PR_BODY=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null || echo "")
-if [[ -n "$PR_BODY" ]]; then
-    # Look for GitHub close keywords (case-insensitive): Closes #N, Fixes #N, Resolves #N
-    # Requires word boundary before keyword to avoid "encloses", "prefixes", etc.
-    # Also handles cross-repo form: Closes owner/repo#N (extracts just N)
-    ISSUE_REF=$(printf '%s\n' "$PR_BODY" | grep -ioE '(^|[^[:alnum:]_])(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 || true)
+# --- Resolve issue number ---
+# Order: explicit --issue flag wins; otherwise require a GitHub closure
+# keyword in the PR body. The loose "first standalone #N" fallback was
+# removed in #149 — it silently routed artifacts to unrelated issues
+# (e.g. "see also #42. Related to #99...") and, post-#147, caused the
+# work-plans resolver to abort with a confusing wrong-issue message.
+if [[ -n "$CLI_ISSUE_NUMBER" ]]; then
+    ISSUE_NUMBER="$CLI_ISSUE_NUMBER"
+else
+    PR_BODY=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null || echo "")
+    # Match GitHub closure keywords (case-insensitive): Closes #N,
+    # Fixes #N, Resolves #N. Requires a word boundary before the keyword
+    # to avoid matching "encloses", "prefixes", etc. Also accepts the
+    # cross-repo form "Closes owner/repo#N" (just extracts N).
+    ISSUE_REF=$(printf '%s\n' "$PR_BODY" \
+        | grep -ioE '(^|[^[:alnum:]_])(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' \
+        | head -n1 || true)
     ISSUE_NUMBER=$(printf '%s\n' "$ISSUE_REF" | grep -oE '[0-9]+$' || true)
-    if [[ -z "$ISSUE_NUMBER" ]]; then
-        # Fallback: first standalone #N (not part of a URL path or hex color)
-        ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
-    fi
-fi
 
-# Fall back to PR number if no issue found
-if [[ -z "$ISSUE_NUMBER" ]]; then
-    echo "INFO: Could not extract issue number from PR body — using PR number" >&2
-    ISSUE_NUMBER="$PR_NUMBER"
+    if [[ -z "$ISSUE_NUMBER" ]]; then
+        {
+            echo "ERROR: PR #${PR_NUMBER} body has no 'Closes|Fixes|Resolves #N' keyword."
+            echo ""
+            echo "  The loose '#N' fallback was removed in #149 because it routed"
+            echo "  artifacts to unrelated issues. Two ways to proceed:"
+            echo "    1. Pass --issue <N> to set the issue number explicitly, or"
+            echo "    2. Edit the PR body to include a closure keyword"
+            echo "       (e.g. 'Closes #123')."
+        } >&2
+        exit 2
+    fi
 fi
 
 # --- Set up artifact directory (absolute paths for tmux session) ---

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -103,13 +103,14 @@ CLI_WORK_PLANS_DIR=""
 
 USAGE="Usage: $0 --pr <N> [--issue <N>] [--agent <name>] [--repo owner/repo] [--work-dir <path>] [--work-plans-dir <path>] [--sync]"
 
-# Helper: treat a missing value OR a value that starts with '-' (i.e. the
-# user supplied another flag instead of a value) as "missing value."
-# Consistent with how other scripts in this repo validate flag arguments.
+# Helper: treat a missing value OR a value that looks like another long
+# flag (`--foo`) as "missing value." Narrower than `-*` so negative
+# integers and dash-prefixed paths fall through to their dedicated
+# validators (per review feedback on #149).
 require_value() {
     local flag="$1"
     local value="$2"
-    if [[ -z "$value" || "$value" == -* ]]; then
+    if [[ -z "$value" || "$value" == --* ]]; then
         echo "ERROR: Missing value for $flag" >&2
         echo "$USAGE" >&2
         exit 2
@@ -250,7 +251,20 @@ fi
 if [[ -n "$CLI_ISSUE_NUMBER" ]]; then
     ISSUE_NUMBER="$CLI_ISSUE_NUMBER"
 else
-    PR_BODY=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null || echo "")
+    # Capture gh's exit status distinctly from "retrieved an empty body"
+    # so auth/network/permission failures produce the right remediation
+    # (per review feedback on #149).
+    if ! PR_BODY=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json body --jq '.body' 2>/dev/null); then
+        {
+            echo "ERROR: Failed to retrieve body for PR #${PR_NUMBER}."
+            echo ""
+            echo "  Verify GitHub authentication, repository permissions,"
+            echo "  and network connectivity, then try again."
+            echo "  Alternatively, pass --issue <N> to skip PR-body extraction."
+        } >&2
+        exit 2
+    fi
+
     # Match GitHub closure keywords (case-insensitive): Closes #N,
     # Fixes #N, Resolves #N. Requires a word boundary before the keyword
     # to avoid matching "encloses", "prefixes", etc. Also accepts the

--- a/.agent/scripts/tests/test_cross_model_review.sh
+++ b/.agent/scripts/tests/test_cross_model_review.sh
@@ -68,6 +68,19 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local label="$1" pattern="$2" text="$3"
+    if echo "$text" | grep -qE "$pattern"; then
+        echo "  FAIL: $label"
+        echo "    unexpected pattern found: $pattern"
+        echo "    in: $text"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
 assert_exit_code() {
     local label="$1" expected="$2" actual="$3"
     if [[ "$expected" == "$actual" ]]; then
@@ -446,6 +459,19 @@ GH_EOF
         PASS=$((PASS + 1))
     fi
 
+    # Also assert the script skipped the PR-body extraction entirely
+    # when --issue was supplied (no `gh pr view ... --json body` call).
+    # Tightens the test per review feedback on PR #154.
+    if grep -qE "^pr view .* --json body" "$MOCK_GH_LOG"; then
+        echo "  FAIL: gh pr view --json body was called despite --issue"
+        echo "    gh log:"
+        sed 's/^/      /' "$MOCK_GH_LOG"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: PR-body extraction skipped when --issue is set"
+        PASS=$((PASS + 1))
+    fi
+
     teardown
 }
 
@@ -484,8 +510,11 @@ GH_EOF
         --pr 99 --sync 2>&1) || exit_code=$?
 
     assert_exit_code "missing keyword exits 2" "2" "$exit_code"
+    # Pattern avoids `|` (which grep -E would treat as alternation and
+    # accept a partial match). Testing an unambiguous fragment of the
+    # error message instead — per review feedback on PR #154.
     assert_contains "error mentions missing keyword" \
-        "no 'Closes|Fixes|Resolves #N' keyword" "$stderr"
+        "body has no 'Closes" "$stderr"
     # Pattern must not start with "--" so grep -E doesn't treat it as a flag.
     assert_contains "error suggests --issue flag" "Pass --issue" "$stderr"
 
@@ -519,7 +548,55 @@ test_issue_flag_validates_integer() {
 
     exit_code=0
     stderr=$(bash "${SCRIPT_UNDER_TEST}" --pr 99 --issue -5 2>&1) || exit_code=$?
-    assert_exit_code "--issue -5 rejected (as another flag)" "2" "$exit_code"
+    assert_exit_code "--issue -5 rejected" "2" "$exit_code"
+    # Post-review: require_value was narrowed from -* to --*, so -5
+    # now reaches the integer validator instead of being caught as a
+    # "missing value" flag. Both paths exit 2; the integer message is
+    # more accurate.
+    assert_contains "error mentions integer contract for -5" \
+        "not a positive integer" "$stderr"
+}
+
+# ---- Test: gh pr view failure produces a retrieval-specific error (#149) ----
+#
+# Regression test for the review fix: when gh fails (auth/permissions/
+# network), the script must NOT emit the "no closure keyword" guidance,
+# which would point users at the wrong remediation.
+test_gh_pr_view_failure_distinct_error() {
+    echo "TEST: gh pr view failure produces a distinct error (#149)"
+    setup
+
+    # Mock gh that fails on `pr view --json body` (exit non-zero).
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    shift 2; PR="$1"; shift
+    [[ "${1:-}" == "-R" ]] && shift 2
+    if [[ "$1" == "--json" && "$2" == "body" ]]; then
+        # Simulate auth/network/permission failure
+        echo "gh: authentication required" >&2
+        exit 1
+    fi
+fi
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    cd "${MOCK_REPO}"
+    local exit_code=0
+    local stderr
+    stderr=$(PATH="${MOCK_BIN}:${PATH}" WORKTREE_ISSUE=42 bash "${SCRIPT_UNDER_TEST}" \
+        --pr 99 --sync 2>&1) || exit_code=$?
+
+    assert_exit_code "gh failure exits 2" "2" "$exit_code"
+    assert_contains "error mentions retrieval failure" \
+        "Failed to retrieve body" "$stderr"
+    # Must NOT fall through to the no-keyword remediation — that would
+    # be misleading when the real problem is auth/network.
+    assert_not_contains "no-keyword guidance suppressed on gh failure" \
+        "body has no 'Closes" "$stderr"
+
+    teardown
 }
 
 # ---- Run all tests ----
@@ -538,6 +615,7 @@ test_flag_as_value_rejected
 test_issue_flag_overrides_extraction
 test_missing_keyword_aborts
 test_issue_flag_validates_integer
+test_gh_pr_view_failure_distinct_error
 
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="

--- a/.agent/scripts/tests/test_cross_model_review.sh
+++ b/.agent/scripts/tests/test_cross_model_review.sh
@@ -154,35 +154,33 @@ GH_EOF
 }
 
 # ---- Test: issue extraction from PR body ----
-# Helper: mirrors the extraction logic from cross_model_review.sh
+# Helper: mirrors the extraction logic from cross_model_review.sh.
+# Post-#149: keyword-only — no loose "#N anywhere" fallback.
 extract_issue() {
     local body="$1"
     local ref num
-    ref=$(printf '%s\n' "$body" | grep -ioE '(^|[^[:alnum:]_])(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' | head -n1 || true)
+    ref=$(printf '%s\n' "$body" \
+        | grep -ioE '(^|[^[:alnum:]_])(closes|fixes|resolves)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+' \
+        | head -n1 || true)
     num=$(printf '%s\n' "$ref" | grep -oE '[0-9]+$' || true)
-    if [[ -z "$num" ]]; then
-        num=$(printf '%s\n' "$body" | grep -oE '(^|[[:space:]])#[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
-    fi
     printf '%s' "${num:-}"
 }
 
 test_issue_extraction() {
-    echo "TEST: issue number extraction"
+    echo "TEST: issue number extraction (keyword-only, post-#149)"
 
-    # Positive cases
-    assert_eq "Closes #42 -> 42" "42" "$(extract_issue 'Some text\nCloses #42\nMore text')"
+    # Positive cases — keyword match wins
+    assert_eq "Closes #42 -> 42" "42" "$(extract_issue 'Some text. Closes #42. More text.')"
     assert_eq "fixes #123 -> 123" "123" "$(extract_issue 'fixes #123')"
     assert_eq "Resolves owner/repo#77 -> 77" "77" "$(extract_issue 'Resolves owner/repo#77')"
     assert_eq "CLOSES #5 -> 5" "5" "$(extract_issue 'CLOSES #5')"
-
-    # Negative: substring false positives should NOT match as close keywords
-    assert_eq "encloses #42 -> fallback 42" "42" "$(extract_issue 'encloses #42')"
-    assert_eq "prefixes #7 -> fallback 7" "7" "$(extract_issue 'prefixes #7')"
-    # But with a real close keyword elsewhere, it should pick the right one
+    # A real keyword later in the body wins over substring false positives
     assert_eq "encloses #42, Closes #99 -> 99" "99" "$(extract_issue 'encloses #42 but Closes #99')"
 
-    # Fallback cases
-    assert_eq "Fallback #10 -> 10" "10" "$(extract_issue 'Related to #10 and #20')"
+    # Post-#149: no keyword means empty — no loose "#N anywhere" fallback
+    assert_eq "encloses #42 (substring only) -> empty" "" "$(extract_issue 'encloses #42')"
+    assert_eq "prefixes #7 (substring only) -> empty" "" "$(extract_issue 'prefixes #7')"
+    assert_eq "no keyword, '#N' in body -> empty" "" "$(extract_issue 'Related to #10 and #20')"
     assert_eq "No issue ref -> empty" "" "$(extract_issue 'No issue reference here')"
 }
 
@@ -381,6 +379,149 @@ test_flag_as_value_rejected() {
     assert_contains "error mentions missing value" "Missing value for --pr" "$STDERR"
 }
 
+# ---- Test: --issue flag overrides PR-body extraction (#149) ----
+#
+# When --issue <N> is passed, the script must honour it verbatim without
+# consulting the PR body. This is the escape hatch for PRs that don't
+# use Closes/Fixes/Resolves keywords (rollup PRs, long-running
+# investigations, etc.).
+test_issue_flag_overrides_extraction() {
+    echo "TEST: --issue overrides PR-body extraction (#149)"
+    setup
+
+    export MOCK_GH_LOG="${TMPDIR_BASE}/gh_calls.log"
+    true > "$MOCK_GH_LOG"
+
+    # Mock gh: PR body has NO closure keyword — extraction would fail
+    # without --issue. With --issue the body shouldn't even be queried
+    # for body (but we still need view for title/url; returning body
+    # anyway is harmless because the script skips extraction).
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${MOCK_GH_LOG}"
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    shift 2; PR="$1"; shift
+    [[ "${1:-}" == "-R" ]] && shift 2
+    if [[ "$1" == "--json" && "$2" == "body" ]]; then
+        echo "A PR body with no closure keyword. See also #42."
+    elif [[ "$1" == "--json" && "$2" == "title" ]]; then
+        echo "Test PR"
+    elif [[ "$1" == "--json" && "$2" == "url" ]]; then
+        echo "https://github.com/test/repo/pull/99"
+    fi
+elif [[ "$1" == "pr" && "$2" == "diff" ]]; then
+    echo "diff --git a/file.txt b/file.txt"
+    echo "--- a/file.txt"
+    echo "+++ b/file.txt"
+    echo "@@ -1 +1 @@"
+    echo "-old"
+    echo "+new"
+fi
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    cd "${MOCK_REPO}"
+    # --issue 123 matches WORKTREE_ISSUE so the resolver accepts it; the
+    # wrong match (#42 from the loose fallback) would have been picked
+    # before #149 and broken this test.
+    PATH="${MOCK_BIN}:${PATH}" WORKTREE_ISSUE=123 bash "${SCRIPT_UNDER_TEST}" \
+        --pr 99 --issue 123 --sync >/dev/null 2>&1 || true
+
+    # Artifacts should land under issue-123 (from --issue), not issue-42
+    # (from the PR body).
+    if [[ -d "${MOCK_REPO}/.agent/work-plans/issue-123" ]]; then
+        echo "  PASS: --issue value used as issue number"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: --issue value not used"
+        echo "    ls work-plans: $(ls "${MOCK_REPO}/.agent/work-plans/" 2>/dev/null || echo 'empty')"
+        FAIL=$((FAIL + 1))
+    fi
+    if [[ -d "${MOCK_REPO}/.agent/work-plans/issue-42" ]]; then
+        echo "  FAIL: loose fallback still used — routed to #42"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: PR-body #42 not used"
+        PASS=$((PASS + 1))
+    fi
+
+    teardown
+}
+
+# ---- Test: missing closure keyword aborts with guidance (#149) ----
+#
+# Before #149 the script silently routed artifacts to the first '#N'
+# found anywhere in the PR body, or fell back to the PR number. Both
+# behaviors hid real errors. Now: no keyword + no --issue => exit 2.
+test_missing_keyword_aborts() {
+    echo "TEST: missing closure keyword without --issue aborts (#149)"
+    setup
+
+    # Mock gh: PR body deliberately has only a loose '#N' reference and
+    # a substring like "encloses #42" that should not be picked up.
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    shift 2; PR="$1"; shift
+    [[ "${1:-}" == "-R" ]] && shift 2
+    if [[ "$1" == "--json" && "$2" == "body" ]]; then
+        echo "Related to #42 (encloses #7). No closure keyword here."
+    elif [[ "$1" == "--json" && "$2" == "title" ]]; then
+        echo "Test PR"
+    elif [[ "$1" == "--json" && "$2" == "url" ]]; then
+        echo "https://github.com/test/repo/pull/99"
+    fi
+fi
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    cd "${MOCK_REPO}"
+    local exit_code=0
+    local stderr
+    stderr=$(PATH="${MOCK_BIN}:${PATH}" WORKTREE_ISSUE=42 bash "${SCRIPT_UNDER_TEST}" \
+        --pr 99 --sync 2>&1) || exit_code=$?
+
+    assert_exit_code "missing keyword exits 2" "2" "$exit_code"
+    assert_contains "error mentions missing keyword" \
+        "no 'Closes|Fixes|Resolves #N' keyword" "$stderr"
+    # Pattern must not start with "--" so grep -E doesn't treat it as a flag.
+    assert_contains "error suggests --issue flag" "Pass --issue" "$stderr"
+
+    # No artifacts should have been written (abort before resolver).
+    if [[ -d "${MOCK_REPO}/.agent/work-plans/issue-42" ]] || \
+       [[ -d "${MOCK_REPO}/.agent/work-plans/issue-7" ]]; then
+        echo "  FAIL: artifacts leaked from the loose fallback"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: no artifacts written when extraction fails"
+        PASS=$((PASS + 1))
+    fi
+
+    teardown
+}
+
+# ---- Test: --issue validates positive integer shape (#149) ----
+test_issue_flag_validates_integer() {
+    echo "TEST: --issue rejects non-integer values (#149)"
+
+    local exit_code=0
+    local stderr
+    stderr=$(bash "${SCRIPT_UNDER_TEST}" --pr 99 --issue not-a-number 2>&1) || exit_code=$?
+    assert_exit_code "non-integer --issue exits 2" "2" "$exit_code"
+    assert_contains "error mentions integer contract" \
+        "not a positive integer" "$stderr"
+
+    exit_code=0
+    stderr=$(bash "${SCRIPT_UNDER_TEST}" --pr 99 --issue 0 2>&1) || exit_code=$?
+    assert_exit_code "--issue 0 rejected" "2" "$exit_code"
+
+    exit_code=0
+    stderr=$(bash "${SCRIPT_UNDER_TEST}" --pr 99 --issue -5 2>&1) || exit_code=$?
+    assert_exit_code "--issue -5 rejected (as another flag)" "2" "$exit_code"
+}
+
 # ---- Run all tests ----
 echo "=== cross_model_review.sh tests ==="
 echo ""
@@ -394,6 +535,9 @@ test_work_dir_flag
 test_empty_diff_guard
 test_resolver_refuses_without_worktree_issue
 test_flag_as_value_rejected
+test_issue_flag_overrides_extraction
+test_missing_keyword_aborts
+test_issue_flag_validates_integer
 
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="

--- a/.agent/work-plans/issue-149/progress.md
+++ b/.agent/work-plans/issue-149/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 149
+---
+
+# Issue #149 — cross_model_review.sh: loose #N fallback routes artifacts to wrong issue when no Closes/Fixes/Resolves keyword
+
+## External Review
+**Status**: complete
+**When**: 2026-04-19
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #154 — 1 review (Copilot), 4 valid, 0 false positives
+**CI**: all 8 checks pass
+
+### Actions
+- [ ] (must) Separate `gh pr view` failure from empty-body case; distinct error message for auth/network failures — `.agent/scripts/cross_model_review.sh:~253`
+- [ ] (polish) Narrow `require_value`'s `-*` check to `--*` so `--issue -5` produces the integer-validator's message — `.agent/scripts/cross_model_review.sh:~129`
+- [ ] (test) Escape `|` in `assert_contains` pattern for "no 'Closes|Fixes|Resolves...'" — `.agent/scripts/tests/test_cross_model_review.sh:488`
+- [ ] (test) Assert `--json body` is not called when `--issue` is passed — `.agent/scripts/tests/test_cross_model_review.sh:407`

--- a/.agent/work-plans/issue-149/progress.md
+++ b/.agent/work-plans/issue-149/progress.md
@@ -13,7 +13,7 @@ issue: 149
 **CI**: all 8 checks pass
 
 ### Actions
-- [ ] (must) Separate `gh pr view` failure from empty-body case; distinct error message for auth/network failures — `.agent/scripts/cross_model_review.sh:~253`
-- [ ] (polish) Narrow `require_value`'s `-*` check to `--*` so `--issue -5` produces the integer-validator's message — `.agent/scripts/cross_model_review.sh:~129`
-- [ ] (test) Escape `|` in `assert_contains` pattern for "no 'Closes|Fixes|Resolves...'" — `.agent/scripts/tests/test_cross_model_review.sh:488`
-- [ ] (test) Assert `--json body` is not called when `--issue` is passed — `.agent/scripts/tests/test_cross_model_review.sh:407`
+- [x] (must) Separate `gh pr view` failure from empty-body case; distinct error message for auth/network failures — `.agent/scripts/cross_model_review.sh:~253`
+- [x] (polish) Narrow `require_value`'s `-*` check to `--*` so `--issue -5` produces the integer-validator's message — `.agent/scripts/cross_model_review.sh:~129`
+- [x] (test) Escape `|` in `assert_contains` pattern for "no 'Closes|Fixes|Resolves...'" — `.agent/scripts/tests/test_cross_model_review.sh:488`
+- [x] (test) Assert `--json body` is not called when `--issue` is passed — `.agent/scripts/tests/test_cross_model_review.sh:407`


### PR DESCRIPTION
Closes #149

## Summary

Implements option 3 from the issue: keyword-only extraction + explicit
`--issue` override, no loose fallback. `cross_model_review.sh` now
refuses to guess at the issue number when the PR body lacks a
`Closes|Fixes|Resolves #N` keyword.

## Changes

- **Added `--issue <N>` flag** — validated as a bare positive integer.
  When supplied, takes precedence and skips PR-body extraction.
- **Removed the loose `#N` fallback** — it silently routed artifacts
  to unrelated issues any time a PR referenced "#N" in passing (e.g.
  "see also #42") before the real closure keyword, or without any
  keyword at all.
- **Removed the PR-number fallback** — conflating PR numbers with
  issue numbers hid real errors.
- **Abort with guidance** — missing keyword + no `--issue` → exit 2
  with a message listing the two remediations.

## Behavior change

This is a behavior change. Anyone whose PR bodies don't include a
closure keyword must either:
1. Add `Closes #<N>` (or `Fixes`/`Resolves`) to the PR body, or
2. Pass `--issue <N>` explicitly to the script.

## Test plan

- [x] `bash .agent/scripts/tests/test_cross_model_review.sh` — 37/37 pass
      (up from 27, +10 assertions for this fix, plus 4 tests adjusted
      to match the new keyword-only behavior)
- [x] `pre-commit run shellcheck --files ...` — passes

## Coordination note

This PR is one of three stacked off current `main` after #148 merged:
- #152 (issue #151) — resolver rule-3 echo concat + set -u fix
- #153 (issue #150) — `gh repo view` for slug resolution
- #154 (this PR, issue #149) — keyword-only extraction

All three touch different lines; no conflicts expected. Merge order
flexible.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
