### PR TITLE
Port quality-doctrine batch from ros2_agent_workspace (Quality Standard + plan-task + ADR-0008 + triage-reviews)

### DIFF
--- a/.agent/knowledge/principles_review_guide.md
+++ b/.agent/knowledge/principles_review_guide.md
@@ -31,6 +31,7 @@ humans use it as a checklist.
 | 0005 — Layered enforcement | Adding or modifying enforcement | CI/branch protection is authoritative; pre-commit provides local feedback; framework hooks provide early feedback |
 | 0006 — Shared AGENTS.md | Changing agent instructions | Shared rules in `AGENTS.md`; framework adapters are thin wrappers |
 | 0007 — Retain Make with Dependency Tracking | Changing the Makefile or proposing a different task runner | Keep Make; use stamp-file dependencies for incremental setup and build |
+| 0008 — Permit cross-reference addendums in ADRs | Editing an accepted ADR | Status-line notes pointing at related ADRs and References-section additions are permitted; substantive edits (Decision rewording, position reversal, Consequences changes) still require superseding |
 | 0009 — Python package management | Installing Python packages or modifying `.venv` | Use .venv for dev tools; never bare pip install |
 | 0010 — git-bug installed by default | Adding or modifying issue lookup scripts, bootstrap, or sync | git-bug installed by default; scripts use `_issue_helpers.sh` (git-bug first with sync-on-miss, fall back to `gh`); graceful degradation required |
 

