### PR TITLE
Fix merge_pr.sh ROOT_DIR detection from inside worktrees (#146)

### DIFF
--- a/.agent/scripts/merge_pr.sh
+++ b/.agent/scripts/merge_pr.sh
@@ -65,9 +65,25 @@ if [[ -n "$WORKTREE_TYPE" ]] && [[ "$WORKTREE_TYPE" != "workspace" && "$WORKTREE
     exit 2
 fi
 
-# --- Resolve workspace root ---
-ROOT_DIR="$SCRIPT_DIR/../.."
-ROOT_DIR="$(cd "$ROOT_DIR" && pwd)"
+# --- Resolve workspace root (main tree) ---
+# Use `git worktree list --porcelain` instead of $SCRIPT_DIR/../.. so the
+# resolution is correct when the script is invoked from inside a
+# worktree (e.g. `make merge-pr` from a feature worktree). With the
+# relative-path approach, ROOT_DIR resolved to the worktree root, not
+# the main tree, so downstream worktree detection and cleanup silently
+# skipped. See issue #146.
+#
+# git worktree list always prints the main worktree first, in absolute
+# form, regardless of invocation cwd.
+# `|| true` so invocation outside any repo (git fails, pipefail would
+# otherwise trip set -e) falls through to the explicit empty-string
+# check below with a clearer error.
+ROOT_DIR=$({ git -C "$SCRIPT_DIR" worktree list --porcelain 2>/dev/null \
+    | head -n1 | sed 's/^worktree //'; } || true)
+if [[ -z "$ROOT_DIR" ]]; then
+    echo "ERROR: merge_pr.sh must run from within a git repository" >&2
+    exit 1
+fi
 
 # --- Resolve target repo for gh commands ---
 # For project PRs, gh must target the project repo, not the workspace repo.

--- a/.agent/scripts/tests/test_merge_pr_root_resolution.sh
+++ b/.agent/scripts/tests/test_merge_pr_root_resolution.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Tests for merge_pr.sh's ROOT_DIR resolution (issue #146).
+#
+# Instead of driving the full script (which would require mocking gh
+# pr view / pr merge, the roadmap updater, worktree_remove.sh, etc.),
+# these tests exercise the exact shell pipeline the script uses to
+# resolve the main tree's absolute path, proving it returns the main
+# tree from both the main tree itself and from a linked worktree.
+#
+# Run: bash .agent/scripts/tests/test_merge_pr_root_resolution.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR_BASE=""
+MAIN_REPO=""
+WORKTREE=""
+
+setup_main_and_worktree() {
+    TMPDIR_BASE=$(mktemp -d /tmp/test_mpr.XXXXXX)
+    MAIN_REPO="${TMPDIR_BASE}/main"
+    git init -q "${MAIN_REPO}"
+    git -C "${MAIN_REPO}" -c user.name="Test" -c user.email="t@t" commit --allow-empty -m "init" -q
+    git -C "${MAIN_REPO}" checkout -q -b feature/issue-999 2>/dev/null
+    git -C "${MAIN_REPO}" -c user.name="Test" -c user.email="t@t" commit --allow-empty -m "feature" -q
+    git -C "${MAIN_REPO}" checkout -q main 2>/dev/null || git -C "${MAIN_REPO}" checkout -q master 2>/dev/null
+    # Create a linked worktree on the feature branch
+    WORKTREE="${MAIN_REPO}/worktrees/issue-999"
+    git -C "${MAIN_REPO}" worktree add -q "${WORKTREE}" feature/issue-999
+    # Simulate the .agent/scripts layout inside the worktree
+    mkdir -p "${WORKTREE}/.agent/scripts"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_BASE" && -d "$TMPDIR_BASE" ]]; then
+        # Clean up worktree registration before removing dirs
+        git -C "${MAIN_REPO}" worktree remove -f "${WORKTREE}" 2>/dev/null || true
+        rm -rf "$TMPDIR_BASE"
+    fi
+}
+trap teardown EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Extract ROOT_DIR the same way merge_pr.sh does. Keep this in sync
+# with merge_pr.sh:69-83 — if that changes, update here.
+# `|| true` so an outside-repo call returns empty instead of tripping
+# the caller's pipefail.
+resolve_root() {
+    local script_dir="$1"
+    { git -C "$script_dir" worktree list --porcelain 2>/dev/null \
+        | head -n1 | sed 's/^worktree //'; } || true
+}
+
+# ---- Test: resolution from main tree returns main tree ----
+test_resolution_from_main_tree() {
+    echo "TEST: ROOT_DIR resolution from main tree"
+    setup_main_and_worktree
+
+    # Simulate invocation from the main tree's .agent/scripts dir.
+    mkdir -p "${MAIN_REPO}/.agent/scripts"
+    local script_dir="${MAIN_REPO}/.agent/scripts"
+    local root
+    root=$(resolve_root "$script_dir")
+    assert_eq "from main tree -> main tree" "${MAIN_REPO}" "$root"
+
+    teardown
+}
+
+# ---- Test: resolution from linked worktree returns main tree (#146) ----
+test_resolution_from_worktree() {
+    echo "TEST: ROOT_DIR resolution from inside a worktree (#146)"
+    setup_main_and_worktree
+
+    # Simulate invocation from the worktree's .agent/scripts dir — the
+    # exact bug case: old `$SCRIPT_DIR/../..` would give WORKTREE here.
+    local script_dir="${WORKTREE}/.agent/scripts"
+    local root
+    root=$(resolve_root "$script_dir")
+    assert_eq "from worktree -> main tree (bug fix)" "${MAIN_REPO}" "$root"
+
+    # And explicitly: the old relative approach would have returned
+    # the worktree root — assert our fix doesn't regress to that.
+    local old_approach
+    old_approach=$(cd "$script_dir/../.." && pwd)
+    if [[ "$old_approach" == "$WORKTREE" ]]; then
+        echo "  PASS: old \$SCRIPT_DIR/../.. approach indeed resolves to worktree"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: old-approach control assertion unexpectedly passed"
+        echo "    old_approach: $old_approach"
+        echo "    WORKTREE:     $WORKTREE"
+        FAIL=$((FAIL + 1))
+    fi
+    assert_eq "new approach differs from old" "$MAIN_REPO" "$root"
+
+    teardown
+}
+
+# ---- Test: resolution outside any git repo returns empty ----
+test_resolution_outside_repo() {
+    echo "TEST: ROOT_DIR resolution outside any git repo"
+    local tmp
+    tmp=$(mktemp -d /tmp/test_mpr_norepo.XXXXXX)
+    local root
+    root=$(resolve_root "$tmp")
+    assert_eq "outside repo -> empty string" "" "$root"
+    rm -rf "$tmp"
+}
+
+# ---- Run all tests ----
+echo "=== merge_pr.sh ROOT_DIR resolution tests ==="
+echo ""
+
+test_resolution_from_main_tree
+test_resolution_from_worktree
+test_resolution_outside_repo
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[[ $FAIL -eq 0 ]]

--- a/.agent/scripts/tests/test_merge_pr_root_resolution.sh
+++ b/.agent/scripts/tests/test_merge_pr_root_resolution.sh
@@ -18,13 +18,19 @@ MAIN_REPO=""
 WORKTREE=""
 
 setup_main_and_worktree() {
+    local initial_branch
+
     TMPDIR_BASE=$(mktemp -d /tmp/test_mpr.XXXXXX)
     MAIN_REPO="${TMPDIR_BASE}/main"
     git init -q "${MAIN_REPO}"
     git -C "${MAIN_REPO}" -c user.name="Test" -c user.email="t@t" commit --allow-empty -m "init" -q
+    # Capture the user's init default branch (main/master/trunk/etc.)
+    # so we can return to it after the feature branch is created.
+    # Hardcoding main/master breaks on init.defaultBranch=trunk setups.
+    initial_branch=$(git -C "${MAIN_REPO}" symbolic-ref --short HEAD)
     git -C "${MAIN_REPO}" checkout -q -b feature/issue-999 2>/dev/null
     git -C "${MAIN_REPO}" -c user.name="Test" -c user.email="t@t" commit --allow-empty -m "feature" -q
-    git -C "${MAIN_REPO}" checkout -q main 2>/dev/null || git -C "${MAIN_REPO}" checkout -q master 2>/dev/null
+    git -C "${MAIN_REPO}" checkout -q "${initial_branch}"
     # Create a linked worktree on the feature branch
     WORKTREE="${MAIN_REPO}/worktrees/issue-999"
     git -C "${MAIN_REPO}" worktree add -q "${WORKTREE}" feature/issue-999

--- a/.agent/work-plans/issue-146/progress.md
+++ b/.agent/work-plans/issue-146/progress.md
@@ -13,4 +13,4 @@ issue: 146
 **CI**: all 8 checks pass
 
 ### Actions
-- [ ] Capture initial branch via `git symbolic-ref --short HEAD` and check out by that instead of hardcoded `main`/`master` — `.agent/scripts/tests/test_merge_pr_root_resolution.sh:~27`
+- [x] Capture initial branch via `git symbolic-ref --short HEAD` and check out by that instead of hardcoded `main`/`master` — `.agent/scripts/tests/test_merge_pr_root_resolution.sh:~27`

--- a/.agent/work-plans/issue-146/progress.md
+++ b/.agent/work-plans/issue-146/progress.md
@@ -1,0 +1,16 @@
+---
+issue: 146
+---
+
+# Issue #146 — merge_pr.sh fails to detect worktrees when invoked from inside a worktree
+
+## External Review
+**Status**: complete
+**When**: 2026-04-19
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #155 — 1 review (Copilot), 1 valid, 0 false positives
+**CI**: all 8 checks pass
+
+### Actions
+- [ ] Capture initial branch via `git symbolic-ref --short HEAD` and check out by that instead of hardcoded `main`/`master` — `.agent/scripts/tests/test_merge_pr_root_resolution.sh:~27`


### PR DESCRIPTION
Closes #146

## Summary

`merge_pr.sh` resolved `ROOT_DIR` via `$SCRIPT_DIR/../..`, which
silently resolved to the **worktree** root (not the main tree) when
the script was invoked from inside a worktree — the common case when
finishing feature work. Downstream worktree detection then failed,
silently skipping the roadmap update and worktree cleanup.

We hit this exact case during today's #148 merge:
> `WARNING: No worktree found for issue #147 — will merge and sync only`

## Fix

Resolve `ROOT_DIR` via `git worktree list --porcelain | head -n1`,
which always prints the main worktree first in absolute form,
regardless of invocation cwd. Wrap the pipeline in `{ ... } || true`
so an invocation outside any git repo falls through to an explicit
empty-string check with a clearer error instead of tripping
`pipefail`.

## Changes

- `.agent/scripts/merge_pr.sh` — 4 lines changed in the ROOT_DIR
  resolution block, plus an explanatory comment.
- `.agent/scripts/tests/test_merge_pr_root_resolution.sh` — new test
  file, 5 assertions across 3 test cases (main tree, worktree, outside
  repo). The worktree test includes a control assertion that the old
  `$SCRIPT_DIR/../..` approach *does* resolve to the worktree —
  making the regression explicit.

## Out of scope

Several other scripts use the same `$SCRIPT_DIR/../..` pattern
(`agent`, `dashboard.sh`, `worktree_{create,enter,list,remove}.sh`,
`lock.sh`, `setup_project.sh`, etc.). They may have the same latent
issue when invoked from worktrees. Not touched here — that's a wider
refactor worth its own issue if you want it tracked.

## Test plan

- [x] `bash .agent/scripts/tests/test_merge_pr_root_resolution.sh` — 5/5 pass
- [x] `pre-commit run shellcheck --files ...` — passes
- [x] Manual: ran the resolution pipeline from both main tree and the #146 worktree; both return `/home/roland/daddy_camp` as expected
- [x] Verified the old `$SCRIPT_DIR/../..` approach returned the
      worktree path (reproducing the bug), and the new approach
      returns the main tree

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
