### PR TITLE
Update inspiration digest: engram (2026-05-07)

### DIFF
--- a/.agent/knowledge/inspiration_engram_digest.md
+++ b/.agent/knowledge/inspiration_engram_digest.md
@@ -1,8 +1,8 @@
 # Inspiration Digest: engram
 
 Type: inspiration
-Last checked: 2026-04-26 (first run)
-Repo: shiblon/engram @ a4c577c25872c74567343faa55b93c7c7b43c8df
+Last checked: 2026-05-07
+Repo: shiblon/engram @ 125f1d4 (was a4c577c on 2026-04-26)
 
 ## Survey Summary
 
@@ -121,17 +121,51 @@ a known footgun.
 | Memory dump/load for portability | `engram mem dump` / `mem load` to/from markdown. | We get this implicitly via git-checked memory directory. |
 | Bootstrap UX | Single command sets up CLAUDE.md, hooks, gitignore, global invariants. | Compelling pattern but irrelevant unless we adopt the binary. |
 
+## Changelog Since Last Check (2026-04-26 → 2026-05-07)
+
+9 commits, 16 files (a4c577c..125f1d4). Single contributor still; still no
+issues or PRs — author works on `main` directly.
+
+### Major additions
+
+- **MCP server** (commit c9957b8) — new `engram mcp` subcommand serves engram
+  over MCP stdio. Exposes resources `engram://inject` (session context:
+  identity, preferences, memories, recent activity) and `engram://agentinfo`
+  (workflow instructions). Lets non-Claude-Code agents (Cursor, Gemini,
+  Copilot, AntiGravity) integrate via MCP rather than hooks.
+- **`agentinfo` command** (commit 1123d25) — prints canonical "how to use
+  engram" prose for embedding via `>> CLAUDE.md` or `@<path>` reference.
+  Pattern: tool-as-source-of-truth for agent instructions instead of
+  hand-edited copies in each adapter file.
+- **DB migration system** (commit 7d3e9b1) — `engram migrate` plus internal
+  `pkg/engram/migrate.go`. Schema-evolution support for installed DBs.
+- **Multi-platform bootstrap** (commits 5d89e67, b33fc9a, fec2d69) —
+  `engram bootstrap <claude|gemini|antigravity|copilot|cursor>`. Cursor
+  newly added. Claude gets full hook support; others use system prompt
+  injection. Bootstrap also extended for `go install`-based distribution.
+- **CLAUDE.md @file inclusion** (commit a3b9d9d) — bootstrap now writes
+  `@<path>` reference into CLAUDE.md instead of inlining `agentinfo` text.
+  Daddy_camp already uses this pattern for `@AGENTS.md`.
+- **`promote` → `move`** (commit b33fc9a) — internal CLI rename.
+- **Refined global vs project instructions** (commit 125f1d4).
+
+### What did NOT change
+
+- Memory tier model (invariant / preference / long / short).
+- Personality canary mechanism (codename in invariant + status-line).
+- Hook-based file-activity tracking (PostToolUse → record).
+- Architectural footprint: still ~10-15 Go files, single author, no tests.
+
 ## Activity Snapshot
 
-- **No issues, no PRs.** Author works on `main` directly.
-- **27 commits total** since project inception (recent: bootstrap polish,
-  CLI ergonomics, README tightening, GoReleaser fixes).
-- Activity reads as personal-project iteration, not a maintained library.
-- Single contributor (`shiblon` aka Chris Monson).
+- **No issues, no PRs.** Author still works on `main` directly.
+- **36 commits total** (was 27 at last check; +9 in 11 days).
+- Direction: consolidation toward multi-agent platform support via MCP +
+  agentinfo, plus migration infrastructure for in-the-wild DBs.
 
-## Pending Review
+## Pending Review (2026-05-07)
 
-(none — all items triaged below)
+(triaged inline below)
 
 ## Issued
 

--- a/.agent/knowledge/inspiration_engram_digest.md
+++ b/.agent/knowledge/inspiration_engram_digest.md
@@ -163,9 +163,9 @@ issues or PRs — author works on `main` directly.
 - Direction: consolidation toward multi-agent platform support via MCP +
   agentinfo, plus migration infrastructure for in-the-wild DBs.
 
-## Pending Review (2026-05-07)
+## Pending Review
 
-(triaged inline below)
+(none — all 2026-05-07 items triaged below)
 
 ## Issued
 
