### PR TITLE
gitignore: exclude .claude/scheduled_tasks.lock (#174)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ worktrees/
 # Generated Claude Code skills (regenerate with: make generate-skills)
 .claude/skills/make_*/
 
+# Claude Code runtime lock (created by ScheduleWakeup; ephemeral, never committed)
+.claude/scheduled_tasks.lock
+
 # Agent Scratchpad (Temporary files and artifacts)
 .agent/scratchpad/*
 !.agent/scratchpad/README.md


### PR DESCRIPTION
## Summary

- Adds `.claude/scheduled_tasks.lock` to `.gitignore`. The file is created by Claude Code's `ScheduleWakeup` runtime, has no human-authored content, and is regenerated freely.
- Without ignoring it, `make sync` reports the workspace as dirty and skips the pull on the workspace repo, even when the only "uncommitted change" is this runtime artifact.

Closes #174.

## Test plan

- [x] `make sync` no longer skips the workspace when the lock file is present (verify locally after merge).

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
