### PR TITLE
fix(#181): cross_model_review.sh — gemini -p needs an explicit empty value

### DIFF
--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -58,7 +58,12 @@ build_invoke_cmd() {
 
     case "$agent" in
         gemini)
-            echo "\"${bin}\" -p < \"${prompt}\" > \"${findings}\" 2>&1"
+            # gemini's -p (--prompt) requires a value, even when stdin
+            # supplies the real prompt. Empty string activates headless
+            # mode; the help text confirms gemini "appends" stdin to it.
+            # Without the "", argparse reports "Not enough arguments" and
+            # dumps the help screen into the findings file. Issue #181.
+            echo "\"${bin}\" -p \"\" < \"${prompt}\" > \"${findings}\" 2>&1"
             ;;
         codex)
             # Codex exec reads prompt via stdin
@@ -84,7 +89,9 @@ run_agent_sync() {
     local agent="$1" bin="$2" prompt="$3" findings="$4"
 
     case "$agent" in
-        gemini)  "$bin" -p < "$prompt" > "$findings" 2>&1 ;;
+        # gemini's -p needs an explicit value — empty string activates
+        # headless mode while leaving the real prompt on stdin (#181).
+        gemini)  "$bin" -p "" < "$prompt" > "$findings" 2>&1 ;;
         codex)   "$bin" exec < "$prompt" > "$findings" 2>&1 ;;
         claude)  "$bin" -p < "$prompt" > "$findings" 2>&1 ;;
         copilot) "$bin" -p < "$prompt" > "$findings" 2>&1 ;;

