### PR TITLE
Add agent-orchestrator + overstory to inspiration registry

### DIFF
--- a/.agent/knowledge/inspiration_registry.yml
+++ b/.agent/knowledge/inspiration_registry.yml
@@ -55,6 +55,39 @@ projects:
       - subagent patterns and orchestration
       - development methodology and workflows
 
+  agent-orchestrator:
+    type: inspiration
+    repo: ComposioHQ/agent-orchestrator
+    description: Reference open-source orchestrator for parallel coding agents
+    # Added 2026-04-19. Tracked despite our Tier 3 "Defer" decision —
+    # the patterns (reaction system, adapter architecture, worktree-per-
+    # agent discipline) inform how we'd adopt IF mechanical backlog
+    # pressure ever makes Tier 3 worthwhile. Also the reference point
+    # for the "additive-only" constraint (D5) — if they move toward less
+    # intermediated designs, revisit.
+    interest_areas:
+      - reaction system (CI failures, review comments, PR approvals)
+      - task decomposition patterns
+      - adapter architecture (runtime/agent/workspace/tracker/notifier pluggability)
+      - worktree-per-agent discipline (convergent with our own)
+      - dashboard model for multi-agent oversight
+
+  overstory:
+    type: inspiration
+    repo: jayminwest/overstory
+    description: Multi-agent orchestrator with SQLite-backed messaging and watchdog daemon
+    # Added 2026-04-19. Paired with agent-orchestrator to cover the
+    # category from two angles — agent-orchestrator is the big/reference
+    # implementation, Overstory explores different messaging tech
+    # (SQLite-backed mailbox) and conflict-resolution patterns. Of
+    # particular interest: watchdog daemon, which we're building
+    # separately as a small bash helper per Row 7 decision.
+    interest_areas:
+      - inter-agent messaging (SQLite-backed mailbox)
+      - conflict resolution (4-tier)
+      - watchdog daemon patterns
+      - multi-runtime agent support (Claude Code, Pi, Gemini CLI)
+
   # --- Archived sources (2026-04-19) ---
   #
   # The following entries were removed from active tracking after a signal-


### PR DESCRIPTION
## Inspiration Tracker: add agent-orchestrator + overstory

Two new orchestrator-category candidates added from today's research
refresh. Brings active registry from 3 to 5 sources.

### What's new

**`agent-orchestrator`** (ComposioHQ) — reference open-source
orchestrator for parallel coding agents. Agent-agnostic, runtime-
agnostic, tracker-agnostic. Interest areas focused on:
- Reaction system (CI failures, review comments, PR approvals)
- Task decomposition patterns
- Adapter architecture pluggability
- Worktree-per-agent discipline
- Dashboard model for multi-agent oversight

**`overstory`** (jayminwest) — paired with agent-orchestrator to cover
the category from two angles. Interest areas focused on:
- Inter-agent messaging (SQLite-backed mailbox)
- Conflict resolution (4-tier)
- Watchdog daemon patterns
- Multi-runtime agent support

### Why now

Per 2026-04-19 session Row 7 decision: we **declined** Agent Teams
(experimental Claude Code feature) and extracted its useful concepts
(swarm-of-personas, watchdog) into simpler tools we'll build ourselves.
But the broader orchestrator category is worth tracking — the patterns
evolve rapidly, and if daddy_camp's backlog shifts toward mechanical-
work density (Tier 3 trigger), we'd want to adopt informed.

Interest areas are curated to focus on what's DIFFERENT from existing
trackers (gstack for skills/review, superpowers for TDD/subagents,
ros2_agent_workspace for dashboard evolution) rather than re-covering
ground.

### What is NOT in this PR

- Initial digest surveys — those come on the first
  `/inspiration-tracker agent-orchestrator` and `/inspiration-tracker
  overstory` runs, not pre-created here
- Any roadmap changes — PR #157 (draft) captures the roadmap implications

### Deferred or declined alternatives

From the same research refresh:
- **Vibe Kanban** — skipped (web-UI model, counter to CLI-first)
- **Superset / Capy / CodeMachine-CLI** — watch only, too new
- **wshobson/agents** — watch only, plugin-architecture pattern not
  actively relevant to our skill approach

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
