### PR TITLE
docs: add engram to inspiration registry

### DIFF
--- a/.agent/knowledge/inspiration_registry.yml
+++ b/.agent/knowledge/inspiration_registry.yml
@@ -88,6 +88,24 @@ projects:
       - watchdog daemon patterns
       - multi-runtime agent support (Claude Code, Pi, Gemini CLI)
 
+  engram:
+    type: inspiration
+    repo: shiblon/engram
+    description: Memory and personality aid for Claude Code — stack-based short-term memory and dump/load portability
+    # Added 2026-04-26. Author's own framing emphasizes personality
+    # as a context-decay canary. Daddy_camp already has a working
+    # auto-memory setup (CLAUDE.md + per-project memory files);
+    # interest is in the patterns, not adopting the Go binary.
+    # Personality angle is exploratory — user is curious but no
+    # commitment to adopt.
+    interest_areas:
+      - stack-based short-term memory (push/pop for nested brainstorm contexts)
+      - personality as context-decay canary (drift signals full context window)
+      - multi-layer memory architecture (global vs project, seamless switching)
+      - tool-driven memory management (CLI vs file edits during conversation)
+      - memory dump/load for cross-machine portability
+      - bootstrap UX (single command sets up CLAUDE.md, hooks, gitignore)
+
   # --- Archived sources (2026-04-19) ---
   #
   # The following entries were removed from active tracking after a signal-


### PR DESCRIPTION
## Summary

Adds `shiblon/engram` to the inspiration registry as type=inspiration. Memory and personality aid for Claude Code with stack-based short-term memory, multi-layer architecture (global + project), tool-driven memory management, and dump/load portability for cross-machine identity.

## Why tracked

Daddy_camp's auto-memory setup is working but flat (no nested context handling). Engram's stack semantics for brainstorm-then-resume, personality-as-context-canary framing, and dump/load patterns are interesting *as design ideas* — no commitment to adopt the Go binary. User flagged personality angle as exploratory curiosity.

## Test plan

- [x] Pre-commit hooks pass (yamllint, line-length)
- [x] Registry remains valid YAML
- [x] Description and interest_areas are concise and specific

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