@@ -176,7 +176,9 @@ issues or PRs — author works on `main` directly.
   index updated. 30-day revisit (~2026-05-26) to evaluate whether the
   light layer earns its keep or escalation/deletion is warranted.
 
-## Skipped (2026-04-26 decisions)
+## Skipped
+
+### 2026-04-26 decisions
 
 - `memory-dump-load-pattern` — Marginal value; git already provides
   cross-machine portability for the auto-memory directory.
@@ -189,13 +191,28 @@ issues or PRs — author works on `main` directly.
   `.claude/settings.json`. Engram's bootstrap explicitly warns about
   duplicate hook configuration as a footgun.
 
+### 2026-05-07 decisions
+
+- `agentinfo-command-pattern` — Engram's "tool prints its own usage"
+  pattern. Daddy_camp already gets the portable insight via CLAUDE.md →
+  `@AGENTS.md` referencing; no new helper needed.
+- `db-migration-system` — Engram's schema-evolution support for SQLite
+  DBs. Markdown-based memory has no schema to migrate; pattern is N/A.
+
 ## Deferred
 
 - `short-term-stack-workflow` — Push/pop conventions for nested digressions
-  (engram's "save context, brainstorm, resume" pattern). Deferred 2026-04-26;
-  most current digressions are short enough that resume context isn't lost.
-  Resurface on next run. Pairs with `tier-by-durability-axis`.
+  (engram's "save context, brainstorm, resume" pattern). Deferred
+  2026-04-26 and re-confirmed 2026-05-07; most digressions still short
+  enough that resume context isn't lost. Pairs with
+  `tier-by-durability-axis`. Resurface on next run.
 - `tier-by-durability-axis` — `durability:` frontmatter field
   (`short`/`long`/`permanent`), orthogonal to existing `type:`. Deferred
-  2026-04-26; without short-term-stack workflow there's no use case for
-  a `short` value. Resurface paired with the stack workflow item.
+  2026-04-26 and re-confirmed 2026-05-07; without the stack workflow
+  there's no use case for a `short` value. Pairs with the stack workflow
+  item. Resurface paired.
+- `engram-mcp-server` (2026-05-07) — Engram now ships an MCP server
+  exposing memory/personality state to non-Claude-Code agents. Daddy_camp
+  could write a small MCP wrapper over its file-based auto-memory dir to
+  serve Codex / Gemini / Copilot. Deferred until we actually run those
+  agents against this workspace and discover memory loading is awkward.


### PR DESCRIPTION
## Inspiration Tracker: engram (2026-05-07)

Refresh from `shiblon/engram` since 2026-04-26 (last digest run).

### Upstream activity

9 commits, 16 files (a4c577c..125f1d4). Single contributor; still no issues or PRs (works on `main` directly).

Major additions:

- **MCP server** (`engram mcp`) — exposes engram as MCP resources (`engram://inject`, `engram://agentinfo`) and tools over stdio. Lets non-Claude-Code agents (Cursor, Gemini, Copilot, AntiGravity) integrate via MCP rather than hooks.
- **`agentinfo` command** — prints canonical "how to use engram" prose for embedding via `>> CLAUDE.md` or `@<path>`. Tool-as-source-of-truth pattern.
- **DB migration system** (`engram migrate` + `pkg/engram/migrate.go`).
- **Multi-platform bootstrap** — `engram bootstrap <claude|gemini|antigravity|copilot|cursor>`. Cursor newly added.
- **CLAUDE.md @file inclusion** — bootstrap writes `@<path>` reference rather than inlining text.
- **`promote` → `move`** internal rename.

Core memory/personality model unchanged from last check (tier model, codename canary, status-line render).

### Decisions

| Disposition | Items |
|---|---|
| Roadmapped | (none) |
| Deferred | engram-mcp-server (new), short-term-stack-workflow (re-defer), tier-by-durability-axis (re-defer) |
| Skipped | agentinfo command pattern (we already do it via CLAUDE.md → `@AGENTS.md`), DB migration system (no schema to migrate) |

### Why nothing roadmapped

Engram's 2026-05-07 update was multi-platform consolidation — patterns daddy_camp already addresses differently (MCP unnecessary while we run Claude Code only; the agentinfo / `@<path>` pattern is already in our adapter setup). Core memory/personality patterns (where we previously deferred two items) are unchanged from last check, so both stay deferred for the same reason.

### Files changed

- `.agent/knowledge/inspiration_engram_digest.md` — refreshed: new "Last checked" date, full changelog a4c577c..125f1d4, three new triage decisions added.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
