### PR TITLE
Refresh research digest (2026-04-19) + Opus 4.7, permission, mode-posture entries

### DIFF
--- a/.agent/knowledge/research_digest.md
+++ b/.agent/knowledge/research_digest.md
@@ -3,6 +3,47 @@
 <!-- Last full refresh: 2026-04-19 (partial — high-movement topics refreshed, stable topics date-bumped only) -->
 <!-- Run /research --refresh periodically to re-survey stale entries -->
 
+## Permission Prompt Reduction Patterns (Claude Code)
+
+**Added**: 2026-04-19 | **Last verified**: 2026-04-19 | **Sources**: [Configure permissions — Claude Code Docs](https://code.claude.com/docs/en/permissions), [Claude Code auto mode](https://www.anthropic.com/engineering/claude-code-auto-mode), [Claude Code changelog 2026](https://claudefa.st/blog/guide/changelog), [managed-settings.json guide](https://managed-settings.com/), [--dangerously-skip-permissions: 5 modes](https://www.morphllm.com/claude-code-dangerously-skip-permissions), [bug #18160 — allow permissions ignored in global settings](https://github.com/anthropics/claude-code/issues/18160)
+
+Key takeaways:
+- **Built-in read-only allowlist** — Claude Code automatically runs `ls`, `cat`, `head`, `tail`, `grep`, `find`, `wc`, `diff`, `stat`, `du`, `cd`, and read-only forms of `git` without prompt. Unquoted globs are permitted when every flag is read-only (e.g., `ls *.ts`, `wc -l src/*.py`).
+- **Project-level `.claude/settings.json` allowlists** — commit to source control to share permission decisions across your team. User-level lives at `~/.claude.json`.
+- **`/fewer-permission-prompts` skill** (renamed from "Less Permission Prompts") — scans session transcripts to extract frequently used read-only tool-call patterns and proposes allowlist additions. Already present locally in `.claude/skills/fewer-permission-prompts/`.
+- **Tilde expansion gotcha** — pattern matching in `settings.json` evaluates BEFORE shell tilde expansion. So `~/.claude/` won't match `/home/user/.claude/`. Gstack #993 addressed a similar issue (tilde-in-assignment silently triggered prompts). Use absolute paths in allowlist patterns or document the workaround. Known upstream issue (#18160).
+- **`auto mode`** — "safer way to skip permissions." Anthropic's framing: opt into it for known-safe workflows, not a blanket `--dangerously-skip-permissions`. Five distinct skip modes exist with different risk profiles.
+- **Permission prompts remain the #1 friction point** in multi-agent workflows at scale (roadmap #110 in this workspace).
+
+**Relevance**: Direct hit on this workspace's #110 priority. Three concrete actions suggested:
+1. Run `/fewer-permission-prompts` after the session to propose allowlist additions from today's transcripts.
+2. Audit for tilde-in-assignment + tilde-in-pattern issues; use absolute paths.
+3. Commit `.claude/settings.json` to source control (already our pattern) so the pruned allowlist survives across developers/agents.
+
+---
+
+## Mode-Posture Preservation in Multi-Mode Skills
+
+**Added**: 2026-04-19 | **Last verified**: 2026-04-19 | **Sources**: [gstack #1065 — mode-posture energy fix](https://github.com/garrytan/gstack/pull/1065), [Prompt Engineering Guide — priming and style control](https://www.promptingguide.ai/techniques), [Mirascope — LLM prompt best practices](https://mirascope.com/blog/llm-prompt), [Palantir Foundry — LLM prompt best practices](https://www.palantir.com/docs/foundry/aip/best-practices-prompt-engineering)
+
+Key takeaways:
+- **Problem**: When a skill has multiple "modes" (e.g., scope expansion vs. holding, forcing question vs. softening, wild-builder vs. structured-PRD), a generic style rule in a shared preamble can silently flatten all of them toward whichever framing the examples favor. Gstack documented this as a real regression across `/plan-ceo-review` and `/office-hours` in early 2026.
+- **Root cause** is a well-known LLM property: **few-shot examples dominate abstract rules.** Psychological/linguistic priming research shows even small phrasings activate different knowledge areas — so any one-sided example set becomes a strong attractor.
+- **Fix pattern** (gstack #1065):
+  1. **Paired examples** in shared preambles — cover the full range of postures the skill spans (pain / upside / forcing), not just the most common one.
+  2. **Inline exemplars** anchored on stable headings in each skill template (so the mode-specific energy survives the preamble).
+  3. **Gate-tier regression tests** with judge rubrics on distinct axes (surface framing + decision preservation; stacking + domain match; excitement over optimization). Pass threshold ~4/5 per axis.
+- **Under Opus 4.7's more literal instruction following** (see Opus 4.7 entry), mode collapse from biased examples gets MORE reliable, not less. Paired examples matter more on 4.7 than they did on 4.6.
+
+**Relevance**: Directly applicable to this workspace's existing multi-mode skills:
+- **#56 "Explicit scope modes for planning"** (done) — four modes: expansion, selective expansion, hold, reduction. At risk if any shared preamble examples favor one mode.
+- **#71 "Brainstorm multi-level modes"** (done) — vision / strategy / architecture / design. Same risk.
+- **`/plan-task`** skill — currently single-mode, but if we ever split by task type, this constraint applies.
+
+Recommended follow-ups: audit those skills for preamble examples that bias toward one mode; add paired examples where mode-spanning preambles exist; consider gate-tier judge-rubric tests.
+
+---
+
 ## Claude Opus 4.7 — Behavioral Changes Since 4.6
 
 **Added**: 2026-04-19 | **Last verified**: 2026-04-19 | **Sources**: [What's new in Claude Opus 4.7 (Anthropic API Docs)](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7), [GitHub Changelog — Opus 4.7 GA April 16, 2026](https://github.blog/changelog/2026-04-16-claude-opus-4-7-is-generally-available/), [Verdent — What Changed for Coding Agents](https://www.verdent.ai/guides/what-is-claude-opus-4-7), [Labellerr — 4.7 vs 4.6 comparison](https://www.labellerr.com/blog/claude-opus-4-7-vs-opus-4-6-comparison/amp/), [Apiyi — Launch-day in-depth review](https://help.apiyi.com/en/claude-opus-4-7-vs-4-6-real-performance-review-en.html)
@@ -25,7 +66,7 @@ Key takeaways:
 
 ## Command Runner Alternatives to Make
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [just](https://github.com/casey/just), [Task](https://github.com/go-task/task), [mise](https://github.com/jdx/mise)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [just](https://github.com/casey/just), [Task](https://github.com/go-task/task), [mise](https://github.com/jdx/mise)
 
 Key takeaways:
 - `just` is the strongest candidate for replacing Make as a command runner — closest syntax, built-in `just --list`, no `.PHONY` needed, multi-language recipes
@@ -39,7 +80,7 @@ Key takeaways:
 
 ## AGENTS.md — Cross-Platform Agent Instruction Standard
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [agents.md spec](https://agents.md/), [GitHub repo](https://github.com/agentsmd/agents.md), [OpenAI Codex guide](https://developers.openai.com/codex/guides/agents-md/), [Agentic AI Foundation](https://openai.com/index/agentic-ai-foundation/), [deep dive](https://prpm.dev/blog/agents-md-deep-dive), [sync strategy](https://kau.sh/blog/agents-md/)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [agents.md spec](https://agents.md/), [GitHub repo](https://github.com/agentsmd/agents.md), [OpenAI Codex guide](https://developers.openai.com/codex/guides/agents-md/), [Agentic AI Foundation](https://openai.com/index/agentic-ai-foundation/), [deep dive](https://prpm.dev/blog/agents-md-deep-dive), [sync strategy](https://kau.sh/blog/agents-md/)
 
 Key takeaways:
 - Vendor-neutral spec stewarded by the Agentic AI Foundation (Linux Foundation), with contributions from OpenAI, Anthropic, and others
@@ -54,7 +95,7 @@ Key takeaways:
 
 ## AI Agent Spec Writing Best Practices
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [Osmani, "How to Write a Good Spec for AI Agents" (O'Reilly, Jan 2026)](https://www.oreilly.com/radar/how-to-write-a-good-spec-for-ai-agents/), [addyosmani.com](https://addyosmani.com/blog/good-spec/)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [Osmani, "How to Write a Good Spec for AI Agents" (O'Reilly, Jan 2026)](https://www.oreilly.com/radar/how-to-write-a-good-spec-for-ai-agents/), [addyosmani.com](https://addyosmani.com/blog/good-spec/)
 
 Key takeaways:
 - Informed by GitHub's analysis of 2,500+ agent configuration files
@@ -70,7 +111,7 @@ Key takeaways:
 
 ## Harness Engineering — Production-Scale Agent-First Development
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [OpenAI blog (Lopopolo, Feb 2026)](https://openai.com/index/harness-engineering/), [Böckeler analysis (martinfowler.com)](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html), [InfoQ coverage](https://www.infoq.com/news/2026/02/openai-harness-engineering-codex/)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [OpenAI blog (Lopopolo, Feb 2026)](https://openai.com/index/harness-engineering/), [Böckeler analysis (martinfowler.com)](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html), [InfoQ coverage](https://www.infoq.com/news/2026/02/openai-harness-engineering-codex/)
 
 Key takeaways:
 - Team of 3–7 engineers built ~1M LOC product with zero human-written code over 5 months using Codex; 3.5 PRs/engineer/day
@@ -88,7 +129,7 @@ Key takeaways:
 
 ## Multi-Agent Engineering Patterns
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [GitHub blog, "Multi-agent workflows often fail" (Feb 2026)](https://github.blog/ai-and-ml/generative-ai/multi-agent-workflows-often-fail-heres-how-to-engineer-ones-that-dont/)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [GitHub blog, "Multi-agent workflows often fail" (Feb 2026)](https://github.blog/ai-and-ml/generative-ai/multi-agent-workflows-often-fail-heres-how-to-engineer-ones-that-dont/)
 
 Key takeaways:
 - Core thesis: most multi-agent failures come from **missing structure**, not model capability — treat agents as distributed system components
@@ -119,7 +160,7 @@ Key takeaways:
 
 ## Model Context Protocol (MCP) — Industry Standard
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [MCP spec](https://spec.modelcontextprotocol.io/), [Agentic AI Foundation](https://www.linuxfoundation.org/press/linux-foundation-launches-the-agentic-ai-foundation)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [MCP spec](https://spec.modelcontextprotocol.io/), [Agentic AI Foundation](https://www.linuxfoundation.org/press/linux-foundation-launches-the-agentic-ai-foundation)
 
 Key takeaways:
 - Donated to the Linux Foundation's Agentic AI Foundation (Dec 2025) — now the cross-vendor standard adopted by OpenAI, Google, Anthropic, and others
@@ -133,7 +174,7 @@ Key takeaways:
 
 ## ROS 2 Agent Frameworks
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [ROSA (NASA JPL)](https://github.com/nasa-jpl/rosa), [RAI (RobotecAI)](https://github.com/RobotecAI/rai), [ROS-LLM (Auromix)](https://github.com/Auromix/ROS-LLM), [EmbodiedAgents (Automatika)](https://automatika-robotics.github.io/embodied-agents/)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 (reference only — daddy_camp is non-ROS) | **Sources**: [ROSA (NASA JPL)](https://github.com/nasa-jpl/rosa), [RAI (RobotecAI)](https://github.com/RobotecAI/rai), [ROS-LLM (Auromix)](https://github.com/Auromix/ROS-LLM), [EmbodiedAgents (Automatika)](https://automatika-robotics.github.io/embodied-agents/)
 
 Key takeaways:
 - **ROSA** (NASA JPL): natural language interaction with ROS 1/2 systems — inspect nodes, query topics, diagnose issues; published at IROS 2024
@@ -149,7 +190,7 @@ Key takeaways:
 
 ## Agentic Coding Market and Tool Landscape
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [GitHub blog](https://github.blog/ai-and-ml/generative-ai/multi-agent-workflows-often-fail-heres-how-to-engineer-ones-that-dont/), [Anthropic engineering](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [GitHub blog](https://github.blog/ai-and-ml/generative-ai/multi-agent-workflows-often-fail-heres-how-to-engineer-ones-that-dont/), [Anthropic engineering](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 
 Key takeaways:
 - Market grew from $550M to $4B in one year; 57% of companies run AI agents in production (Jan 2026)
@@ -165,7 +206,7 @@ Key takeaways:
 
 ## GitHub Outage Resilience and Offline Development
 
-**Added**: 2026-03-04 | **Last verified**: 2026-03-04 | **Sources**: [SecureSlate: GitHub outage resilience](https://getsecureslate.com/blog/what-the-github-outage-taught-us-about-resilience-and-compliance-2026), [GitHub down Feb 2026](https://serenitiesai.com/articles/github-down-ai-coding-tools-dependency-2026), [GitHub June 2025 outage](https://www.webpronews.com/githubs-june-2025-outage-how-a-routine-database-migration-cascaded-into-a-platform-wide-crisis/), [Self-hosted git platforms 2026](https://dasroot.net/posts/2026/01/self-hosted-git-platforms-gitlab-gitea-forgejo-2026/)
+**Added**: 2026-03-04 | **Last verified**: 2026-04-19 | **Sources**: [SecureSlate: GitHub outage resilience](https://getsecureslate.com/blog/what-the-github-outage-taught-us-about-resilience-and-compliance-2026), [GitHub down Feb 2026](https://serenitiesai.com/articles/github-down-ai-coding-tools-dependency-2026), [GitHub June 2025 outage](https://www.webpronews.com/githubs-june-2025-outage-how-a-routine-database-migration-cascaded-into-a-platform-wide-crisis/), [Self-hosted git platforms 2026](https://dasroot.net/posts/2026/01/self-hosted-git-platforms-gitlab-gitea-forgejo-2026/)
 
 Key takeaways:
 - GitHub has had multiple major outages in 2025–2026, partly due to its ongoing datacenter-to-Azure migration; Feb 2026 outage blocked pushes, CI, and PR reviews globally
@@ -181,23 +222,24 @@ Key takeaways:
 
 ## git-bug — Distributed Offline-First Issue Tracker
 
-**Added**: 2026-03-04 | **Last verified**: 2026-03-04 | **Sources**: [git-bug repo](https://github.com/git-bug/git-bug), [BrightCoding overview](https://www.blog.brightcoding.dev/2025/06/01/git-bug-a-distributed-offline-first-bug-tracker-embedded-in-git/), [HN discussion](https://news.ycombinator.com/item?id=43971620)
+**Added**: 2026-03-04 | **Last verified**: 2026-04-19 | **Sources**: [git-bug repo (git-bug/git-bug)](https://github.com/git-bug/git-bug), [Releases](https://github.com/git-bug/git-bug/releases), [BrightCoding overview](https://www.blog.brightcoding.dev/2025/06/01/git-bug-a-distributed-offline-first-bug-tracker-embedded-in-git/), [HN discussion](https://news.ycombinator.com/item?id=43971620), [ros2_agent_workspace #418 — v0.10.1 syntax-drift lesson](https://github.com/rolker/ros2_agent_workspace/issues/418)
 
 Key takeaways:
-- Stores issues as git objects (under `refs/bugs`), not files — no clutter in the working tree, full version history, distributed by default
-- **Offline-first**: create, edit, comment on issues without network; syncs via `git push/pull` to any remote
-- **Bidirectional bridges**: GitHub, GitLab, Jira, Launchpad — can pull issues from GitHub and push local issues back
-- Multiple interfaces: CLI, terminal UI (TUI), and web UI (significantly improved in recent releases)
-- Latest release: v0.10.1 (May 2025), active development with 2,400+ commits
-- **git-issue** (Spinellis) is a simpler alternative storing issues as files in a dedicated branch
+- Stores issues as git objects (under `refs/bugs`), not files — no clutter in working tree, full version history, distributed by default.
+- **Offline-first**: create, edit, comment without network; syncs via `git push/pull` to any remote.
+- **Bidirectional bridges**: GitHub, GitLab, Jira, Launchpad.
+- Multiple interfaces: CLI, TUI, web UI.
+- **Latest release still v0.10.1** (May 2025). Last repo activity noted Apr 9, 2026; master branch removed Jan 31, 2026 (structural change). No v0.11/v0.12 cut yet.
+- **v0.10.1 syntax migration** (lesson from ros2 #418): commands moved from top-level (`git bug select/show`) to nested under `git bug bug` in v0.10.1. Scripts written for earlier versions silently fall back to whatever wraps them (`2>/dev/null`) without complaint — the ros2 workspace's scripts fell back to `gh` for ~2 weeks before someone noticed. daddy_camp verified 2026-04-19 that our scripts use the correct `git bug bug ...` form.
+- **git-issue** (Spinellis) is a simpler alternative storing issues as files in a dedicated branch.
 
-**Relevance**: Could serve as a local issue cache that stays in sync with GitHub when online and continues working offline. The GitHub bridge would allow the workspace's issue-first workflow to continue during outages. The `refs/bugs` storage means no interference with the working tree or worktree isolation.
+**Relevance**: Our workspace has adopted git-bug as the first read path (ADR-0010). 96 issues cached locally as of 2026-04-19. Two gaps remain vs. an ideal offline-first story: (1) visible fallback warnings when git-bug is unavailable (roadmap item in PR #157); (2) writes still go through `gh issue create` — offline issue creation exists via `GITBUG_CREATE=1` but hasn't been exercised end-to-end. Forgejo as an alternative remote has been explicitly declined this session (D6).
 
 ---
 
 ## Local CI with Act (nektos/act)
 
-**Added**: 2026-03-04 | **Last verified**: 2026-03-04 | **Sources**: [nektos/act repo](https://github.com/nektos/act), [CICube guide](https://cicube.io/blog/run-github-actions-locally/), [Microsoft guide](https://techcommunity.microsoft.com/blog/azureinfrastructureblog/using-act-to-test-github-workflows-locally-for-azure-deployments-cicd/4414310)
+**Added**: 2026-03-04 | **Last verified**: 2026-04-19 | **Sources**: [nektos/act repo](https://github.com/nektos/act), [CICube guide](https://cicube.io/blog/run-github-actions-locally/), [Microsoft guide](https://techcommunity.microsoft.com/blog/azureinfrastructureblog/using-act-to-test-github-workflows-locally-for-azure-deployments-cicd/4414310)
 
 Key takeaways:
 - Runs GitHub Actions workflows locally using Docker — reads `.github/workflows/` and spins up containers matching the GitHub environment
@@ -212,7 +254,7 @@ Key takeaways:
 
 ## ROS 2 Offline Development Patterns
 
-**Added**: 2026-03-04 | **Last verified**: 2026-03-04 | **Sources**: [rosdep offline mirror PR](https://github.com/ros-infrastructure/rosdep/pull/839), [ROS Answers: rosdep offline](https://answers.ros.org/question/276942/can-sudo-rosdep-init-and-rosdep-update-be-done-offline/), [rosdep mirror guide](https://answers.ros.org/question/338122/how-do-i-deploy-a-rosdep-mirror/)
+**Added**: 2026-03-04 | **Last verified**: 2026-04-19 (reference only — daddy_camp is non-ROS) | **Sources**: [rosdep offline mirror PR](https://github.com/ros-infrastructure/rosdep/pull/839), [ROS Answers: rosdep offline](https://answers.ros.org/question/276942/can-sudo-rosdep-init-and-rosdep-update-be-done-offline/), [rosdep mirror guide](https://answers.ros.org/question/338122/how-do-i-deploy-a-rosdep-mirror/)
 
 Key takeaways:
 - `rosdep` can work offline by setting `ROSDISTRO_INDEX_URL=file:///path/to/local/index-v4.yaml` — clone the `rosdistro` repo locally and point to it
@@ -226,7 +268,7 @@ Key takeaways:
 
 ## Lightweight Self-Hosted Git Forges (Forgejo / Gitea)
 
-**Added**: 2026-03-04 | **Last verified**: 2026-03-04 | **Sources**: [Self-hosted git platforms 2026](https://dasroot.net/posts/2026/01/self-hosted-git-platforms-gitlab-gitea-forgejo-2026/), [Forgejo comparison](https://forgejo.org/compare/), [Forgejo vs Gitea](https://forgejo.org/compare-to-gitea/), [Gitea comparison](https://docs.gitea.com/installation/comparison)
+**Added**: 2026-03-04 | **Last verified**: 2026-04-19 (Forgejo/Gitea explicitly declined 2026-04-19 — see session D6; entry retained as reference in case constraints change) | **Sources**: [Self-hosted git platforms 2026](https://dasroot.net/posts/2026/01/self-hosted-git-platforms-gitlab-gitea-forgejo-2026/), [Forgejo comparison](https://forgejo.org/compare/), [Forgejo vs Gitea](https://forgejo.org/compare-to-gitea/), [Gitea comparison](https://docs.gitea.com/installation/comparison)
 
 Key takeaways:
 - **Gitea** and **Forgejo** (community fork of Gitea) are functionally near-identical: ~200MB RAM, single binary or Docker one-liner, run on Raspberry Pi
@@ -257,7 +299,7 @@ Key takeaways:
 
 ## Potential Inspiration Tracker Candidates
 
-**Added**: 2026-03-22 | **Last verified**: 2026-03-22 | **Sources**: [obra/superpowers](https://github.com/obra/superpowers), [obra/superpowers-lab](https://github.com/obra/superpowers-lab), [steveyegge/gastown](https://github.com/steveyegge/gastown), [microsoft/skills](https://github.com/microsoft/skills), [wshobson/agents](https://github.com/wshobson/agents), [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code), [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator)
+**Added**: 2026-03-22 | **Last verified**: 2026-04-19 (updated: gastown + microsoft-skills dropped from registry per 2026-04-19 inspiration-tracker run — see their digests for archival reason) | **Sources**: [obra/superpowers](https://github.com/obra/superpowers), [obra/superpowers-lab](https://github.com/obra/superpowers-lab), [steveyegge/gastown](https://github.com/steveyegge/gastown), [microsoft/skills](https://github.com/microsoft/skills), [wshobson/agents](https://github.com/wshobson/agents), [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code), [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator)
 
 Survey of repos that could be tracked via `/inspiration-tracker add` for portable patterns and enhancements. Assessed against this workspace's concerns: skills architecture, governance, worktree isolation, multi-agent coordination, and multi-framework identity.
 
@@ -278,3 +320,12 @@ Survey of repos that could be tracked via `/inspiration-tracker add` for portabl
 - **hesreallyhim/awesome-claude-code**, **VoltAgent/awesome-claude-code-subagents**, **rohitg00/awesome-claude-code-toolkit** — Curated lists / catalogs. Useful for one-off browsing but too broad and fast-churning for structured tracking. Better used as discovery sources when searching for a specific pattern.
 
 **Relevance**: The inspiration tracker currently only tracks `ros2_agent_workspace` (fork) and `gstack` (inspiration). Adding 2–3 of the strong candidates would broaden the workspace's awareness of evolving patterns in skills architecture, multi-agent coordination, and governance enforcement. Recommended priority: **superpowers** first (most relevant to skills and review workflows), then **gastown** (most relevant to multi-agent coordination).
+
+**Update 2026-04-19**: Registry evolved since this survey — superpowers added, gastown + microsoft-skills added then archived (low signal-to-noise per 2026-04-19 inspiration-tracker run). New candidates surfaced during 2026-04-19 research refresh, not yet triaged:
+
+- **Vibe Kanban** ([vibekanban.com](https://vibekanban.com/)) — Visual Kanban UI for orchestrating AI coding agents. May not fit our CLI-first preference but worth looking at the task-decomposition model.
+- **Superset** ([superset.sh](https://superset.sh/)) — Orchestrator stack pattern (Superset/Capy for orchestration + Claude Code/Codex for primary + Copilot/Cursor for editor-side).
+- **Capy** — Orchestrator, mentioned alongside Superset as the other leading 2026 orchestration platform.
+- **CodeMachine-CLI** ([BrightCoding article](https://www.blog.brightcoding.dev/2026/04/14/codemachine-cli-the-revolutionary-ai-agent-orchestrator)) — New AI agent orchestrator (April 2026).
+
+None pursued as inspiration-tracker entries yet. Triage on next brainstorm.

--- a/.agent/knowledge/research_digest.md
+++ b/.agent/knowledge/research_digest.md
@@ -1,7 +1,27 @@
 # Research Digest: Workspace
 
-<!-- Last full refresh: — (no full refresh has been run yet) -->
+<!-- Last full refresh: 2026-04-19 (partial — high-movement topics refreshed, stable topics date-bumped only) -->
 <!-- Run /research --refresh periodically to re-survey stale entries -->
+
+## Claude Opus 4.7 — Behavioral Changes Since 4.6
+
+**Added**: 2026-04-19 | **Last verified**: 2026-04-19 | **Sources**: [What's new in Claude Opus 4.7 (Anthropic API Docs)](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7), [GitHub Changelog — Opus 4.7 GA April 16, 2026](https://github.blog/changelog/2026-04-16-claude-opus-4-7-is-generally-available/), [Verdent — What Changed for Coding Agents](https://www.verdent.ai/guides/what-is-claude-opus-4-7), [Labellerr — 4.7 vs 4.6 comparison](https://www.labellerr.com/blog/claude-opus-4-7-vs-opus-4-6-comparison/amp/), [Apiyi — Launch-day in-depth review](https://help.apiyi.com/en/claude-opus-4-7-vs-4-6-real-performance-review-en.html)
+
+Key takeaways:
+- **GA April 16, 2026** — three days before this entry. Today's agent (this session) runs 4.7.
+- **More literal instruction following**. Opus 4.6 interpreted instructions loosely, sometimes skipped steps, filled gaps with judgment. Opus 4.7 takes them precisely — "respond in JSON" returns JSON and nothing else; "write exactly 3 functions" writes exactly 3. Anthropic **explicitly warns** that prompts written for earlier models that relied on judgment to fill gaps need review and rewrite.
+- **More direct, opinionated tone**. Less validation-forward phrasing, fewer emoji, more regular progress updates during long agentic traces.
+- **New `xhigh` effort level** between `high` and `max`. Anthropic's docs recommend starting with `xhigh` for coding and agentic use.
+- **Reduced confident-wrong rate** — new self-verification behavior that lowers how often agents surface confidently wrong output.
+- **Vision upgrade** — max image resolution jumped from ~1.15 MP to ~3.75 MP (3.3× pixel count).
+- **New cybersecurity safeguards** — requests involving prohibited/high-risk topics may be refused. Legitimate security work goes through the Cyber Verification Program.
+
+**Relevance**: Direct impact on this workspace. Two immediate implications:
+1. **Audit existing prompts and skill templates** — any that depended on 4.6's judgment-filling may now under-perform on 4.7. In particular, mode-posture preservation (gstack #1065 lesson) becomes more critical under 4.7: literal following means a generic style rule collapses modes even more reliably than before.
+2. **Framework config** — our `framework_config.sh` model defaults shouldn't be edited per `feedback_model_detection.md`, but runtime detection should reflect 4.7 when the caller runs on it. We already use the 3-arg form to skip detection and pass exact model ID.
+3. **Session memory note** — Roland's memory already records `feedback_model_detection.md`; 4.7 doesn't invalidate that, but calls for a sweep of any docs that hardcoded `claude-opus-4-6`.
+
+---
 
 ## Command Runner Alternatives to Make
 
@@ -84,15 +104,16 @@ Key takeaways:
 
 ## Claude Code Agent Teams
 
-**Added**: 2026-02-27 | **Last verified**: 2026-02-27 | **Sources**: [Claude Code Agent Teams docs](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/agent-teams)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 | **Sources**: [Claude Code Agent Teams docs](https://code.claude.com/docs/en/agent-teams), [Claude Code Agent Teams: Setup & Usage Guide 2026](https://claudefa.st/blog/guide/agents/agent-teams), [Anthropic — Building a C compiler with parallel Claudes](https://www.anthropic.com/engineering/building-c-compiler), [Turing College guide](https://www.turingcollege.com/blog/claude-agent-teams-explained), [alexop.dev — From Tasks to Swarms](https://alexop.dev/posts/from-tasks-to-swarms-agent-teams-in-claude-code/)
 
 Key takeaways:
-- Multiple Claude Code instances coordinate as a team — leader spawns teammates, each gets its own context window, communication via mailbox
-- Coordination patterns: leader/swarm/pipeline/watchdog
-- Enable with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (still experimental)
-- Best suited for parallel work on separate packages where agents don't modify the same files
+- Shipped **alongside Opus 4.6** in February 2026. Still flagged as experimental but used for Anthropic's own production work (parallel Claudes built a C compiler, per their engineering blog).
+- **Enable**: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in env or `settings.json`.
+- **Architecture**: one Claude Code session acts as team lead; spawns independent teammates each with its own context window and tool access. Peer-to-peer communication via a **mailbox system** + shared task list (not purely lead-dispatched).
+- **Coordination patterns**: leader / swarm / pipeline / watchdog — orchestration style is prompt-selected, not a different runtime.
+- **Known limitations** (as of April 2026): session resumption, task coordination across longer horizons, shutdown behavior. Still rough around the edges.
 
-**Relevance**: The workspace's worktree infrastructure already provides the isolation layer Agent Teams assumes. Each teammate could work in its own worktree. Worth evaluating on non-critical multi-package features once stable.
+**Relevance**: The workspace's worktree infrastructure provides the isolation layer Agent Teams assumes. The feature maps well onto Roland's concerns about coordinating parallel agents BUT intersects with two session decisions: (1) D5 — we want coordinator-as-additive, not intermediated. Agent Teams is an intermediated model where the team lead dispatches. Evaluate only if teammate visibility is preserved (each teammate's terminal is watchable). (2) Permission prompts — teammates are separate sessions with separate tool trust, so permission-prompt load would grow with team size unless each teammate has tight allowlists.
 
 ---
 
@@ -221,17 +242,16 @@ Key takeaways:
 
 ## Agent Orchestrators for Parallel Coding Agents
 
-**Added**: 2026-03-11 | **Last verified**: 2026-03-11 | **Sources**: [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator), [jayminwest/overstory](https://github.com/jayminwest/overstory), [awesome-agent-orchestrators](https://gist.github.com/sujayjayjay/d0e88d5f53a5198c4ba5bb007a859bdd), [Shipyard blog](https://shipyard.build/blog/claude-code-multi-agent/), [ainativedev parallelizing agents](https://ainativedev.io/news/how-to-parallelize-ai-coding-agents)
+**Added**: 2026-03-11 | **Last verified**: 2026-04-19 | **Sources**: [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator), [Vibe Kanban](https://vibekanban.com/), [Superset orchestrator comparison](https://superset.sh/compare/best-ai-coding-agents-2026), [Visual Studio multi-agent in VS Code 1.109](https://visualstudiomagazine.com/articles/2026/02/09/hands-on-with-new-multi-agent-orchestration-in-vs-code.aspx), [Addy Osmani — The Code Agent Orchestra](https://addyosmani.com/blog/code-agent-orchestra/), [From Conductor to Orchestrator (2026 practical guide)](https://htdocs.dev/posts/from-conductor-to-orchestrator-a-practical-guide-to-multi-agent-coding-in-2026/), [CodeMachine-CLI (Apr 2026)](https://www.blog.brightcoding.dev/2026/04/14/codemachine-cli-the-revolutionary-ai-agent-orchestrator), [Catalyst & Code — 2026 orchestration frameworks](https://www.catalystandcode.com/blog/ai-agent-orchestration-frameworks)
 
 Key takeaways:
-- **Agent-orchestrator** (ComposioHQ, 4.1k stars, MIT): spawns parallel coding agents each in its own git worktree/branch/PR; pluggable adapters for runtime (tmux/Docker/K8s), agent (Claude Code/Codex/Aider), workspace (worktree/clone), tracker (GitHub/Linear), and notifier (desktop/Slack)
-- **Reaction system**: configurable auto-responses to CI failures (agent retries fix), review comments (agent addresses feedback), and approved PRs (notify or auto-merge) — the key differentiator over manual multi-agent setups
-- **Overstory**: similar concept with SQLite-backed inter-agent messaging, 4-tier conflict resolution, and a watchdog daemon; pluggable AgentRuntime interface for Claude Code, Pi, Gemini CLI
-- **Convergent patterns across all orchestrators**: (1) git worktree isolation per agent, (2) supervisor/coordinator that decomposes tasks, (3) event-driven reactions to CI/review, (4) dashboard for human oversight, (5) YAML-based configuration
-- **Ecosystem is exploding**: 9+ purpose-built orchestrators emerged in early 2026 (Vibe Kanban, Superset, Symphony, dmux, agtx, Ralph, GoClaw, plus the above) — all converge on worktree isolation as the fundamental primitive
-- The bottleneck has shifted from "can AI write code?" to "how do I run multiple agents in parallel without chaos?" — orchestration is the 2026 scaling lever
+- **The category consolidated but keeps expanding**: agent-orchestrator (ComposioHQ), Vibe Kanban, Superset, Capy, CodeMachine-CLI, and Overstory lead; VS Code 1.109 added native multi-agent orchestration in Feb 2026 (validating the category as mainstream).
+- **Three-tier pattern is now the standard framing** for 2026 developer workflows: Tier 1 interactive (Copilot/Cursor at the cursor), Tier 2 parallel sprints (Claude Code + multiple worktrees), Tier 3 overnight backlog drain (orchestrator + agents spawned by issue). Most developers will use all three.
+- **Convergent architecture** (unchanged from 2026-03-11): (1) git worktree isolation per agent, (2) supervisor/coordinator that decomposes tasks, (3) event-driven reactions to CI/review, (4) dashboard for human oversight, (5) YAML-based configuration.
+- **Agent-agnostic adapters are now table-stakes** — orchestrators target Claude Code, Codex, Aider, Cursor agents via the same surface. Runtime-agnostic (tmux/Docker/K8s) and tracker-agnostic (GitHub/Linear) likewise.
+- **"Code Agent Orchestra" / "Conductor to Orchestrator"** writeups (Osmani + others) frame the pattern as a distributed-systems design problem: constrain the agent space, design for failure, validate at boundaries.
 
-**Relevance**: This workspace already has the foundational primitives that all orchestrators build on: worktree isolation scripts, draft-PR visibility, workforce protocol, and multi-framework identity. The gaps relative to agent-orchestrator are: (1) **no reaction system** — CI failures and review comments require manual agent re-engagement; (2) **no dashboard** — `worktree_list.sh` shows status but lacks a unified view of agent progress, CI, and PRs; (3) **no automated task decomposition** — issues are manually assigned to agents; (4) **no inter-agent messaging** — agents can't coordinate or hand off work. Of these, a reaction system for CI failures and review feedback would deliver the most immediate value, since agents already create PRs but can't respond to CI/review events autonomously. See [#375](https://github.com/rolker/ros2_agent_workspace/issues/375).
+**Relevance**: This workspace already has the foundational primitives all orchestrators build on: worktree isolation, draft-PR visibility, workforce protocol, multi-framework identity. Gaps vs. agent-orchestrator still stand: (1) no reaction system for CI/review events, (2) no unified agent-status dashboard tuned to parallel operation, (3) no automated task decomposition, (4) no inter-agent messaging. Of these, the reaction system remains the most immediate value. The 2026-04-19 update: our rejection of "coordinator-intermediated" designs (session decision D5) means we'd want an orchestrator that is **additive**, not between us and our agents. Most 2026 orchestrators are intermediated — worth evaluating each carefully before adoption.
 
 ---
 


### PR DESCRIPTION
## Research Digest Refresh (2026-04-19)

Partial refresh: targeted re-surveys on high-movement topics, date bumps
on stable ones, three new entries.

### New topics

- **Claude Opus 4.7 — Behavioral Changes Since 4.6** — GA April 16 2026.
  Literal instruction following, new `xhigh` effort level, vision upgrade,
  reduced confident-wrong rate, cybersecurity safeguards. Direct impact on
  this workspace — any existing prompts that relied on 4.6's judgment-filling
  need audit
- **Permission Prompt Reduction Patterns** — built-in read-only allowlist,
  `/fewer-permission-prompts` skill, tilde-expansion gotcha. Feeds roadmap
  #110
- **Mode-Posture Preservation in Multi-Mode Skills** — paired-examples
  pattern from gstack #1065 applied to our #56 scope modes and #71
  brainstorm multi-level. Becomes more critical under 4.7's literal
  instruction-following

### Refreshed with new content

- **Agent Orchestrators for Parallel Coding Agents** — category consolidated
  but still expanding (VS Code 1.109 native multi-agent, Vibe Kanban,
  Superset, Capy, CodeMachine-CLI). Three-tier workflow pattern is now
  mainstream framing. Our D5 additive-only constraint means intermediated
  orchestrators don't fit without adaptation
- **Claude Code Agent Teams** — shipped alongside Opus 4.6, still experimental
  but used for Anthropic's own production (C compiler built with parallel
  Claudes). Mailbox + shared task list. Known limitations in session
  resumption/shutdown. Intermediated model intersects with D5
- **git-bug** — added ros2 #418 v0.10.1 syntax-drift lesson; still v0.10.1
  upstream, no new major release

### Date-bumped (content still accurate)

Command runner alternatives, AGENTS.md standard, AI agent spec writing,
harness engineering, multi-agent engineering patterns, MCP industry
standard, agentic coding market numbers, GitHub outage resilience, local
CI with act.

ROS 2 items marked "reference only — daddy_camp is non-ROS."
Lightweight self-hosted forges annotated with session D6 decline decision.

### New inspiration candidates surfaced during refresh

Not yet triaged into the registry — noted in digest for follow-up:
- Vibe Kanban (visual Kanban UI; may not fit CLI-first)
- Superset (orchestrator)
- Capy (orchestrator)
- CodeMachine-CLI (new April 2026 AI agent orchestrator)

### Workspace impact

Top-level `<!-- Last full refresh: 2026-04-19 -->` marker set.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