--- a/.agent/work-plans/issue-164/plan.md
+++ b/.agent/work-plans/issue-164/plan.md
@@ -1,0 +1,75 @@
+# Plan: Port quality-doctrine batch from ros2_agent_workspace
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/164
+
+## Context
+
+Port four upstream items (ros2_agent_workspace @ `395b1c5`, range `8465ebd...395b1c5`) bundled as a coherent quality doctrine + enforcement pass:
+
+1. **AGENTS.md Quality Standard section** (upstream PR #438) — public-release framing
+2. **plan-task `## During implementation` section** (upstream PR #450) — `--no-pr` flag is already present locally (commit `680d895`); only port the new section
+3. **ADR-0012 cross-reference addendums** — generalize Context to drop upstream-specific PR #448 trigger
+4. **triage-reviews column rename + tightened wording** (upstream PR #441) — preserve local Step 7 (Update progress.md) and `issue-*/plan.md` path convention
+
+Per the review-issue comment: also update `.agent/knowledge/principles_review_guide.md` to add an ADR-0012 row (consequences-map requirement).
+
+Local files diverge from upstream (git-bug-first lookup in plan-task; local Guidelines bullets in triage-reviews) — port by merging, not overwriting.
+
+## Approach
+
+Implement as four atomic commits on `feature/issue-164`, then a final commit for the consequences-map update. Single PR.
+
+1. **Commit 1 — AGENTS.md Quality Standard** — Insert a new `## Quality Standard` section after `## Communication Standards` (line 76, before `## Tool Usage`). Replace upstream's "robot boats on open water" intro with a public-release framing. Adapt bullet 3 from "field fixes" to "code from outside the normal review path" (covers field imports, cherry-picks, copy-pastes, hurried agent commits).
+2. **Commit 2 — plan-task `## During implementation` section** — Append upstream's section verbatim after Step 9 (line 277), before `## Guidelines`. Do not touch `--no-pr` (already present from `680d895`). Use upstream's exact `## Implementation Notes` capitalization.
+3. **Commit 3 — ADR-0012** — Create `docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md`. Port upstream verbatim except the Context: drop the PR #448-specific trigger paragraph; reframe motivation around the inherited-ADRs discoverability gap (older ADRs lack forward links). Update References to point at agent_workspace ADRs only.
+4. **Commit 4 — triage-reviews tightening** — In `.claude/skills/triage-reviews/SKILL.md`: rename column `Reasoning` → `Justification` (line 172); change example wording `Why it's not applicable` → `Specific reason the failure mode cannot occur` (line 174); add upstream's "Justify every false positive" bullet to the Guidelines section (after the existing `Governance alignment` bullet) but **keep** local's `No GitHub review actions` and `Plan-first workflow PRs` bullets and the `issue-*/plan.md` path.
+5. **Commit 5 — consequences map update** — Add ADR-0012 row to the ADR Applicability table in `.agent/knowledge/principles_review_guide.md`.
+
+Run `make lint` (pre-commit) before opening PR. Verify final grep: no remaining "Reasoning" column header in triage-reviews; no upstream PR #448 reference in ADR-0012.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `AGENTS.md` | New `## Quality Standard` section between Communication Standards and Tool Usage (~12 lines) |
+| `.claude/skills/plan-task/SKILL.md` | Append `## During implementation` section (~35 lines) before `## Guidelines` |
+| `docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md` | New file (~80 lines), Context generalized for inherited-ADR setting |
+| `.claude/skills/triage-reviews/SKILL.md` | Column rename + wording tighten + new Guidelines bullet (preserve local extensions) |
+| `.agent/knowledge/principles_review_guide.md` | Add ADR-0012 row to ADR Applicability table |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Capture decisions, not just implementations | ADR-0012 is the recorded decision; Quality Standard codifies behavioral norms in AGENTS.md |
+| A change includes its consequences | Step 5 adds the ADR-0012 row to the review guide as part of this PR (not deferred) |
+| Workspace vs. project separation | All edits are workspace-generic; Quality Standard reframed away from upstream's robotics phrasing |
+| Improve incrementally | Atomic commits per item make selective revert and review tractable despite four-item bundle |
+| Enforcement over documentation | Item #1 (Quality Standard) is doctrine; item #4 (triage-reviews tightening) is its enforcement leg in the dismissal flow |
+| Only what's needed | Each item solves a concrete pain identified in the inspiration digest; no speculative additions |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0001 (Adopt ADRs) | Yes | New ADR-0012 follows Status / Context / Decision / Consequences / References structure |
+| ADR-0006 (Shared AGENTS.md) | Yes (low impact) | Verified pre-flight: framework adapters (`CLAUDE.md`, `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`) do not reference AGENTS.md section names by title — adding a new section requires no adapter edits. Re-confirm before merge |
+| ADR-0012 (this PR) | Yes — being added | Once accepted, permits the deferred ADR-0001/0002 status-line addendums (intentionally held for a follow-up PR) |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| An ADR in `docs/decisions/` | `principles_review_guide.md` ADR table | Yes — Step 5 |
+| `AGENTS.md` | Framework adapters if affected | No update needed (verified above) |
+| A framework skill (`.claude/skills/...`) | That framework's adapter file; regenerate skills if needed | No update needed (CLAUDE.md doesn't enumerate skills; not added to a workflow list) |
+
+## Open Questions
+
+- None blocking. The Context generalization for ADR-0012 is the only judgment call — propose draft text in the commit and let review iterate if the framing reads off.
+
+## Estimated Scope
+
+Single PR, 5 atomic commits, ~150 net lines added.

--- a/.agent/work-plans/issue-164/plan.md
+++ b/.agent/work-plans/issue-164/plan.md
@@ -10,10 +10,10 @@ Port four upstream items (ros2_agent_workspace @ `395b1c5`, range `8465ebd...395
 
 1. **AGENTS.md Quality Standard section** (upstream PR #438) — public-release framing
 2. **plan-task `## During implementation` section** (upstream PR #450) — `--no-pr` flag is already present locally (commit `680d895`); only port the new section
-3. **ADR-0012 cross-reference addendums** — generalize Context to drop upstream-specific PR #448 trigger
+3. **ADR-0008 cross-reference addendums** — port upstream's ADR-0012 content under the next-available local sequential number (per ADR-0001's "numbered sequentially" rule); generalize Context to drop upstream-specific PR #448 trigger
 4. **triage-reviews column rename + tightened wording** (upstream PR #441) — preserve local Step 7 (Update progress.md) and `issue-*/plan.md` path convention
 
-Per the review-issue comment: also update `.agent/knowledge/principles_review_guide.md` to add an ADR-0012 row (consequences-map requirement).
+Per the review-issue comment: also update `.agent/knowledge/principles_review_guide.md` to add an ADR-0008 row (consequences-map requirement).
 
 Local files diverge from upstream (git-bug-first lookup in plan-task; local Guidelines bullets in triage-reviews) — port by merging, not overwriting.
 
@@ -21,13 +21,13 @@ Local files diverge from upstream (git-bug-first lookup in plan-task; local Guid
 
 Implement as four atomic commits on `feature/issue-164`, then a final commit for the consequences-map update. Single PR.
 
-1. **Commit 1 — AGENTS.md Quality Standard** — Insert a new `## Quality Standard` section after `## Communication Standards` (line 76, before `## Tool Usage`). Replace upstream's "robot boats on open water" intro with a public-release framing. Adapt bullet 3 from "field fixes" to "code from outside the normal review path" (covers field imports, cherry-picks, copy-pastes, hurried agent commits).
-2. **Commit 2 — plan-task `## During implementation` section** — Append upstream's section verbatim after Step 9 (line 277), before `## Guidelines`. Do not touch `--no-pr` (already present from `680d895`). Use upstream's exact `## Implementation Notes` capitalization.
-3. **Commit 3 — ADR-0012** — Create `docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md`. Port upstream verbatim except the Context: drop the PR #448-specific trigger paragraph; reframe motivation around the inherited-ADRs discoverability gap (older ADRs lack forward links). Update References to point at agent_workspace ADRs only.
-4. **Commit 4 — triage-reviews tightening** — In `.claude/skills/triage-reviews/SKILL.md`: rename column `Reasoning` → `Justification` (line 172); change example wording `Why it's not applicable` → `Specific reason the failure mode cannot occur` (line 174); add upstream's "Justify every false positive" bullet to the Guidelines section (after the existing `Governance alignment` bullet) but **keep** local's `No GitHub review actions` and `Plan-first workflow PRs` bullets and the `issue-*/plan.md` path.
-5. **Commit 5 — consequences map update** — Add ADR-0012 row to the ADR Applicability table in `.agent/knowledge/principles_review_guide.md`.
+1. **Commit 1 — AGENTS.md Quality Standard** — Insert a new `## Quality Standard` section after `## Communication Standards`, before `## Tool Usage`. Replace upstream's "robot boats on open water" intro with a public-release framing. Adapt bullet 3 from "field fixes" to "code from outside the normal review path" (covers field imports, cherry-picks, copy-pastes, hurried agent commits).
+2. **Commit 2 — plan-task `## During implementation` section** — Append upstream's section after Step 9, before `## Guidelines`. Do not touch `--no-pr` (already present from `680d895`). Use upstream's exact `## Implementation Notes` capitalization. Adapt path references to local `issue-*/plan.md` convention (upstream uses `PLAN_ISSUE-*.md`).
+3. **Commit 3 — ADR-0008** — Create `docs/decisions/0008-permit-cross-reference-addendums-in-adrs.md` (next available sequential number; ADR-0001 mandates sequential numbering). Port upstream's ADR-0012 content except the Context: drop the PR #448-specific trigger paragraph; reframe motivation around the inherited-ADRs discoverability gap (older ADRs lack forward links). Update References to point at agent_workspace ADRs only. Internal cross-references (`ADR-0011`) update to existing local ADRs that illustrate the same scoped-exception pattern, or are kept generic.
+4. **Commit 4 — triage-reviews tightening** — In `.claude/skills/triage-reviews/SKILL.md`: rename column `Reasoning` → `Justification`; change example wording `Why it's not applicable` → `Specific reason the failure mode cannot occur`; add upstream's "Justify every false positive" bullet to the Guidelines section (after the existing `Governance alignment` bullet) but **keep** local's `No GitHub review actions` and `Plan-first workflow PRs` bullets and the `issue-*/plan.md` path.
+5. **Commit 5 — consequences map update** — Add ADR-0008 row to the ADR Applicability table in `.agent/knowledge/principles_review_guide.md`.
 
-Run `make lint` (pre-commit) before opening PR. Verify final grep: no remaining "Reasoning" column header in triage-reviews; no upstream PR #448 reference in ADR-0012.
+Run `make lint` (pre-commit) before pushing. Verify final grep: no remaining "Reasoning" column header in triage-reviews; no upstream PR #448 reference in ADR-0008.
 
 ## Files to Change
 
@@ -35,9 +35,9 @@ Run `make lint` (pre-commit) before opening PR. Verify final grep: no remaining 
 |------|--------|
 | `AGENTS.md` | New `## Quality Standard` section between Communication Standards and Tool Usage (~12 lines) |
 | `.claude/skills/plan-task/SKILL.md` | Append `## During implementation` section (~35 lines) before `## Guidelines` |
-| `docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md` | New file (~80 lines), Context generalized for inherited-ADR setting |
+| `docs/decisions/0008-permit-cross-reference-addendums-in-adrs.md` | New file (~80 lines), Context generalized for inherited-ADR setting |
 | `.claude/skills/triage-reviews/SKILL.md` | Column rename + wording tighten + new Guidelines bullet (preserve local extensions) |
-| `.agent/knowledge/principles_review_guide.md` | Add ADR-0012 row to ADR Applicability table |
+| `.agent/knowledge/principles_review_guide.md` | Add ADR-0008 row to ADR Applicability table |
 
 ## Principles Self-Check
 
@@ -54,9 +54,9 @@ Run `make lint` (pre-commit) before opening PR. Verify final grep: no remaining 
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| ADR-0001 (Adopt ADRs) | Yes | New ADR-0012 follows Status / Context / Decision / Consequences / References structure |
+| ADR-0001 (Adopt ADRs) | Yes | New ADR-0008 follows Status / Context / Decision / Consequences / References structure; numbering is sequential per ADR-0001's "numbered sequentially (0001, 0002, ...)" rule (ADR-0008 is the next available local number; the missing 0008 slot in `docs/decisions/` is filled rather than skipped) |
 | ADR-0006 (Shared AGENTS.md) | Yes (low impact) | Verified pre-flight: framework adapters (`CLAUDE.md`, `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`) do not reference AGENTS.md section names by title — adding a new section requires no adapter edits. Re-confirm before merge |
-| ADR-0012 (this PR) | Yes — being added | Once accepted, permits the deferred ADR-0001/0002 status-line addendums (intentionally held for a follow-up PR) |
+| ADR-0008 (this PR) | Yes — being added | Once accepted, permits the deferred ADR-0001/0002 status-line addendums (intentionally held for a follow-up PR) |
 
 ## Consequences
 

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -2,7 +2,7 @@
 issue: 164
 ---
 
-# Issue #164 — Port quality-doctrine batch from ros2_agent_workspace (Quality Standard + plan-task + ADR-0012 + triage-reviews)
+# Issue #164 — Port quality-doctrine batch from ros2_agent_workspace (Quality Standard + plan-task + ADR-0008 + triage-reviews)
 
 ## Plan
 **Status**: complete
@@ -11,4 +11,11 @@ issue: 164
 
 Plan file: `.agent/work-plans/issue-164/plan.md`.
 
-Five atomic commits porting four upstream items (AGENTS.md Quality Standard, plan-task `## During implementation` section, ADR-0012, triage-reviews column rename + wording) plus a consequences-map row for ADR-0012. `--no-pr` flag in plan-task is already local; only the new section is ported. Local triage-reviews extensions (Step 7 progress.md, `issue-*/plan.md` path, `No GitHub review actions` bullet) are preserved.
+Five atomic commits porting four upstream items (AGENTS.md Quality Standard, plan-task `## During implementation` section, ADR-0008, triage-reviews column rename + wording) plus a consequences-map row for ADR-0008. `--no-pr` flag in plan-task is already local; only the new section is ported. Local triage-reviews extensions (Step 7 progress.md, `issue-*/plan.md` path, `No GitHub review actions` bullet) are preserved.
+
+## Plan revision (review-plan finding)
+**Status**: complete
+**When**: 2026-04-26 13:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Renumbered the new ADR from 0012 → 0008 to comply with ADR-0001's "numbered sequentially" rule. The previously-empty 0008 slot in `docs/decisions/` is now filled. Plan and review references updated.

--- a/.agent/work-plans/issue-164/progress.md
+++ b/.agent/work-plans/issue-164/progress.md
@@ -1,0 +1,14 @@
+---
+issue: 164
+---
+
+# Issue #164 — Port quality-doctrine batch from ros2_agent_workspace (Quality Standard + plan-task + ADR-0012 + triage-reviews)
+
+## Plan
+**Status**: complete
+**When**: 2026-04-26 12:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Plan file: `.agent/work-plans/issue-164/plan.md`.
+
+Five atomic commits porting four upstream items (AGENTS.md Quality Standard, plan-task `## During implementation` section, ADR-0012, triage-reviews column rename + wording) plus a consequences-map row for ADR-0012. `--no-pr` flag in plan-task is already local; only the new section is ported. Local triage-reviews extensions (Step 7 progress.md, `issue-*/plan.md` path, `No GitHub review actions` bullet) are preserved.

--- a/.claude/skills/plan-task/SKILL.md
+++ b/.claude/skills/plan-task/SKILL.md
@@ -275,6 +275,57 @@ Summarize:
 - Which principles and ADRs were considered
 - Any open questions that need input
 - Link to the draft PR (or note that PR creation was skipped)
+- Pointer to the "During implementation" section below, so the
+  implementer knows to keep the plan in sync with landed code
+
+## During implementation
+
+The `plan-task` skill's primary artifact is the committed plan file
+created in steps 5–6; step 8 publishes that plan into a draft PR.
+Implementation then proceeds on the same branch — and typically deviates
+from the plan: types get refined, functions change signatures, a "pure
+logic" module picks up a dependency. Keep the plan in sync as this
+happens so the file stays usable reference material — for Copilot's
+plan-file review, for `review-code`, and for the next agent who picks
+up the work.
+
+1. **Inline edits are the default.** When implementation diverges from the
+   plan in any way — wording, method names, file paths, dependency
+   choices, a test contract that tightened during coding — edit the plan
+   inline to match the landed code. Git history preserves the original
+   planning state; nobody benefits from stale text at the top of an
+   otherwise-current plan.
+
+2. **Appended "Implementation Notes" only for rationale-bearing design
+   pivots.** If the deviation is a real design decision whose *why* is
+   not obvious from the code diff alone (e.g. "switched from `QGridLayout`
+   to a custom layout because `QGridLayout` can't express slack-to-outside
+   with shared inner edges"), make the inline edit *and* add a one-liner
+   to an `## Implementation Notes` section at the bottom of the plan
+   capturing the rationale. The section is for rationale only, not a
+   changelog.
+
+3. **Never append-only.** Leaving stale text at the top of the plan while
+   listing "changes" in a section below misleads Copilot, human reviewers,
+   and future onboarding agents — all of whom read the top first.
+
+4. **Commit discipline.** Plan edits flow in commits alongside the code
+   changes that triggered them (same commit when caught while coding;
+   follow-up commit if caught later during review triage). Never amend a
+   pushed commit just to update the plan.
+
+This guidance is enforced at the instructions layer only. There is no
+local hook for "did you update the plan"; the enforcement signal is
+review feedback — Copilot's plan-drift flags and `review-code` catching
+misalignment between the plan and the PR. If drift becomes a recurring
+finding across multiple PRs, that's a signal the rule needs more teeth,
+not that the rule is wrong.
+
+The plan path under this rule is `.agent/work-plans/issue-<N>/plan.md`
+(the local convention; upstream uses `PLAN_ISSUE-<N>.md`). `review-plan`
+already supports `--issue` / file-path forms, so it reads the live plan
+file rather than the snapshotted PR body — inline plan edits stay
+visible to plan review without further wiring.
 
 ## Guidelines
 

--- a/.claude/skills/triage-reviews/SKILL.md
+++ b/.claude/skills/triage-reviews/SKILL.md
@@ -169,9 +169,9 @@ Output a structured report:
 
 ### False Positives (Bot)
 
-| # | Source | File | Line | Comment | Reasoning |
-|---|--------|------|------|---------|-----------|
-| 1 | Copilot | `path/to/file` | 10 | What the bot said | Why it's not applicable |
+| # | Source | File | Line | Comment | Justification |
+|---|--------|------|------|---------|---------------|
+| 1 | Copilot | `path/to/file` | 10 | What the bot said | Specific reason the failure mode cannot occur |
 
 ### Recommended Actions
 
@@ -250,6 +250,15 @@ current working directory):
   issue, group them in the valid issues table.
 - **Governance alignment** — note when a comment aligns with or contradicts
   workspace principles or ADRs.
+- **Justify every false positive** — every "false positive" classification must
+  include a specific reason the failure mode cannot occur in this system. Blanket
+  dismissals are not sufficient:
+  - "Config is under our control" — explain what prevents misconfiguration in the field
+  - "Pathological input" — explain why that input genuinely cannot reach this code path
+  - "Nice-to-have" / "low priority" — not valid justifications; if the concern is
+    about error handling, stale data, or silent failures, classify as Valid unless
+    you can prove the failure mode is impossible
+  - If you cannot articulate why it's safe, classify as Valid and suggest the fix
 - **No GitHub review actions** — this skill does not post review comments,
   dismiss reviews, or modify the PR on GitHub. The only side-effect is
   appending to progress.md and committing it (step 7).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,27 @@ code being changed:
 - Push back when something seems wrong rather than agreeing too readily
 - Lead with the answer or action, not the reasoning
 
+## Quality Standard
+
+This project is bound for public release. Players will see what we ship; bugs,
+half-fixes, and silent failures degrade trust in the product. The marginal cost
+of completeness is near zero with AI — do the whole thing, do it right, do it
+with tests.
+
+- When fixing a bug, fix it completely: add the test, handle the edge case, check
+  the state transition. Never leave a "good enough" fix when the proper one is
+  within reach.
+- When triaging reviews, do not dismiss concerns about error handling, silent
+  failures, stale data, or missing validation as "nits" unless the failure mode
+  genuinely cannot occur. Speculative or vague "won't happen in practice" is not
+  a dismissal.
+- Code that arrives from outside the normal review path is a draft — field
+  imports, cherry-picks, copy-pastes, hurried agent commits merged without
+  review. Add tests, verify external identifiers and contracts, check for
+  idempotency before treating it as landed.
+- Never offer to "table this for later" when the permanent solve is five minutes
+  away. Never present a workaround when the real fix exists.
+
 ## Tool Usage
 
 - **Prefer dedicated tools over shell equivalents** — When your framework

--- a/docs/decisions/0008-permit-cross-reference-addendums-in-adrs.md
+++ b/docs/decisions/0008-permit-cross-reference-addendums-in-adrs.md
@@ -1,0 +1,92 @@
+# ADR-0008: Permit Cross-Reference Addendums in Accepted ADRs
+
+## Status
+
+Accepted. Narrows the immutability rule from
+[ADR-0001](0001-adopt-architecture-decision-records.md).
+
+## Context
+
+[ADR-0001](0001-adopt-architecture-decision-records.md) established that
+*"ADRs are immutable once accepted — supersede rather than edit"*. The
+intent of that rule is sound: substantive edits to accepted ADRs
+(rewording the Decision, reversing position, changing Consequences) can
+silently reverse settled decisions and undermine the "check
+`docs/decisions/` before proposing changes" discoverability the practice
+depends on.
+
+But a strict read of "immutable" also blocks a useful, low-risk class of
+edit: **cross-reference addendums** — pointers from one ADR to another
+that was written later. Specifically:
+
+- A Status-line note like *"Scoped exception in ADR-N permits ..."*
+  on an older ADR, making the relationship discoverable from the older
+  ADR.
+- A References section at the end of an ADR listing related ADRs (earlier
+  or later) that inform or qualify it.
+
+These additions are purely navigational. They don't restate, reword, or
+reverse the original Decision — they point at additional decisions the
+reader should know about. Without them, relationships between ADRs are
+only visible when reading the newer ADR, not the older one.
+
+This workspace inherited its `docs/decisions/` set from
+`ros2_agent_workspace`, where ADRs accumulated incrementally over many
+issues. Older ADRs predate later ADRs that scope, qualify, or partially
+supersede them, and have no forward links. Without a permitted-addendum
+rule, the only options are (a) leave older ADRs without forward
+references, hurting discoverability, or (b) supersede an ADR purely to
+add a navigational pointer, inflating the supersede mechanism.
+
+## Decision
+
+Narrow ADR-0001's immutability rule: cross-reference addendums to
+accepted ADRs are permitted; substantive changes still require
+superseding.
+
+### Permitted (cross-reference addendums)
+
+- Updating the **Status** line to note a related ADR (e.g. *"Scoped
+  exception in ADR-N…"*)
+- Adding or appending to a **References** section listing related ADRs
+- Fixing broken links, typos in metadata, or formatting nits that don't
+  change meaning
+
+### Still requires a new/superseding ADR (substantive changes)
+
+- Rewording the **Decision** section
+- Reversing or softening the position
+- Adding or removing **Consequences** that weren't previously recorded
+- Anything a reader could mistake for "this ADR now says something
+  different"
+
+### How to tell the difference
+
+Ask: *if someone reads only the edited ADR without knowing about the
+change, will they get a misleading picture of what was originally
+decided?* If yes → supersede. If no → addendum is fine.
+
+## Consequences
+
+**Positive:**
+- Relationships between ADRs are discoverable from both directions —
+  forward (newer ADR references older) and backward (older ADR notes
+  newer).
+- Keeps the supersede mechanism for what it's designed for: substantive
+  change. Navigation isn't change.
+- Self-bootstrapping: the one-line Status update to ADR-0001 that
+  records this narrowing (*"narrowed by ADR-0008"*) is itself the first
+  addendum permitted under this rule.
+
+**Negative:**
+- Slippery-slope risk — if the "cross-reference" category expands
+  gradually, substantive edits could sneak in under the label. The "how
+  to tell" test above is the guardrail.
+- One more thing for ADR authors to think about when touching existing
+  ADRs. Mitigated by the rule-of-thumb being quick to apply.
+
+## References
+
+- [ADR-0001](0001-adopt-architecture-decision-records.md) — Adopt
+  Architecture Decision Records (this ADR narrows ADR-0001's
+  immutability rule)


### PR DESCRIPTION
Closes #164

# Plan: Port quality-doctrine batch from ros2_agent_workspace

## Issue

https://github.com/rolker/agent_workspace/issues/164

## Context

Port four upstream items (ros2_agent_workspace @ `395b1c5`, range `8465ebd...395b1c5`) bundled as a coherent quality doctrine + enforcement pass:

1. **AGENTS.md Quality Standard section** (upstream PR #438) — public-release framing
2. **plan-task `## During implementation` section** (upstream PR #450) — `--no-pr` flag is already present locally (commit `680d895`); only port the new section
3. **ADR-0012 cross-reference addendums** — generalize Context to drop upstream-specific PR #448 trigger
4. **triage-reviews column rename + tightened wording** (upstream PR #441) — preserve local Step 7 (Update progress.md) and `issue-*/plan.md` path convention

Per the review-issue comment: also update `.agent/knowledge/principles_review_guide.md` to add an ADR-0012 row (consequences-map requirement).

Local files diverge from upstream (git-bug-first lookup in plan-task; local Guidelines bullets in triage-reviews) — port by merging, not overwriting.

## Approach

Implement as four atomic commits on `feature/issue-164`, then a final commit for the consequences-map update. Single PR.

1. **Commit 1 — AGENTS.md Quality Standard** — Insert a new `## Quality Standard` section after `## Communication Standards` (line 76, before `## Tool Usage`). Replace upstream's "robot boats on open water" intro with a public-release framing. Adapt bullet 3 from "field fixes" to "code from outside the normal review path" (covers field imports, cherry-picks, copy-pastes, hurried agent commits).
2. **Commit 2 — plan-task `## During implementation` section** — Append upstream's section verbatim after Step 9 (line 277), before `## Guidelines`. Do not touch `--no-pr` (already present from `680d895`). Use upstream's exact `## Implementation Notes` capitalization.
3. **Commit 3 — ADR-0012** — Create `docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md`. Port upstream verbatim except the Context: drop the PR #448-specific trigger paragraph; reframe motivation around the inherited-ADRs discoverability gap (older ADRs lack forward links). Update References to point at agent_workspace ADRs only.
4. **Commit 4 — triage-reviews tightening** — In `.claude/skills/triage-reviews/SKILL.md`: rename column `Reasoning` → `Justification` (line 172); change example wording `Why it's not applicable` → `Specific reason the failure mode cannot occur` (line 174); add upstream's "Justify every false positive" bullet to the Guidelines section (after the existing `Governance alignment` bullet) but **keep** local's `No GitHub review actions` and `Plan-first workflow PRs` bullets and the `issue-*/plan.md` path.
5. **Commit 5 — consequences map update** — Add ADR-0012 row to the ADR Applicability table in `.agent/knowledge/principles_review_guide.md`.

Run `make lint` (pre-commit) before opening PR. Verify final grep: no remaining "Reasoning" column header in triage-reviews; no upstream PR #448 reference in ADR-0012.

## Files to Change

| File | Change |
|------|--------|
| `AGENTS.md` | New `## Quality Standard` section between Communication Standards and Tool Usage (~12 lines) |
| `.claude/skills/plan-task/SKILL.md` | Append `## During implementation` section (~35 lines) before `## Guidelines` |
| `docs/decisions/0012-permit-cross-reference-addendums-in-adrs.md` | New file (~80 lines), Context generalized for inherited-ADR setting |
| `.claude/skills/triage-reviews/SKILL.md` | Column rename + wording tighten + new Guidelines bullet (preserve local extensions) |
| `.agent/knowledge/principles_review_guide.md` | Add ADR-0012 row to ADR Applicability table |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Capture decisions, not just implementations | ADR-0012 is the recorded decision; Quality Standard codifies behavioral norms in AGENTS.md |
| A change includes its consequences | Step 5 adds the ADR-0012 row to the review guide as part of this PR (not deferred) |
| Workspace vs. project separation | All edits are workspace-generic; Quality Standard reframed away from upstream's robotics phrasing |
| Improve incrementally | Atomic commits per item make selective revert and review tractable despite four-item bundle |
| Enforcement over documentation | Item #1 (Quality Standard) is doctrine; item #4 (triage-reviews tightening) is its enforcement leg in the dismissal flow |
| Only what's needed | Each item solves a concrete pain identified in the inspiration digest; no speculative additions |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0001 (Adopt ADRs) | Yes | New ADR-0012 follows Status / Context / Decision / Consequences / References structure |
| ADR-0006 (Shared AGENTS.md) | Yes (low impact) | Verified pre-flight: framework adapters (`CLAUDE.md`, `.github/copilot-instructions.md`, `.agent/instructions/gemini-cli.instructions.md`) do not reference AGENTS.md section names by title — adding a new section requires no adapter edits. Re-confirm before merge |
| ADR-0012 (this PR) | Yes — being added | Once accepted, permits the deferred ADR-0001/0002 status-line addendums (intentionally held for a follow-up PR) |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| An ADR in `docs/decisions/` | `principles_review_guide.md` ADR table | Yes — Step 5 |
| `AGENTS.md` | Framework adapters if affected | No update needed (verified above) |
| A framework skill (`.claude/skills/...`) | That framework's adapter file; regenerate skills if needed | No update needed (CLAUDE.md doesn't enumerate skills; not added to a workflow list) |

## Open Questions

- None blocking. The Context generalization for ADR-0012 is the only judgment call — propose draft text in the commit and let review iterate if the framing reads off.

## Estimated Scope

Single PR, 5 atomic commits, ~150 net lines added.


---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
