### PR TITLE
feat: adopt 1h prompt cache + tighten settings.json permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "ENABLE_PROMPT_CACHING_1H": "1"
+  },
   "permissions": {
     "allow": [
       "Bash(ls *)",
@@ -25,9 +28,9 @@
       "Bash(git remote show *)",
       "Bash(git remote get-url *)",
       "Bash(git fetch *)",
-      "Bash(git fetch)",
       "Bash(git pull --ff-only *)",
       "Bash(git pull --ff-only)",
+      "Bash(git add *)",
       "Bash(git rev-parse *)",
 
       "Bash(gh issue view *)",
@@ -47,10 +50,16 @@
       "Bash(source .agent/scripts/set_git_identity_env.sh *)",
       "Bash(.agent/scripts/worktree_list.sh *)",
       "Bash(.agent/scripts/worktree_list.sh)",
+      "Bash(*/.agent/scripts/worktree_list.sh *)",
       "Bash(.agent/scripts/dashboard.sh *)",
       "Bash(.agent/scripts/dashboard.sh)",
       "Bash(.agent/scripts/fetch_pr_reviews.sh *)",
+      "Bash(*/.agent/scripts/fetch_pr_reviews.sh *)",
       "Bash(.agent/scripts/worktree_create.sh *)",
+      "Bash(.agent/scripts/worktree_remove.sh *)",
+      "Bash(bash .agent/scripts/tests/*)",
+      "Bash(bash -n *)",
+      "Bash(*/.venv/bin/shellcheck *)",
 
       "Bash(make dashboard *)",
       "Bash(make dashboard)",
@@ -67,25 +76,20 @@
       "Bash(shellcheck *)",
       "Bash(git-bug version *)",
       "Bash(git-bug version)",
-      "Bash(git-bug bug ls *)",
-      "Bash(git-bug bug ls)",
-      "Bash(git-bug bug show *)",
-      "Bash(git-bug user ls *)",
-      "Bash(git-bug user ls)",
-      "Bash(git-bug bridge list *)",
-      "Bash(git-bug bridge list)",
+      "Bash(git-bug bug *)",
+      "Bash(git-bug bug)",
+      "Bash(git-bug bridge *)",
+      "Bash(git-bug user *)",
       "Bash(git-bug --help *)",
       "Bash(git-bug --help)"
     ],
     "deny": [
       "Bash(git push --force *)",
       "Bash(git push -f *)",
-      "Bash(git push --force-with-lease *)",
       "Bash(git reset --hard *)",
       "Bash(git checkout -- *)",
       "Bash(git clean *)",
-      "Bash(rm -rf *)",
-      "Bash(rm -r *)"
+      "Bash(rm -rf *)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

- Adopt the 1h prompt caching env var (`ENABLE_PROMPT_CACHING_1H=1`) per the ROADMAP "Challenge Existing Solutions" Adopt decision.
- Reduce permission prompts by adding/consolidating safe allowlist entries (matches #110's direction without expanding its scope).
- Soften two deny rules so they prompt rather than auto-block.

These changes had accumulated as uncommitted state in the workspace tree; this PR is the proper landing.

## Detail

### Permission additions
- `git add *`
- Worktree-absolute-path forms: `*/.agent/scripts/worktree_list.sh *`, `*/.agent/scripts/fetch_pr_reviews.sh *`, `*/.venv/bin/shellcheck *`
- `.agent/scripts/worktree_remove.sh *`
- `bash .agent/scripts/tests/*` (script test runner)
- `bash -n *` (shell syntax check)

### Permission consolidations
- `git-bug bug ls/show` + `git-bug user ls` + `git-bug bridge list` → broader `git-bug bug *`, `git-bug bridge *`, `git-bug user *`
- Removed redundant bare `git fetch` (covered by `git fetch *`)

### Deny softening — please review
| Rule | Before | After | Rationale |
|------|--------|-------|-----------|
| `git push --force-with-lease *` | Auto-denied | Prompts | force-with-lease refuses if remote moved — safe form, worth allowing case-by-case. |
| `rm -r *` | Auto-denied | Prompts | Routine cleanup. `rm -rf *` remains denied. |

## Test plan
- [ ] Verify pre-commit hook passes (✓ done at commit time)
- [ ] Confirm `ENABLE_PROMPT_CACHING_1H=1` takes effect on next session start
- [ ] Spot-check that the new allowlist entries match actual command shapes used in recent sessions

Closes #170

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