--- a/.agent/work-plans/issue-181/plan.md
+++ b/.agent/work-plans/issue-181/plan.md
@@ -1,0 +1,121 @@
+# Plan: cross_model_review.sh — gemini agent fails because `-p` is invoked without a value
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/181
+
+## Context
+
+`cross_model_review.sh --agent gemini` (used by `/review-code` Deep tier)
+fails: gemini's argparse rejects `-p` without a value, dumps the help
+screen, and `--- Review failed ---` gets written to the findings file
+with no actual review content. Filed during PR #177's Deep-tier review,
+where Codex worked but Gemini's findings file was just the help dump.
+
+Two parallel call sites need the same fix:
+
+- **Sync mode** (`merge_pr.sh:87` … wait, this is `cross_model_review.sh:87`) — `run_agent_sync` case branch.
+- **Tmux mode** (`cross_model_review.sh:61`) — `build_invoke_cmd` case
+  branch.
+
+**Important constraint** (from the script's own line 55 comment): "All
+agents use stdin-based invocation to avoid argv limits on large diffs."
+Deep-tier reviews routinely contain 1000+ line diffs and can exceed
+`ARG_MAX` (commonly 128 KB on Linux). So the fix cannot be the
+"obvious" `gemini -p "$(cat "$prompt")"` — that inlines the prompt as
+an argv item and reintroduces the size limit. The fix must keep stdin
+as the prompt-delivery path.
+
+## Approach
+
+Fix both call sites by passing an explicit empty string value to `-p`,
+which (per `gemini --help`) is appended with stdin: "Run in non-interactive
+(headless) mode with the given prompt. Appended to input on stdin (if any)."
+
+Empirically verified before planning:
+
+```bash
+$ /home/roland/.nvm/versions/node/v24.14.0/bin/gemini -p "" \
+    -m gemini-2.5-flash <<<'Reply with exactly the word OK and nothing else.'
+OK   # exit 0
+```
+
+So the literal fix is one token per call site (`-p` → `-p ""`).
+
+1. **Fix sync path** (`cross_model_review.sh:87`): replace
+   `"$bin" -p < "$prompt" > "$findings" 2>&1` with
+   `"$bin" -p "" < "$prompt" > "$findings" 2>&1`.
+
+2. **Fix tmux path** (`cross_model_review.sh:61`): same change inside the
+   shell-string echo.
+
+3. **Add a code comment** explaining *why* the empty string is required.
+   The historical record of this bug (filed and fixed in the same day)
+   needs to live next to the code so the next agent who edits this
+   doesn't drop the `""` thinking it's a typo.
+
+4. **Smoke test** by running the dispatch end-to-end against PR #177
+   (or any merged workspace PR) with `--agent gemini`. Verify the
+   findings file contains a real `### Findings` section, not the help
+   screen.
+
+5. **Out of scope (separate issues if confirmed):**
+   - `claude` and `copilot` cases use the same `-p < file` pattern (lines
+     68-71, 89-91). They might have the same bug, but the actual claude
+     CLI accepts `-p` without a value (different argparse), and copilot
+     CLI behavior is unverified. **Don't speculatively change them
+     here** — file follow-up issues only if a real failure is observed
+     for either agent.
+   - Adding a post-invocation sanity check ("does the findings file look
+     like a CLI help dump?") would catch future breakage for *any*
+     agent, not just gemini. Worth doing eventually, but it's its own
+     hardening change with its own design decisions (regex tightness,
+     false-positive handling, retry semantics) — keep this PR narrowly
+     scoped to the filed bug.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/cross_model_review.sh` | Add `""` after `-p` for the gemini case in both `build_invoke_cmd` (line 61) and `run_agent_sync` (line 87). Add a 1-line code comment at each site. |
+| `.agent/work-plans/issue-181/progress.md` | Plan + implementation history. |
+
+No tests added — workspace has no shell-test scaffold (same precedent as
+#173). Manual smoke test deterministically reproduces pre-fix failure
+and post-fix success; documented in PR description.
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Test what breaks | Verified the fix empirically *before* writing the plan (one-line gemini invocation returned "OK"). PR description will document the deterministic repro. |
+| Only what's needed | Two literal tokens + 2 comment lines. Resist scope creep into claude/copilot cases (separate issues if real failures emerge) and post-invocation sanity checks (separate hardening change). |
+| A change includes its consequences | The `""` is load-bearing — losing it on a future edit reintroduces the bug. Mitigate via code comment, not just commit message. |
+| Capture decisions | Code comment captures *why* the empty string is required (avoids a future "looks like a typo, let me clean it up" regression). |
+| Improve incrementally | One commit, ~6 LOC of script change. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0001 — ADRs | No | Bug fix; no architectural decision worth recording. |
+| 0007 — Retain Make + dependency tracking | No | No Makefile changes. |
+| Others | No | Script fix entirely contained to `cross_model_review.sh`. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `cross_model_review.sh` invocation pattern for gemini | Documentation that explains the script's behavior | **No update needed** — `cross_model_review.sh` is documented in `AGENTS.md`'s Script Reference table only by purpose ("Cross-model adversarial review"); the fix doesn't change that. |
+| Adversarial-review behavior | `/review-code` skill description | **No update needed** — Deep tier already says "Cross-model adversarial (all available non-caller agents, via `cross_model_review.sh`)". The fix makes that line accurate for gemini. |
+
+## Open Questions
+
+None. The fix is empirically verified, the constraint (stdin to avoid
+argv limits) is clear, and scope is bounded.
+
+## Estimated Scope
+
+Single PR, single commit. ~6 LOC of script change (2 token additions +
+2 single-line comments) + progress.md. Manual smoke test against any
+merged workspace PR.

--- a/.agent/work-plans/issue-181/progress.md
+++ b/.agent/work-plans/issue-181/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 181
+---
+
+# Issue #181 — cross_model_review.sh: gemini agent fails — `gemini -p` is invoked without a value
+
+## Plan
+**Status**: complete
+**When**: 2026-05-07 23:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Plan file: `.agent/work-plans/issue-181/plan.md`.
+
+Pass an explicit empty string value to `gemini -p` in both sync and tmux
+call sites, keeping stdin as the prompt source so the script's argv-
+limit avoidance constraint (line 55 comment) stays honored. Add a code
+comment at each site explaining why the `""` is load-bearing. Fix
+verified empirically before planning.

--- a/.agent/work-plans/issue-181/progress.md
+++ b/.agent/work-plans/issue-181/progress.md
@@ -16,3 +16,37 @@ call sites, keeping stdin as the prompt source so the script's argv-
 limit avoidance constraint (line 55 comment) stays honored. Add a code
 comment at each site explaining why the `""` is load-bearing. Fix
 verified empirically before planning.
+
+## Implementation
+**Status**: complete
+**When**: 2026-05-07 23:45
+**By**: Claude Code Agent (claude-opus-4-7)
+
+- Edited `.agent/scripts/cross_model_review.sh` at two sites: line 61
+  (`build_invoke_cmd`, tmux mode) and line 87 (`run_agent_sync`).
+  Added 5-line comment block at the tmux site and a 2-line comment at
+  the sync site. Both sites now invoke `gemini -p "" < "$prompt"`.
+- Diff size: +9/-2 in cross_model_review.sh.
+
+### Smoke tests
+
+- [x] `bash -n` — syntax clean
+- [x] `shellcheck --severity=warning` — clean
+- [x] **End-to-end sync mode**: `cross_model_review.sh --pr 177
+      --agent gemini --sync` produced a real `### Findings` table with
+      severity/file/line columns. Pre-fix this run wrote the gemini
+      help screen to the findings file. (Tangential observation:
+      Gemini hallucinated a "Makefile corruption" finding in this run
+      — that's a Gemini-quality concern, not a script bug, so out of
+      scope here.)
+- [x] **Tmux mode constructed command**: verified by inspection that
+      `build_invoke_cmd` now emits `"gemini" -p "" < "$prompt" >
+      "$findings" 2>&1` — same shape as the sync invocation, so the
+      sync test transitively validates tmux. A separate full tmux
+      smoke run would be ceremony given the literal command string is
+      identical.
+- Smoke-test artifact: the run wrote a temporary findings file to
+  `.agent/work-plans/issue-173/` (the issue closed by PR #177). I
+  `git restore`d the pre-existing PR-#177 review artifacts so this
+  PR's diff is purely the script change — the historical "Review
+  failed" record stays intact.


### PR DESCRIPTION
Closes #181

## Summary

`cross_model_review.sh --agent gemini` silently failed: gemini's argparse rejects `-p` without a value, dumped its help screen into the findings file, and `/review-code` at Deep tier lost Gemini coverage entirely. Codex still worked because its invocation pattern (`codex exec < prompt`) is structurally different.

## What changed

Two literal token additions plus comments at both call sites of `.agent/scripts/cross_model_review.sh`:

- **`build_invoke_cmd`** (tmux mode, line 61) — the shell-string echoed for `tmux new-session`.
- **`run_agent_sync`** (sync mode, line 87) — the direct invocation when tmux is unavailable.

Both now invoke:

```bash
gemini -p "" < "$prompt" > "$findings" 2>&1
```

The empty string activates headless mode while leaving stdin as the prompt source, per gemini's help text: *"Run in non-interactive (headless) mode with the given prompt. Appended to input on stdin (if any)."*

## Why not just `gemini -p "$(cat prompt)"`?

The script's line-55 comment explicitly says *"All agents use stdin-based invocation to avoid argv limits on large diffs."* Deep-tier review prompts routinely contain 1000+ line diffs and can exceed `ARG_MAX` (commonly 128 KB) when inlined as an argv. The fix has to keep stdin in the loop, which is exactly what `-p "" < "$prompt"` does.

## Why the comment

The `""` looks like a typo. Without context, a future agent could "clean it up" and silently reintroduce this bug. Inline comments at both sites pin the load-bearing detail.

## Smoke test

| Case | Pre-fix | Post-fix |
|------|---------|----------|
| `cross_model_review.sh --pr 177 --agent gemini --sync` | findings file contains the gemini help screen + `--- Review failed ---` | findings file contains a real `### Findings` table with severity/file/line columns and a Summary section |
| `bash -n` | clean | clean |
| `shellcheck --severity=warning` | clean | clean |
| Tmux mode | (not tested) | `build_invoke_cmd` emits the same `gemini -p ""` shape — the sync test transitively validates the constructed command, since the literal command string is identical |

Tangential observation from the smoke test: Gemini hallucinated a "Makefile corruption" finding for PR #177 that doesn't exist in the diff. That's a Gemini-quality concern, not a script bug — out of scope for this PR.

## Out of scope (called out in the plan)

- `claude` and `copilot` cases on lines 67-71 / 89-91 use the same `-p < file` pattern, but their CLI argparses behave differently. Not speculatively patched here. File follow-up issues only if real failures surface for those agents.
- A post-invocation sanity check ("does the findings file look like a CLI help dump?") would catch this class of bug for *any* agent, but it's its own hardening change with its own design questions (regex tightness, false-positive handling, retry semantics). Keep this PR narrowly scoped to the filed bug.

## Files changed

- `.agent/scripts/cross_model_review.sh` — +9/-2
- `.agent/work-plans/issue-181/{plan,progress}.md` — plan + implementation history

---

For the planning detail and design rationale, see `.agent/work-plans/issue-181/plan.md`.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
