### PR TITLE
Add branch mode to /review-code (local pre-push self-review)

### DIFF
--- a/.agent/AGENT_ONBOARDING.md
+++ b/.agent/AGENT_ONBOARDING.md
@@ -66,6 +66,10 @@ Available workflow skills: `review-issue`, `plan-task`, `review-plan`,
 `triage-reviews`, `skill-importer`, `document-package`, `issue-triage`,
 `test-engineering`.
 
+`review-code` has two modes: pass a PR number/URL for post-push review
+of an open PR, or pass `--branch [<base-ref>]` for local pre-push
+self-review against a base ref.
+
 ## References
 
 - [`AGENTS.md`](../AGENTS.md) — Shared workspace rules (all agents)

--- a/.agent/knowledge/review_depth_classification.md
+++ b/.agent/knowledge/review_depth_classification.md
@@ -5,7 +5,10 @@ How to determine the appropriate review depth for a PR. Used by the
 
 ## Risk Signals
 
-Collect these from PR metadata (`gh pr view` output):
+Collect these from diff metadata. In PR mode the source is
+`gh pr view` output; in branch mode (`/review-code --branch`) the same
+signals come from local git (`git diff --name-only <base>...HEAD`,
+`git diff --shortstat <base>...HEAD`).
 
 | Signal | Source | How to measure |
 |--------|--------|----------------|
@@ -119,12 +122,16 @@ based on other signals.
 ## User Override
 
 The user can request a specific tier by including a depth keyword in the
-`/review-code` invocation:
+`/review-code` invocation. Same keywords apply in both PR and branch
+modes:
 
-- `/review-code 42 light` — force Light review
-- `/review-code 42 standard` — force Standard review
-- `/review-code 42 deep` — force Deep review
+- `/review-code 42 light` — force Light review (PR mode)
+- `/review-code 42 standard` — force Standard review (PR mode)
+- `/review-code 42 deep` — force Deep review (PR mode)
+- `/review-code --branch deep` — force Deep review on local branch
+- `/review-code --branch main light` — force Light review against `main`
 
 User overrides take precedence over automatic classification. This allows
 forcing a thorough review on a small change, or a quick review on a large
-but low-risk change (e.g., bulk formatting).
+but low-risk change (e.g., bulk formatting). The `--skip-static` flag
+(both modes) suppresses the static-analysis specialist regardless of tier.

--- a/.agent/scripts/_resolve_default_branch.sh
+++ b/.agent/scripts/_resolve_default_branch.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# .agent/scripts/_resolve_default_branch.sh
+# Shared helper for resolving a repository's default branch.
+#
+# Source this file from other scripts:
+#   source "$SCRIPT_DIR/_resolve_default_branch.sh"
+#
+# Exposes: resolve_default_branch [<repo-root>]
+#   On success: echoes a ref usable for `git diff <ref>...HEAD` on stdout.
+#               Prefers a local branch name (e.g. `main`); falls back to
+#               `origin/<branch>` when the local branch is absent. No
+#               trailing whitespace.
+#   On failure: prints error to stderr and returns 1.
+#
+#   <repo-root> defaults to `git rev-parse --show-toplevel` of the current
+#   working directory.
+#
+# Resolution order:
+#   1. Per-project manifest hook (inert today; wires up when #172 lands).
+#   2. `git symbolic-ref refs/remotes/origin/HEAD` (the configured default).
+#   3. Literal `main` as last-ditch fallback.
+#
+# After picking a name, the helper verifies the ref is reachable locally
+# or on `origin/`. Callers receive a ref that is safe to feed straight
+# into `git diff <ref>...HEAD`.
+#
+# Rationale: workspace and project repos default to `main` today, but
+# the workspace-improvements-cascade-to-projects principle and #172's
+# upcoming per-project manifest mean we need a single resolution point
+# rather than hardcoding `main` in every consumer.
+
+resolve_default_branch() {
+    local repo_root="${1:-}"
+    if [ -z "$repo_root" ]; then
+        repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+            echo "ERROR: resolve_default_branch: not inside a git repository" >&2
+            return 1
+        }
+    fi
+
+    local branch=""
+
+    # --- Step 1: per-project manifest hook ---
+    # When #172's per-project manifest schema is decided, the read goes
+    # here. The block is intentionally empty so resolution falls through
+    # to git's symbolic-ref detection until then. Wire-up will look like:
+    #
+    #   if [ -f "$repo_root/.agent/manifest.yaml" ]; then
+    #       branch=$(yq -r '.default_branch // ""' "$repo_root/.agent/manifest.yaml")
+    #   fi
+
+    # --- Step 2: git's configured default ---
+    if [ -z "$branch" ]; then
+        branch=$(git -C "$repo_root" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+                    | sed 's|^refs/remotes/origin/||')
+    fi
+
+    # --- Step 3: hardcoded fallback ---
+    branch="${branch:-main}"
+
+    # --- Verify the chosen ref is reachable ---
+    if git -C "$repo_root" rev-parse --verify --quiet "$branch" >/dev/null 2>&1; then
+        echo "$branch"
+        return 0
+    fi
+    if git -C "$repo_root" rev-parse --verify --quiet "origin/$branch" >/dev/null 2>&1; then
+        echo "origin/$branch"
+        return 0
+    fi
+
+    {
+        echo "ERROR: resolve_default_branch: cannot find '$branch' locally or as 'origin/$branch'."
+        echo ""
+        echo "  Tried: git symbolic-ref refs/remotes/origin/HEAD, then 'main' fallback."
+        echo "  If origin/HEAD is unset, run: git remote set-head origin -a"
+        echo "  Or pass an explicit base via the caller's --branch <ref> flag."
+    } >&2
+    return 1
+}
+
+# Warn if the file is executed directly — it only defines a function and
+# must be sourced.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    echo "ERROR: _resolve_default_branch.sh must be sourced, not executed directly." >&2
+    echo "Usage: source .agent/scripts/_resolve_default_branch.sh" >&2
+    exit 1
+fi

--- a/.agent/scripts/_resolve_default_branch.sh
+++ b/.agent/scripts/_resolve_default_branch.sh
@@ -36,9 +36,18 @@ resolve_default_branch() {
             echo "ERROR: resolve_default_branch: not inside a git repository" >&2
             return 1
         }
+    else
+        # Validate explicit repo_root up-front so a bad path produces
+        # a clear error instead of falling through to the
+        # "main fallback didn't work" branch later.
+        git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1 || {
+            echo "ERROR: resolve_default_branch: not a git repository: $repo_root" >&2
+            return 1
+        }
     fi
 
     local branch=""
+    local resolved_via=""
 
     # --- Step 1: per-project manifest hook ---
     # When #172's per-project manifest schema is decided, the read goes
@@ -53,10 +62,14 @@ resolve_default_branch() {
     if [ -z "$branch" ]; then
         branch=$(git -C "$repo_root" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
                     | sed 's|^refs/remotes/origin/||')
+        [ -n "$branch" ] && resolved_via="git symbolic-ref"
     fi
 
     # --- Step 3: hardcoded fallback ---
-    branch="${branch:-main}"
+    if [ -z "$branch" ]; then
+        branch="main"
+        resolved_via="hardcoded fallback"
+    fi
 
     # --- Verify the chosen ref is reachable ---
     if git -C "$repo_root" rev-parse --verify --quiet "$branch" >/dev/null 2>&1; then
@@ -69,11 +82,18 @@ resolve_default_branch() {
     fi
 
     {
-        echo "ERROR: resolve_default_branch: cannot find '$branch' locally or as 'origin/$branch'."
+        echo "ERROR: resolve_default_branch: '${branch}' (resolved via ${resolved_via})"
+        echo "  is not reachable as a local ref or as origin/${branch}."
         echo ""
-        echo "  Tried: git symbolic-ref refs/remotes/origin/HEAD, then 'main' fallback."
-        echo "  If origin/HEAD is unset, run: git remote set-head origin -a"
-        echo "  Or pass an explicit base via the caller's --branch <ref> flag."
+        if [ "$resolved_via" = "hardcoded fallback" ]; then
+            echo "  Repo at '${repo_root}' has no origin/HEAD configured AND no 'main' branch."
+            echo "  Either run: git remote set-head origin -a"
+            echo "  Or pass an explicit base via the caller's --branch <ref> flag."
+        else
+            echo "  origin/HEAD points at '${branch}' but that ref does not resolve."
+            echo "  Try: git fetch origin"
+            echo "  Or pass an explicit base via the caller's --branch <ref> flag."
+        fi
     } >&2
     return 1
 }

--- a/.agent/scripts/_resolve_default_branch.sh
+++ b/.agent/scripts/_resolve_default_branch.sh
@@ -59,10 +59,18 @@ resolve_default_branch() {
     #   fi
 
     # --- Step 2: git's configured default ---
+    # Two-step capture (instead of `git ... | sed`) so callers running
+    # under `set -e -o pipefail` (e.g. cross_model_review.sh) don't abort
+    # here when origin/HEAD is unset — the failing symbolic-ref would
+    # make the pipeline non-zero and short-circuit the step-3 fallback.
+    # Parameter expansion replaces sed for the prefix strip.
     if [ -z "$branch" ]; then
-        branch=$(git -C "$repo_root" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
-                    | sed 's|^refs/remotes/origin/||')
-        [ -n "$branch" ] && resolved_via="git symbolic-ref"
+        local symref=""
+        symref=$(git -C "$repo_root" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || symref=""
+        if [ -n "$symref" ]; then
+            branch="${symref#refs/remotes/origin/}"
+            resolved_via="git symbolic-ref"
+        fi
     fi
 
     # --- Step 3: hardcoded fallback ---

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -238,7 +238,9 @@ fi
 GH_REPO_SLUG=""
 if [[ -n "$EXPLICIT_REPO" ]]; then
     GH_REPO_SLUG="$EXPLICIT_REPO"
-elif command -v gh &>/dev/null; then
+elif [[ "$BRANCH_MODE" != true ]] && command -v gh &>/dev/null; then
+    # PR mode only — branch mode never uses GH_REPO_ARGS so the
+    # network call is wasted work.
     GH_REPO_SLUG=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 fi
 GH_REPO_ARGS=()
@@ -297,7 +299,12 @@ if [[ -n "$CLI_ISSUE_NUMBER" ]]; then
     ISSUE_NUMBER="$CLI_ISSUE_NUMBER"
 elif [[ "$BRANCH_MODE" == true ]]; then
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-    if [[ "$CURRENT_BRANCH" =~ ^feature/[Ii][Ss][Ss][Uu][Ee]-([0-9]+) ]]; then
+    # Tightened regex: requires a separator after digits (so
+    # `feature/issue-3foo` doesn't silently capture `3`) and rejects
+    # leading zeros (so `feature/issue-03` doesn't bypass the
+    # --issue validator's positive-integer check). #149 lesson:
+    # silent issue-number misrouting is the failure mode to prevent.
+    if [[ "$CURRENT_BRANCH" =~ ^feature/[Ii][Ss][Ss][Uu][Ee]-([1-9][0-9]*)(-|$) ]]; then
         ISSUE_NUMBER="${BASH_REMATCH[1]}"
     elif [[ "$NO_PROGRESS" == true ]]; then
         # Sentinel used for SESSION_NAME and findings filename; the
@@ -382,7 +389,14 @@ elif [[ -n "$EXPLICIT_WORK_DIR" ]]; then
 elif [[ "$NO_PROGRESS" == true ]]; then
     # --no-progress: ephemeral artifact dir. Findings remain readable
     # for the session but aren't tied to a per-issue directory and won't
-    # be picked up by progress.md commit conventions.
+    # be picked up by progress.md commit conventions. Note that the
+    # branch-name regex may still resolve a real ISSUE_NUMBER (e.g.
+    # `feature/issue-3` with --no-progress); the artifact dir override
+    # always wins when --no-progress is set, even if the issue number
+    # was resolvable. Tmpdir is left in /tmp for the session; the OS
+    # cleans it up on next boot. Adding a `trap` to remove on exit was
+    # considered and declined: users frequently want to inspect
+    # findings after the script finishes.
     NO_PROGRESS_TMP_DIR=$(mktemp -d -t "cross-model-review.XXXXXX")
     echo "INFO: --no-progress: artifacts going to ${NO_PROGRESS_TMP_DIR}" >&2
     export WORK_PLANS_DIR_OVERRIDE="${NO_PROGRESS_TMP_DIR}"
@@ -394,17 +408,13 @@ mkdir -p "$WORK_PLANS_DIR"
 PROMPT_FILE="${WORK_PLANS_DIR}/review-${TARGET_AGENT}-prompt.md"
 FINDINGS_FILE="${WORK_PLANS_DIR}/review-${TARGET_AGENT}-findings.md"
 SESSION_NAME="review-${TARGET_AGENT}-${ISSUE_NUMBER}"
-
-# Human-readable label for status messages. Mode-aware so branch-mode
-# logs read sensibly without "PR #" prefixes that don't apply.
-if [[ "$BRANCH_MODE" == true ]]; then
-    if [[ "$ISSUE_NUMBER" == "noprogress" ]]; then
-        TARGET_LABEL="branch ${BRANCH_NAME} (no-progress mode)"
-    else
-        TARGET_LABEL="branch ${BRANCH_NAME} (issue #${ISSUE_NUMBER})"
-    fi
-else
-    TARGET_LABEL="PR #${PR_NUMBER} (issue #${ISSUE_NUMBER})"
+# Two concurrent --no-progress runs share ISSUE_NUMBER="noprogress"
+# and would collide on the tmux session name; the existing
+# "kill any pre-existing session" logic would silently terminate the
+# first run. Append the PID so concurrent skill-worktree pre-push
+# reviews coexist.
+if [[ "$ISSUE_NUMBER" == "noprogress" ]]; then
+    SESSION_NAME="${SESSION_NAME}-$$"
 fi
 
 # --- Get review-target metadata ---
@@ -416,11 +426,16 @@ if [[ "$BRANCH_MODE" == true ]]; then
     HEAD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
     if [[ -n "$BRANCH_BASE" ]]; then
-        BASE_REF="$BRANCH_BASE"
-        # Validate the user-supplied ref exists.
-        if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1 \
-            && ! git rev-parse --verify --quiet "origin/$BASE_REF" >/dev/null 2>&1; then
-            echo "ERROR: --branch base '${BASE_REF}' is not a known ref" >&2
+        # Validate and normalize: prefer the local ref, fall back to
+        # origin/<ref> when only the remote-tracking branch exists.
+        # Without normalization, `git diff develop...HEAD` would fail
+        # on a fresh clone where only `origin/develop` is reachable.
+        if git rev-parse --verify --quiet "$BRANCH_BASE" >/dev/null 2>&1; then
+            BASE_REF="$BRANCH_BASE"
+        elif git rev-parse --verify --quiet "origin/$BRANCH_BASE" >/dev/null 2>&1; then
+            BASE_REF="origin/$BRANCH_BASE"
+        else
+            echo "ERROR: --branch base '${BRANCH_BASE}' is not a known ref (locally or as origin/${BRANCH_BASE})" >&2
             exit 2
         fi
     else
@@ -432,6 +447,19 @@ if [[ "$BRANCH_MODE" == true ]]; then
 else
     PR_TITLE=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json title --jq '.title' 2>/dev/null || echo "PR #${PR_NUMBER}")
     PR_URL=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json url --jq '.url' 2>/dev/null || echo "")
+fi
+
+# Human-readable label for status messages. Mode-aware so branch-mode
+# logs read sensibly without "PR #" prefixes that don't apply. Computed
+# after the metadata block so BRANCH_NAME is in scope under `set -u`.
+if [[ "$BRANCH_MODE" == true ]]; then
+    if [[ "$ISSUE_NUMBER" == "noprogress" ]]; then
+        TARGET_LABEL="branch ${BRANCH_NAME} (no-progress mode)"
+    else
+        TARGET_LABEL="branch ${BRANCH_NAME} (issue #${ISSUE_NUMBER})"
+    fi
+else
+    TARGET_LABEL="PR #${PR_NUMBER} (issue #${ISSUE_NUMBER})"
 fi
 
 # --- Write prompt ---

--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -101,6 +101,9 @@ run_agent_sync() {
 
 # --- Argument parsing ---
 PR_NUMBER=""
+BRANCH_MODE=false
+BRANCH_BASE=""
+NO_PROGRESS=false
 CLI_ISSUE_NUMBER=""
 FORCE_SYNC=false
 TARGET_AGENT="gemini"
@@ -108,7 +111,7 @@ EXPLICIT_REPO=""
 EXPLICIT_WORK_DIR=""
 CLI_WORK_PLANS_DIR=""
 
-USAGE="Usage: $0 --pr <N> [--issue <N>] [--agent <name>] [--repo owner/repo] [--work-dir <path>] [--work-plans-dir <path>] [--sync]"
+USAGE="Usage: $0 (--pr <N> | --branch [<ref>]) [--issue <N>] [--agent <name>] [--repo owner/repo] [--work-dir <path>] [--work-plans-dir <path>] [--sync] [--no-progress]"
 
 # Helper: treat a missing value OR a value that looks like another long
 # flag (`--foo`) as "missing value." Narrower than `-*` so negative
@@ -130,6 +133,23 @@ while [[ $# -gt 0 ]]; do
             require_value "--pr" "${2:-}"
             PR_NUMBER="$2"
             shift 2
+            ;;
+        --branch)
+            BRANCH_MODE=true
+            # --branch takes an optional value. Treat the next token as
+            # the base ref only if it doesn't look like another flag and
+            # isn't empty. Otherwise leave BRANCH_BASE empty so the
+            # default-branch resolver runs.
+            if [[ -n "${2:-}" && "${2}" != --* ]]; then
+                BRANCH_BASE="$2"
+                shift 2
+            else
+                shift 1
+            fi
+            ;;
+        --no-progress)
+            NO_PROGRESS=true
+            shift 1
             ;;
         --issue)
             require_value "--issue" "${2:-}"
@@ -168,8 +188,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "$PR_NUMBER" ]]; then
-    echo "ERROR: --pr <N> is required" >&2
+if [[ -n "$PR_NUMBER" && "$BRANCH_MODE" == true ]]; then
+    echo "ERROR: --pr and --branch are mutually exclusive." >&2
+    echo "" >&2
+    echo "  Use --pr <N> for PR mode (post-push review)" >&2
+    echo "  or --branch [<base>] for branch mode (local pre-push review)." >&2
+    exit 2
+fi
+if [[ -z "$PR_NUMBER" && "$BRANCH_MODE" != true ]]; then
+    echo "ERROR: one of --pr <N> or --branch [<ref>] is required" >&2
     echo "$USAGE" >&2
     exit 2
 fi
@@ -195,7 +222,9 @@ if [[ -n "$CLI_ISSUE_NUMBER" && ! "$CLI_ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 # --- Dependency checks ---
-if ! command -v gh &>/dev/null; then
+# gh is required for PR mode (PR body/diff retrieval) but optional for
+# branch mode (offline pre-push review uses local git only).
+if [[ "$BRANCH_MODE" != true ]] && ! command -v gh &>/dev/null; then
     echo "WARNING: GitHub CLI (gh) not installed — required for PR metadata" >&2
     exit 1
 fi
@@ -204,10 +233,12 @@ fi
 # nested repos). Prefer `gh repo view` over parsing `git remote get-url`
 # — gh handles SSH host aliases (~/.ssh/config), GitHub Enterprise, and
 # custom remote names correctly, where the regex approach produced
-# garbage or silently fell back (issue #150).
+# garbage or silently fell back (issue #150). Skipped in branch mode
+# unless gh is available, since branch mode never calls gh -R.
+GH_REPO_SLUG=""
 if [[ -n "$EXPLICIT_REPO" ]]; then
     GH_REPO_SLUG="$EXPLICIT_REPO"
-else
+elif command -v gh &>/dev/null; then
     GH_REPO_SLUG=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 fi
 GH_REPO_ARGS=()
@@ -254,14 +285,40 @@ if [[ -z "$AGENT_BIN" ]]; then
 fi
 
 # --- Resolve issue number ---
-# Order: explicit --issue flag wins; otherwise require a GitHub closure
-# keyword in the PR body. The loose "first standalone #N" fallback was
-# removed in #149 — it silently routed artifacts to unrelated issues
-# (e.g. "see also #42. Related to #99...") and, post-#147, caused the
+# Order: explicit --issue flag wins; otherwise mode-specific resolution.
+# PR mode: require a GitHub closure keyword in the PR body. The loose
+# "first standalone #N" fallback was removed in #149 — it silently
+# routed artifacts to unrelated issues and, post-#147, caused the
 # work-plans resolver to abort with a confusing wrong-issue message.
+# Branch mode: parse the current branch name (AGENTS.md branch-naming
+# rule: feature/issue-<N> or feature/ISSUE-<N>-<desc>). On parse
+# failure, hard error unless --no-progress was passed.
 if [[ -n "$CLI_ISSUE_NUMBER" ]]; then
     ISSUE_NUMBER="$CLI_ISSUE_NUMBER"
+elif [[ "$BRANCH_MODE" == true ]]; then
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+    if [[ "$CURRENT_BRANCH" =~ ^feature/[Ii][Ss][Ss][Uu][Ee]-([0-9]+) ]]; then
+        ISSUE_NUMBER="${BASH_REMATCH[1]}"
+    elif [[ "$NO_PROGRESS" == true ]]; then
+        # Sentinel used for SESSION_NAME and findings filename; the
+        # per-issue artifact dir is replaced with a tmp dir below.
+        ISSUE_NUMBER="noprogress"
+    else
+        {
+            echo "ERROR: cannot resolve issue number."
+            echo ""
+            echo "  Current branch '${CURRENT_BRANCH}' does not match feature/issue-<N>."
+            echo ""
+            echo "  Fix one of:"
+            echo "    --issue <N>     point to a specific issue"
+            echo "    --no-progress   skip progress.md persistence"
+            echo "                    (skill worktrees, one-off branches)"
+            echo "    rename branch   if this should be tracked"
+        } >&2
+        exit 2
+    fi
 else
+    # PR mode: parse Closes/Fixes/Resolves keyword from PR body.
     # Capture gh's exit status distinctly from "retrieved an empty body"
     # so auth/network/permission failures produce the right remediation
     # (per review feedback on #149).
@@ -302,11 +359,15 @@ fi
 # --- Set up artifact directory (absolute paths for tmux session) ---
 # Refuse to run outside the matching worktree (issue #147) unless the
 # caller explicitly overrides the location via --work-plans-dir (exact
-# path) or --work-dir (repo root). Either override is routed through
-# $WORK_PLANS_DIR_OVERRIDE so the resolver treats them uniformly.
+# path), --work-dir (repo root), or --no-progress (mktemp -d for
+# ephemeral artifacts when there's no issue to track). Each override
+# routes through $WORK_PLANS_DIR_OVERRIDE so the resolver treats them
+# uniformly.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_resolve_work_plans_dir.sh
 source "${SCRIPT_DIR}/_resolve_work_plans_dir.sh"
+# shellcheck source=_resolve_default_branch.sh
+source "${SCRIPT_DIR}/_resolve_default_branch.sh"
 
 if [[ -n "$CLI_WORK_PLANS_DIR" ]]; then
     export WORK_PLANS_DIR_OVERRIDE="$CLI_WORK_PLANS_DIR"
@@ -318,6 +379,13 @@ elif [[ -n "$EXPLICIT_WORK_DIR" ]]; then
     # Resolve to absolute path so tmux sessions find the directory.
     EXPLICIT_WORK_DIR=$(cd "$EXPLICIT_WORK_DIR" && pwd)
     export WORK_PLANS_DIR_OVERRIDE="${EXPLICIT_WORK_DIR}/.agent/work-plans/issue-${ISSUE_NUMBER}"
+elif [[ "$NO_PROGRESS" == true ]]; then
+    # --no-progress: ephemeral artifact dir. Findings remain readable
+    # for the session but aren't tied to a per-issue directory and won't
+    # be picked up by progress.md commit conventions.
+    NO_PROGRESS_TMP_DIR=$(mktemp -d -t "cross-model-review.XXXXXX")
+    echo "INFO: --no-progress: artifacts going to ${NO_PROGRESS_TMP_DIR}" >&2
+    export WORK_PLANS_DIR_OVERRIDE="${NO_PROGRESS_TMP_DIR}"
 fi
 
 WORK_PLANS_DIR=$(resolve_work_plans_dir "$ISSUE_NUMBER") || exit 4
@@ -327,9 +395,44 @@ PROMPT_FILE="${WORK_PLANS_DIR}/review-${TARGET_AGENT}-prompt.md"
 FINDINGS_FILE="${WORK_PLANS_DIR}/review-${TARGET_AGENT}-findings.md"
 SESSION_NAME="review-${TARGET_AGENT}-${ISSUE_NUMBER}"
 
-# --- Get PR metadata ---
-PR_TITLE=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json title --jq '.title' 2>/dev/null || echo "PR #${PR_NUMBER}")
-PR_URL=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json url --jq '.url' 2>/dev/null || echo "")
+# Human-readable label for status messages. Mode-aware so branch-mode
+# logs read sensibly without "PR #" prefixes that don't apply.
+if [[ "$BRANCH_MODE" == true ]]; then
+    if [[ "$ISSUE_NUMBER" == "noprogress" ]]; then
+        TARGET_LABEL="branch ${BRANCH_NAME} (no-progress mode)"
+    else
+        TARGET_LABEL="branch ${BRANCH_NAME} (issue #${ISSUE_NUMBER})"
+    fi
+else
+    TARGET_LABEL="PR #${PR_NUMBER} (issue #${ISSUE_NUMBER})"
+fi
+
+# --- Get review-target metadata ---
+# PR mode: query gh for the PR's title and URL.
+# Branch mode: resolve base ref via the helper, capture HEAD sha and
+# branch name for the prompt header.
+if [[ "$BRANCH_MODE" == true ]]; then
+    BRANCH_NAME=$(git branch --show-current 2>/dev/null || echo "(detached)")
+    HEAD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+    if [[ -n "$BRANCH_BASE" ]]; then
+        BASE_REF="$BRANCH_BASE"
+        # Validate the user-supplied ref exists.
+        if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1 \
+            && ! git rev-parse --verify --quiet "origin/$BASE_REF" >/dev/null 2>&1; then
+            echo "ERROR: --branch base '${BASE_REF}' is not a known ref" >&2
+            exit 2
+        fi
+    else
+        BASE_REF=$(resolve_default_branch) || exit 2
+    fi
+
+    PR_TITLE="Local branch ${BRANCH_NAME} at ${HEAD_SHA}"
+    PR_URL=""
+else
+    PR_TITLE=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json title --jq '.title' 2>/dev/null || echo "PR #${PR_NUMBER}")
+    PR_URL=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json url --jq '.url' 2>/dev/null || echo "")
+fi
 
 # --- Write prompt ---
 # Use a quoted heredoc for the static header to prevent shell expansion,
@@ -357,27 +460,49 @@ everything. Focus on:
 
 PROMPT_HEADER
 
-# Append PR metadata (needs expansion)
-printf '**Title**: %s\n**URL**: %s\n**PR Number**: #%s\n\n' \
-    "$PR_TITLE" "$PR_URL" "$PR_NUMBER" >> "$PROMPT_FILE"
+# Append review-target metadata (needs expansion).
+# Branch-mode prompt emits Branch + Base + HEAD instead of PR Number/URL
+# so the agent reviewing local pre-push work has the right framing.
+if [[ "$BRANCH_MODE" == true ]]; then
+    printf '**Title**: %s\n**Branch**: %s\n**Base**: %s\n**HEAD**: %s\n\n' \
+        "$PR_TITLE" "$BRANCH_NAME" "$BASE_REF" "$HEAD_SHA" >> "$PROMPT_FILE"
+else
+    printf '**Title**: %s\n**URL**: %s\n**PR Number**: #%s\n\n' \
+        "$PR_TITLE" "$PR_URL" "$PR_NUMBER" >> "$PROMPT_FILE"
+fi
 
-# Stream diff directly into the prompt file
+# Stream diff directly into the prompt file. Branch mode uses local
+# `git diff <base>...HEAD`; PR mode uses `gh pr diff <N>`.
 printf '## Diff\n\n```diff\n' >> "$PROMPT_FILE"
 DIFF_START_LINE=$(wc -l < "$PROMPT_FILE")
-if ! gh pr diff "$PR_NUMBER" "${GH_REPO_ARGS[@]}" >> "$PROMPT_FILE" 2>/dev/null; then
-    echo "ERROR: Could not retrieve diff for PR #${PR_NUMBER}" >&2
-    echo '--- Review error: failed to retrieve diff ---' > "$FINDINGS_FILE"
-    exit 3
+if [[ "$BRANCH_MODE" == true ]]; then
+    if ! git diff "${BASE_REF}...HEAD" >> "$PROMPT_FILE" 2>/dev/null; then
+        echo "ERROR: Could not produce diff for ${BRANCH_NAME} against ${BASE_REF}" >&2
+        echo '--- Review error: failed to produce branch diff ---' > "$FINDINGS_FILE"
+        exit 3
+    fi
+else
+    if ! gh pr diff "$PR_NUMBER" "${GH_REPO_ARGS[@]}" >> "$PROMPT_FILE" 2>/dev/null; then
+        echo "ERROR: Could not retrieve diff for PR #${PR_NUMBER}" >&2
+        echo '--- Review error: failed to retrieve diff ---' > "$FINDINGS_FILE"
+        exit 3
+    fi
 fi
 DIFF_END_LINE=$(wc -l < "$PROMPT_FILE")
 
 # Guard: if diff is empty, abort with a clear error instead of launching an
-# agent with no content to review
+# agent with no content to review.
 if [[ "$DIFF_END_LINE" -le "$DIFF_START_LINE" ]]; then
-    echo "ERROR: PR #${PR_NUMBER} diff is empty — nothing to review" >&2
-    echo "  This usually means the PR was not found in the target repo." >&2
-    echo "  Try passing --repo <owner/repo> explicitly." >&2
-    echo '--- Review error: diff was empty (PR not found or no changes) ---' > "$FINDINGS_FILE"
+    if [[ "$BRANCH_MODE" == true ]]; then
+        echo "ERROR: branch '${BRANCH_NAME}' has no changes against '${BASE_REF}' — nothing to review" >&2
+        echo "  Either the branch is up-to-date with the base, or the base ref is wrong." >&2
+        echo '--- Review error: diff was empty (branch matches base) ---' > "$FINDINGS_FILE"
+    else
+        echo "ERROR: PR #${PR_NUMBER} diff is empty — nothing to review" >&2
+        echo "  This usually means the PR was not found in the target repo." >&2
+        echo "  Try passing --repo <owner/repo> explicitly." >&2
+        echo '--- Review error: diff was empty (PR not found or no changes) ---' > "$FINDINGS_FILE"
+    fi
     exit 3
 fi
 printf '```\n\n' >> "$PROMPT_FILE"
@@ -412,7 +537,7 @@ if [[ "$USE_SYNC" == true ]]; then
     echo "AGENT=${TARGET_AGENT}"
     echo "FINDINGS_FILE=${FINDINGS_FILE}"
     echo ""
-    echo "Running ${TARGET_AGENT} adversarial review synchronously for PR #${PR_NUMBER} (issue #${ISSUE_NUMBER})..."
+    echo "Running ${TARGET_AGENT} adversarial review synchronously for ${TARGET_LABEL}..."
     echo "  Prompt:  ${PROMPT_FILE}"
     echo "  Results: ${FINDINGS_FILE}"
 
@@ -450,7 +575,7 @@ else
     echo "TMUX_SESSION=${SESSION_NAME}"
     echo "FINDINGS_FILE=${FINDINGS_FILE}"
     echo ""
-    echo "${TARGET_AGENT} adversarial review launched for PR #${PR_NUMBER} (issue #${ISSUE_NUMBER})"
+    echo "${TARGET_AGENT} adversarial review launched for ${TARGET_LABEL}"
     echo "  Monitor: tmux attach -t ${SESSION_NAME}"
     echo "  Prompt:  ${PROMPT_FILE}"
     echo "  Results: ${FINDINGS_FILE}"

--- a/.agent/work-plans/issue-3/plan.md
+++ b/.agent/work-plans/issue-3/plan.md
@@ -30,12 +30,18 @@ PR #157.
 ## Approach
 
 1. **Add `--branch [<base>]` to `/review-code`.** Flag toggles branch mode;
-   optional base value resolved from `git symbolic-ref refs/remotes/origin/HEAD`
-   with a fallback to `main`. Step 1 forks: PR mode keeps `gh pr view/diff`;
-   branch mode uses `git diff <base>...HEAD` and `git diff --name-only
-   <base>...HEAD`. Issue-number resolution forks too: PR mode parses
-   "Closes #N" from the PR body; branch mode parses `feature/issue-<N>`
-   from `git branch --show-current`, with `--issue <N>` as override.
+   optional base value resolved through new helper
+   `.agent/scripts/_resolve_default_branch.sh` — single resolution point so
+   #172's manifest can be wired in one place later. Resolution order:
+   `--branch <ref>` argument (caller-side, never reaches helper) → manifest
+   hook (inert today, comment-marked) → `git symbolic-ref refs/remotes/origin/HEAD`
+   → literal `main`. Step 1 forks: PR mode keeps `gh pr view/diff`; branch
+   mode uses `git diff <base>...HEAD` and `git diff --name-only <base>...HEAD`.
+   Issue-number resolution forks too: PR mode parses "Closes #N" from the PR
+   body; branch mode parses `feature/issue-<N>` (or `feature/ISSUE-<N>-...`
+   per AGENTS.md branch-naming rule) from `git branch --show-current`, with
+   `--issue <N>` as override. Hard error if neither resolves and
+   `--no-progress` not passed.
 
 2. **Specialists run unchanged.** Depth-classification signals (line count,
    file count, override-trigger files) operate on the local diff identically.
@@ -76,8 +82,9 @@ PR #157.
 
 | File | Change |
 |------|--------|
-| `.claude/skills/review-code/SKILL.md` | Add "Modes" section; fork Step 1 into PR-mode and branch-mode sub-steps; mark Step 5b "Existing review comments" as PR-only; differentiate Step 8 step header for branch mode |
-| `.agent/scripts/cross_model_review.sh` | Add `--branch [<ref>]` (mutually exclusive with `--pr`); branch-mode prompt header; branch-mode diff capture via `git diff <base>...HEAD`; branch-mode issue resolution from `feature/issue-<N>` |
+| `.agent/scripts/_resolve_default_branch.sh` | **New**. Sourced helper; exports `resolve_default_branch <repo_root>`. Resolution order: manifest hook (inert) → `git symbolic-ref refs/remotes/origin/HEAD` → `main` |
+| `.claude/skills/review-code/SKILL.md` | Add "Modes" section; fork Step 1 into PR-mode and branch-mode sub-steps; mark Step 5b "Existing review comments" as PR-only; differentiate Step 8 step header for branch mode; document `--skip-static` (works in both modes) and `--no-progress` (branch-mode-only) |
+| `.agent/scripts/cross_model_review.sh` | Add `--branch [<ref>]` (mutually exclusive with `--pr`, hard error if both); add `--skip-static` (no-op in this script — for symmetry with skill flag); add `--no-progress`; branch-mode prompt header; branch-mode diff capture via `git diff <base>...HEAD`; branch-mode issue resolution from `feature/issue-<N>` |
 | `.agent/knowledge/review_depth_classification.md` | Generalize "PR metadata" wording; add branch-mode paragraph |
 | `.agent/AGENT_ONBOARDING.md` | One-line note on the `--branch` flag |
 
@@ -108,51 +115,53 @@ PR #157.
 | `review_depth_classification.md` | `review-code` skill | Yes (steps 1, 5 stay in sync) |
 | Workflow skill list | Skill list in non-Claude adapters | Partial — review-code already listed; only flag note added (step 6) |
 
-## Open Questions
+## Decisions
 
-These are the architectural decisions worth your eyes before implement begins.
-Numbered so you can answer "1=A, 2=B, ..." or override individually.
+Captured 2026-05-09 during plan review with Roland. Each decision was
+asked one at a time with concrete previews; recommendations were taken
+in 4 of 5 with one extension.
 
-1. **Default base ref** — recommend dynamic resolution via
-   `git symbolic-ref refs/remotes/origin/HEAD`, fall back to `main`.
-   Both workspace and project default to `main` today, so this is mostly
-   future-proofing. Alternative: hardcode `main`. (Recommend dynamic.)
+1. **Default base ref**: dynamic resolution via new
+   `.agent/scripts/_resolve_default_branch.sh` helper.
+   Order: `--branch <ref>` arg → manifest hook (inert today; wires up when
+   #172 lands) → `git symbolic-ref refs/remotes/origin/HEAD` → `main`.
+   Single resolution point so the manifest landing is one-file later.
 
-2. **Static analysis in branch mode** — the issue body says "static analysis
-   optional — pre-commit already runs". Two reasonable defaults:
-   - **(a) On**: matches Standard tier exactly; silence filter drops
-     linter-clean files; safety net for `--no-verify` bypasses.
-   - **(b) Off, with `--with-static` opt-in**: branch mode is faster;
-     trusts pre-commit as the gate.
-   Recommend (a) — the speed delta is small and `--no-verify` does happen.
+2. **Static analysis**: always on by default in *both* PR and branch modes,
+   `--skip-static` toggle suppresses in either mode. Symmetric. Preserves
+   Light tier's mental model. Catches `--no-verify` bypasses.
 
-3. **Issue-number resolution fallback** — when branch isn't
-   `feature/issue-<N>` and `--issue` isn't passed:
-   - **(a) Hard error** with remediation message ("pass --issue or rename
-     branch"). Strict but avoids silent artifact misrouting (the #149
-     failure mode).
-   - **(b) Soft skip**: run review without progress-log persistence.
-   Recommend (a).
+3. **Branch-name parse failure**: hard error with remediation message;
+   `--no-progress` opt-in for skill worktrees / one-off branches. Matches
+   existing strictness patterns from #72, #147, #149.
 
-4. **Mutual exclusion of `--pr` and `--branch`** — recommend hard error if
-   both provided. Allowing both could mean "review the local branch in the
-   context of the existing PR" but doubles the test surface for unclear
-   benefit.
+4. **`--pr` + `--branch`**: mutually exclusive; hard error if both passed.
+   Two clean modes, no compound logic. Compound use case can be added
+   additively if it ever materializes.
 
-5. **Self-test scope** — once branch mode is built, running it on this
-   feature branch is the obvious smoke test. Two options:
-   - **(a) Same PR**: include any minor findings in this PR. Bigger
-     findings → follow-up issue.
-   - **(b) Separate run** after merge, treat as initial dogfood.
-   Recommend (a) — fast feedback loop.
+5. **Self-test**: same PR. Run `/review-code --branch` against
+   `feature/issue-3` itself before final push; fix minor findings inline,
+   triage anything bigger.
+
+### Resulting flag surface
+
+| Flag | Modes | Meaning |
+|------|-------|---------|
+| `--branch [<ref>]` | new | enable branch mode; optional base ref |
+| `--issue <N>` | both | override issue resolution |
+| `--skip-static` | both | suppress static-analysis specialist |
+| `--no-progress` | branch | skip progress.md persistence (skill worktrees) |
+| (positional `<pr-or-url>`) | PR | unchanged |
+| `light\|standard\|deep` | both | unchanged depth override |
 
 ## Estimated Scope
 
-Single PR, ~250 LOC across the four files. Most volume in
-`cross_model_review.sh` (arg parsing + diff path) and `SKILL.md` (mode
-sub-sections). No new tests — there is no existing test harness for
-`cross_model_review.sh`, and a parity-only addition would be out of scope
-for #3.
+Single PR, ~300 LOC across five files (helper added during plan review).
+Most volume in `cross_model_review.sh` (arg parsing + diff path) and
+`SKILL.md` (mode sub-sections). No new tests — there is no existing test
+harness for `cross_model_review.sh`, and a parity-only addition would be
+out of scope for #3. Self-test on the implementation itself (decision 5)
+serves as the dogfood pass.
 
 ## Implementation Notes
 

--- a/.agent/work-plans/issue-3/plan.md
+++ b/.agent/work-plans/issue-3/plan.md
@@ -84,7 +84,7 @@ PR #157.
 |------|--------|
 | `.agent/scripts/_resolve_default_branch.sh` | **New**. Sourced helper; exports `resolve_default_branch <repo_root>`. Resolution order: manifest hook (inert) → `git symbolic-ref refs/remotes/origin/HEAD` → `main` |
 | `.claude/skills/review-code/SKILL.md` | Add "Modes" section; fork Step 1 into PR-mode and branch-mode sub-steps; mark Step 5b "Existing review comments" as PR-only; differentiate Step 8 step header for branch mode; document `--skip-static` (works in both modes) and `--no-progress` (branch-mode-only) |
-| `.agent/scripts/cross_model_review.sh` | Add `--branch [<ref>]` (mutually exclusive with `--pr`, hard error if both); add `--skip-static` (no-op in this script — for symmetry with skill flag); add `--no-progress`; branch-mode prompt header; branch-mode diff capture via `git diff <base>...HEAD`; branch-mode issue resolution from `feature/issue-<N>` |
+| `.agent/scripts/cross_model_review.sh` | Add `--branch [<ref>]` (mutually exclusive with `--pr`, hard error if both); add `--no-progress`; branch-mode prompt header; branch-mode diff capture via `git diff <base>...HEAD`; branch-mode issue resolution from `feature/issue-<N>`. Note: `--skip-static` is not added here — this script only dispatches cross-model adversarial review; static analysis lives in the skill |
 | `.agent/knowledge/review_depth_classification.md` | Generalize "PR metadata" wording; add branch-mode paragraph |
 | `.agent/AGENT_ONBOARDING.md` | One-line note on the `--branch` flag |
 
@@ -149,7 +149,7 @@ in 4 of 5 with one extension.
 |------|-------|---------|
 | `--branch [<ref>]` | new | enable branch mode; optional base ref |
 | `--issue <N>` | both | override issue resolution |
-| `--skip-static` | both | suppress static-analysis specialist |
+| `--skip-static` | both | suppress static-analysis specialist (skill only — `cross_model_review.sh` doesn't run static) |
 | `--no-progress` | branch | skip progress.md persistence (skill worktrees) |
 | (positional `<pr-or-url>`) | PR | unchanged |
 | `light\|standard\|deep` | both | unchanged depth override |

--- a/.agent/work-plans/issue-3/plan.md
+++ b/.agent/work-plans/issue-3/plan.md
@@ -1,0 +1,159 @@
+# Plan: Add branch mode to /review-code (local pre-push self-review)
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/3
+
+## Context
+
+`/review-code` runs after a PR is open on GitHub. Step 1 fetches diff and
+metadata via `gh pr view` / `gh pr diff`; Step 8 persists findings to
+`progress.md` keyed by the issue number derived from the PR's "Closes #N"
+reference. Specialists 5b (governance) and 5c (plan-drift) consume the diff;
+5e (cross-model adversarial) calls `cross_model_review.sh --pr <N>`, which
+itself fetches the diff via `gh pr diff`.
+
+For Mode-2 push-when-ready, the same review needs to run *before* the PR
+exists. The minimal surface that needs to fork:
+
+- Branch-local diff source (`git diff <base>...HEAD`) instead of `gh pr diff`
+- Branch-local issue resolution (parse `feature/issue-<N>`) instead of
+  "Closes" keyword
+- A skip on the "Existing review comments" sub-step (no PR yet)
+- A second entry point on `cross_model_review.sh` (`--branch [<ref>]`)
+
+The rest of the pipeline — depth classification, specialists 5a/5b/5c/5d,
+silence filter, report format, progress.md persistence — is reused
+unchanged. This is the "one reviewer with two entry points" rescope from
+PR #157.
+
+## Approach
+
+1. **Add `--branch [<base>]` to `/review-code`.** Flag toggles branch mode;
+   optional base value resolved from `git symbolic-ref refs/remotes/origin/HEAD`
+   with a fallback to `main`. Step 1 forks: PR mode keeps `gh pr view/diff`;
+   branch mode uses `git diff <base>...HEAD` and `git diff --name-only
+   <base>...HEAD`. Issue-number resolution forks too: PR mode parses
+   "Closes #N" from the PR body; branch mode parses `feature/issue-<N>`
+   from `git branch --show-current`, with `--issue <N>` as override.
+
+2. **Specialists run unchanged.** Depth-classification signals (line count,
+   file count, override-trigger files) operate on the local diff identically.
+   5a (static), 5b (governance), 5c (plan-drift), 5d (Claude adversarial),
+   5e (cross-model) need no per-mode logic *internally* — only their inputs
+   come from a different source. 5b's "Existing review comments" sub-step
+   is the one part that's skipped in branch mode (no PR exists).
+
+3. **Add `--branch [<ref>]` to `cross_model_review.sh`.** Mutually
+   exclusive with `--pr` (hard error if both). Branch mode swaps the prompt
+   header (`Local branch <name>` instead of PR title/URL) and replaces
+   `gh pr diff` with `git diff <base>...HEAD`. Issue-number resolution
+   forks to parse `feature/issue-<N>` from the current branch; `--issue <N>`
+   override unchanged. Below the diff capture, the prompt-write,
+   agent-dispatch, findings-collection pipeline is unchanged.
+
+4. **Step 8 progress-log differentiation.** Branch mode appends
+   `## Local Review (Pre-Push)` instead of `## Local Review`, so the same
+   issue can carry both a pre-push and a post-PR review entry on its
+   timeline without one overwriting the other in summary skims.
+
+5. **Generalize `review_depth_classification.md`.** Replace "from PR
+   metadata (`gh pr view` output)" with "from diff metadata (PR or local
+   branch)". Add one paragraph noting branch-mode applicability. No tier
+   criteria change.
+
+6. **Document the modes.** Add a "Modes" sub-section near the top of
+   `SKILL.md` describing PR mode (default) and branch mode (`--branch`),
+   and update the lifecycle diagram in the Overview. Add a one-line flag
+   note to `.agent/AGENT_ONBOARDING.md`'s review-code reference.
+
+7. **Self-test.** Once branch mode is built, run `/review-code --branch`
+   against this very feature branch as the first smoke test; record the
+   run in progress.md. Findings worth fixing get a follow-up commit on
+   the same branch.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/review-code/SKILL.md` | Add "Modes" section; fork Step 1 into PR-mode and branch-mode sub-steps; mark Step 5b "Existing review comments" as PR-only; differentiate Step 8 step header for branch mode |
+| `.agent/scripts/cross_model_review.sh` | Add `--branch [<ref>]` (mutually exclusive with `--pr`); branch-mode prompt header; branch-mode diff capture via `git diff <base>...HEAD`; branch-mode issue resolution from `feature/issue-<N>` |
+| `.agent/knowledge/review_depth_classification.md` | Generalize "PR metadata" wording; add branch-mode paragraph |
+| `.agent/AGENT_ONBOARDING.md` | One-line note on the `--branch` flag |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Branch mode is opt-in via flag; report format identical to PR mode; same silence filter |
+| Capture decisions, not just implementations | This plan plus the rescoping comment on #3 capture the "two entry points, one reviewer" choice |
+| A change includes its consequences | `review-code` ↔ `review_depth_classification.md` ↔ `cross_model_review.sh` are all updated in the same PR |
+| Only what's needed | Reuses every specialist; flag-based dispatch instead of a duplicate skill |
+| Workspace improvements cascade to projects | Branch mode works for both workspace and project worktrees from day one (acceptance criterion) |
+| Primary framework first, portability where free | Skill body lives in `.claude/skills/`; `cross_model_review.sh` is portable shell |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Work happens in `worktrees/workspace/issue-workspace-3/`; branch mode itself respects worktree boundaries via the existing `_resolve_work_plans_dir.sh` |
+| 0003 — Project-agnostic workspace | Yes | Branch mode must work on both workspace and project repos (acceptance criterion); both pass a base-ref defaulting to `main` |
+| 0010 — git-bug optional | Partial | Branch mode reads local files first; `gh` only enters via the cross-model review when adversarial dispatch needs it. Graceful degradation preserved |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `review-code` skill | `review_depth_classification.md`; `cross_model_review.sh` | Yes (steps 3, 5) |
+| `review_depth_classification.md` | `review-code` skill | Yes (steps 1, 5 stay in sync) |
+| Workflow skill list | Skill list in non-Claude adapters | Partial — review-code already listed; only flag note added (step 6) |
+
+## Open Questions
+
+These are the architectural decisions worth your eyes before implement begins.
+Numbered so you can answer "1=A, 2=B, ..." or override individually.
+
+1. **Default base ref** — recommend dynamic resolution via
+   `git symbolic-ref refs/remotes/origin/HEAD`, fall back to `main`.
+   Both workspace and project default to `main` today, so this is mostly
+   future-proofing. Alternative: hardcode `main`. (Recommend dynamic.)
+
+2. **Static analysis in branch mode** — the issue body says "static analysis
+   optional — pre-commit already runs". Two reasonable defaults:
+   - **(a) On**: matches Standard tier exactly; silence filter drops
+     linter-clean files; safety net for `--no-verify` bypasses.
+   - **(b) Off, with `--with-static` opt-in**: branch mode is faster;
+     trusts pre-commit as the gate.
+   Recommend (a) — the speed delta is small and `--no-verify` does happen.
+
+3. **Issue-number resolution fallback** — when branch isn't
+   `feature/issue-<N>` and `--issue` isn't passed:
+   - **(a) Hard error** with remediation message ("pass --issue or rename
+     branch"). Strict but avoids silent artifact misrouting (the #149
+     failure mode).
+   - **(b) Soft skip**: run review without progress-log persistence.
+   Recommend (a).
+
+4. **Mutual exclusion of `--pr` and `--branch`** — recommend hard error if
+   both provided. Allowing both could mean "review the local branch in the
+   context of the existing PR" but doubles the test surface for unclear
+   benefit.
+
+5. **Self-test scope** — once branch mode is built, running it on this
+   feature branch is the obvious smoke test. Two options:
+   - **(a) Same PR**: include any minor findings in this PR. Bigger
+     findings → follow-up issue.
+   - **(b) Separate run** after merge, treat as initial dogfood.
+   Recommend (a) — fast feedback loop.
+
+## Estimated Scope
+
+Single PR, ~250 LOC across the four files. Most volume in
+`cross_model_review.sh` (arg parsing + diff path) and `SKILL.md` (mode
+sub-sections). No new tests — there is no existing test harness for
+`cross_model_review.sh`, and a parity-only addition would be out of scope
+for #3.
+
+## Implementation Notes
+
+_(populated during implement phase per skill convention)_

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -107,3 +107,43 @@ the script changes (`3ffc237`).
 
 Self-test (task 4): run the new branch mode against this very branch
 (`feature/issue-3`), triage findings, fix inline if minor.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-09 13:35
+**By**: Claude Code Agent (claude-opus-4-7) + gemini + codex (cross-model)
+**Verdict**: approved (all findings addressed inline)
+
+**Branch**: `feature/issue-3` at `cf4060b`
+**Base**: `main`
+**Depth**: Deep (reason: 724 changed lines + governance-file overrides)
+**Must-fix**: 4 | **Suggestions**: 7 | **Declined**: 2
+
+### Findings
+
+- [x] (must-fix) TARGET_LABEL referenced BRANCH_NAME before metadata block — `cross_model_review.sh:398`
+- [x] (must-fix) `--branch <ref>` didn't normalize BASE_REF when only origin/<ref> exists — `cross_model_review.sh:419`
+- [x] (must-fix) Branch-name regex matched `feature/issue-3foo` and `feature/issue-03` (silent misrouting, #149 pattern) — `cross_model_review.sh:300`
+- [x] (must-fix) tmux session name collision under `--no-progress` — `cross_model_review.sh:396`
+- [x] (suggestion) Script reference row missed `--branch`/`--no-progress` — `AGENTS.md:350`
+- [x] (suggestion) Helper swallowed bad `repo_root` errors — `_resolve_default_branch.sh:33`
+- [x] (suggestion) Helper "main fallback" error wording misleading — `_resolve_default_branch.sh:71`
+- [x] (suggestion) SKILL.md referenced undefined `BASE_ARG` — `SKILL.md:1b snippet`
+- [x] (suggestion) SKILL.md ambiguous about depth keywords passing to script — `SKILL.md:5e dispatch`
+- [x] (suggestion) `gh repo view` called in branch mode (wasted round-trip) — `cross_model_review.sh:241`
+- [x] (suggestion) `--no-progress` artifact-dir asymmetry undocumented — `cross_model_review.sh:382`
+
+### Declined
+
+- (D1) `mktemp -d` cleanup trap — users want to inspect findings after script exits; OS cleans /tmp on boot. Comment added.
+- (D2) `_resolve_default_branch.sh` `origin` assumption — consistent with workspace convention; manifest hook (#172) is the future home for repo-specific overrides.
+
+### Cross-model summary
+
+- Gemini (pre-fix): TARGET_LABEL ordering, BASE_REF normalization, mktemp trap (declined), BASE_ARG, origin assumption (declined)
+- Codex (pre-fix): TARGET_LABEL ordering, BASE_REF normalization (independent confirm of gemini)
+- Claude adversarial subagent: tmux collision, regex tightening, repo_root validation, error wording, depth-keyword passthrough, gh repo view efficiency, no-progress comment
+
+### Fix commit
+
+`cf4060b` — applied all must-fixes plus all suggestions worth fixing inline. Smoke test (`./cross_model_review.sh --branch --agent gemini`) passes clean post-fix.

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -33,3 +33,77 @@ Outcomes (see plan.md `## Decisions` for detail):
 
 Plan refined: helper file added (5 files instead of 4); flag surface
 table added; estimated scope bumped to ~300 LOC.
+
+## Implement
+**Status**: complete (pending self-test)
+**When**: 2026-05-09 12:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Five files landed across two commits (`3ffc237` script + helper,
+`9a6a40b` skill + docs).
+
+### Decisions
+
+Local choices made during implement that weren't pre-decided in the plan
+review. Skim and redirect anything that's wrong before self-test.
+
+1. **Helper function name** — `resolve_default_branch`, not
+   `resolve_default_base_ref`. Picked the user-facing semantic ("what's
+   this repo's default branch?") over the operational one. Internally
+   the function returns a ref directly usable in `git diff <ref>...HEAD`.
+
+2. **Helper return strategy** — prefers a local branch ref (`main`),
+   falls back to `origin/<branch>` if the local ref doesn't exist. Both
+   forms work as the left-hand side of `git diff ...HEAD`, so callers
+   don't need to know which form they got.
+
+3. **Manifest hook = inert comment block, not stub function** — the
+   block is marked clearly with the schema sketch but contains no code
+   today. Stub functions for inert behavior felt like over-engineering.
+   When #172's manifest schema lands, the wire-up is a few lines inside
+   the existing comment.
+
+4. **`--no-progress` artifact dir = `mktemp -d`** — when no per-issue
+   work-plans dir applies, ephemeral `/tmp` was preferred over
+   `.agent/scratchpad/` because findings in this mode are session-only
+   by intent. Scratchpad is for things you might come back to.
+
+5. **`ISSUE_NUMBER="noprogress"` sentinel** — used for SESSION_NAME and
+   findings filename construction in branch+`--no-progress` mode. Two
+   concurrent `--no-progress` runs collide on session name; tmux's
+   existing session-kill behavior handles this (newer kills older,
+   matching how PR-mode re-runs already work).
+
+6. **`TARGET_LABEL` variable** — introduced one mode-aware label
+   computed once instead of forking every status-message `printf`
+   throughout the run-review block. Keeps the sync/tmux invocation
+   blocks unchanged.
+
+7. **Branch-mode prompt header** — emits `Title / Branch / Base / HEAD`
+   instead of `Title / URL / PR Number`. The agent receives concrete
+   refs it can mentally check against, and there's no fake "PR Number"
+   to misread.
+
+8. **Step 8 entry header `## Local Review (Pre-Push)`** — chose this
+   over `## Pre-Push Review` so it sorts next to `## Local Review`
+   alphabetically and the relationship is obvious. Both can coexist on
+   one issue's timeline without overwriting.
+
+9. **Helper marked executable (`chmod +x`)** — matches the convention
+   of `_resolve_work_plans_dir.sh` (also 755) and satisfies pre-commit's
+   "shebang implies executable" rule. Helpers are still sourced, not
+   executed; the executable bit is documentation-only.
+
+### Plan correction (already committed inline)
+
+`--skip-static` was originally listed in `cross_model_review.sh`'s flag
+surface; removed during implement because that script only dispatches
+the cross-model adversarial specialist. Static analysis lives in the
+skill's Step 5a, so the flag belongs to the skill only. Plan-task
+inline-edit convention applied: plan.md updated in the same commit as
+the script changes (`3ffc237`).
+
+### What's next
+
+Self-test (task 4): run the new branch mode against this very branch
+(`feature/issue-3`), triage findings, fix inline if minor.

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -15,3 +15,21 @@ Add `--branch [<base>]` to `/review-code` and `cross_model_review.sh` so the
 existing review pipeline can run on a local branch diff before the PR exists.
 Five architectural decisions surfaced as Open Questions for approval before
 implement.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-09 11:50
+**By**: Claude Code Agent (claude-opus-4-7) + Roland
+
+Walked five architectural decisions one at a time with concrete previews.
+Outcomes (see plan.md `## Decisions` for detail):
+
+1. Default base ref: dynamic resolution via new `_resolve_default_branch.sh`
+   helper; manifest hook reserved for #172 landing.
+2. Static analysis: on by default in both modes, `--skip-static` toggle.
+3. Branch parse failure: hard error + `--no-progress` opt-in.
+4. `--pr` + `--branch`: mutually exclusive.
+5. Self-test: same PR.
+
+Plan refined: helper file added (5 files instead of 4); flag surface
+table added; estimated scope bumped to ~300 LOC.

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -147,3 +147,16 @@ Self-test (task 4): run the new branch mode against this very branch
 ### Fix commit
 
 `cf4060b` — applied all must-fixes plus all suggestions worth fixing inline. Smoke test (`./cross_model_review.sh --branch --agent gemini`) passes clean post-fix.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-09 14:05
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #185 — 1 review (Copilot bot) at `b54597a`, 2 inline comments, 2 valid, 0 false positives
+**CI**: all 8 checks pass
+
+### Actions
+- [ ] Fix `_resolve_default_branch.sh:63-65` — replace pipeline with two-step capture so `set -e + pipefail` callers don't abort before the `main` fallback when `origin/HEAD` is unset. (Self-test missed this because the workspace repo has origin/HEAD set.)
+- [ ] Fix `SKILL.md:87` — clarify that `$BASE_REF_FROM_USER` in the branch-mode snippet is a placeholder for the `--branch` arg value.
+- [ ] (Optional) Dismiss the Copilot review on PR after fixes land.

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -157,6 +157,6 @@ Self-test (task 4): run the new branch mode against this very branch
 **CI**: all 8 checks pass
 
 ### Actions
-- [ ] Fix `_resolve_default_branch.sh:63-65` — replace pipeline with two-step capture so `set -e + pipefail` callers don't abort before the `main` fallback when `origin/HEAD` is unset. (Self-test missed this because the workspace repo has origin/HEAD set.)
-- [ ] Fix `SKILL.md:87` — clarify that `$BASE_REF_FROM_USER` in the branch-mode snippet is a placeholder for the `--branch` arg value.
-- [ ] (Optional) Dismiss the Copilot review on PR after fixes land.
+- [x] Fix `_resolve_default_branch.sh:63-65` — replace pipeline with two-step capture so `set -e + pipefail` callers don't abort before the `main` fallback when `origin/HEAD` is unset. (`944243c`)
+- [x] Fix `SKILL.md:87` — clarify that `$BASE_REF_FROM_USER` in the branch-mode snippet is a placeholder for the `--branch` arg value. (`944243c`)
+- [ ] (Optional) Dismiss the Copilot review on PR after CI confirms fixes; merge once green.

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 3
+---
+
+# Issue #3 — Add branch mode to /review-code (local pre-push self-review)
+
+## Plan
+**Status**: complete
+**When**: 2026-05-09 11:44
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Plan file: `.agent/work-plans/issue-3/plan.md`.
+
+Add `--branch [<base>]` to `/review-code` and `cross_model_review.sh` so the
+existing review pipeline can run on a local branch diff before the PR exists.
+Five architectural decisions surfaced as Open Questions for approval before
+implement.

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -80,11 +80,15 @@ gh pr view <N> --json body --jq '.body' | grep -o '#[0-9]*'
 #### 1b. Branch mode (--branch [<base-ref>])
 
 ```bash
-# Resolve base ref. Explicit arg wins; otherwise the helper consults
-# the per-project manifest (when wired — see #172), falls back to
-# `git symbolic-ref refs/remotes/origin/HEAD`, then `main`.
+# Resolve base ref. Explicit `--branch <base>` arg wins; otherwise
+# the helper consults the per-project manifest (when wired — see #172),
+# falls back to `git symbolic-ref refs/remotes/origin/HEAD`, then `main`.
 source .agent/scripts/_resolve_default_branch.sh
-BASE="${BASE_ARG:-$(resolve_default_branch)}"
+if [[ -n "$BASE_REF_FROM_USER" ]]; then
+    BASE="$BASE_REF_FROM_USER"
+else
+    BASE=$(resolve_default_branch)
+fi
 
 # Branch metadata
 BRANCH=$(git branch --show-current)
@@ -313,6 +317,11 @@ Pass `--repo <owner/repo>` (PR mode) when the PR lives in a different repo
 than the current working directory (e.g., reviewing a project PR from the
 workspace tree). Pass `--work-dir <path>` to place artifacts in a specific
 worktree instead of the current `git rev-parse --show-toplevel`.
+
+**Depth keywords are skill-level only.** `cross_model_review.sh` itself
+does not parse `light`/`standard`/`deep` — those control which
+specialists this skill dispatches. Passing them to the script will
+trigger an "Unknown argument" error.
 
 The script auto-detects the execution mode: tmux (background) when available,
 sync (blocking) when tmux is unavailable or in sandboxed environments. Use

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -79,11 +79,17 @@ gh pr view <N> --json body --jq '.body' | grep -o '#[0-9]*'
 
 #### 1b. Branch mode (--branch [<base-ref>])
 
+This snippet is illustrative pseudo-code; the skill body describes
+behavior, not a copy-pastable shell block. `$BASE_REF_FROM_USER` is a
+placeholder for whatever value the user passed to `--branch <base>`
+(empty string when `--branch` was passed bare).
+
 ```bash
 # Resolve base ref. Explicit `--branch <base>` arg wins; otherwise
 # the helper consults the per-project manifest (when wired — see #172),
 # falls back to `git symbolic-ref refs/remotes/origin/HEAD`, then `main`.
 source .agent/scripts/_resolve_default_branch.sh
+BASE_REF_FROM_USER=""  # set to `--branch` arg value if user passed one
 if [[ -n "$BASE_REF_FROM_USER" ]]; then
     BASE="$BASE_REF_FROM_USER"
 else

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -8,14 +8,36 @@ description: Lead reviewer that orchestrates specialist sub-reviews (static anal
 ## Usage
 
 ```
-/review-code <pr-number-or-url> [light|standard|deep]
+# PR mode (default — review an open PR)
+/review-code <pr-number-or-url> [light|standard|deep] [--skip-static]
+
+# Branch mode (local pre-push self-review)
+/review-code --branch [<base-ref>] [--issue <N>] [--no-progress] [--skip-static] [light|standard|deep]
 ```
 
-Optional depth keyword overrides automatic classification.
+Optional depth keyword overrides automatic classification. `--skip-static`
+suppresses the static-analysis specialist in either mode (useful when
+pre-commit was clean). `--no-progress` (branch mode only) skips the
+progress.md persistence step — used for skill worktrees and one-off
+branches that don't have an issue to track against.
 
 ## Overview
 
-**Lifecycle position**: review-issue → plan-task → review-plan → implement → **review-code**
+**Lifecycle position**:
+
+```
+review-issue → plan-task → review-plan → implement
+   → review-code --branch  (local pre-push self-review)
+   → push
+   → review-code (PR mode)
+   → triage-reviews
+```
+
+The two `review-code` entry points share specialists, depth classification,
+the silence filter, and the report format. They differ only in where the
+diff and metadata come from (local git vs. open PR) and whether the
+"Existing review comments" sub-step runs (no PR comments to fetch
+pre-push).
 
 Multi-specialist code review system. A lead reviewer gathers context,
 classifies review depth based on change risk, dispatches specialist
@@ -37,7 +59,12 @@ modify the PR unless the user asks.
 
 ## Steps
 
-### 1. Gather PR context
+### 1. Gather review context
+
+The two modes draw their inputs from different sources. Pick the
+sub-step that matches the invocation.
+
+#### 1a. PR mode (default)
 
 ```bash
 # PR metadata
@@ -50,11 +77,35 @@ gh pr diff <N>
 gh pr view <N> --json body --jq '.body' | grep -o '#[0-9]*'
 ```
 
-Identify:
-- What repo the PR targets (workspace or project repo?)
+#### 1b. Branch mode (--branch [<base-ref>])
+
+```bash
+# Resolve base ref. Explicit arg wins; otherwise the helper consults
+# the per-project manifest (when wired — see #172), falls back to
+# `git symbolic-ref refs/remotes/origin/HEAD`, then `main`.
+source .agent/scripts/_resolve_default_branch.sh
+BASE="${BASE_ARG:-$(resolve_default_branch)}"
+
+# Branch metadata
+BRANCH=$(git branch --show-current)
+HEAD_SHA=$(git rev-parse --short HEAD)
+
+# Files and diff
+git diff --name-only "$BASE"...HEAD
+git diff "$BASE"...HEAD
+
+# Linked issue: parse `feature/issue-<N>` or `feature/ISSUE-<N>-<desc>`
+# from the branch name. `--issue <N>` overrides; `--no-progress`
+# opts out of progress.md persistence for skill worktrees / one-off
+# branches. If neither resolves and `--no-progress` not passed, hard
+# error with remediation.
+```
+
+Identify (both modes):
+- What repo this affects (workspace or project)
 - What files changed and in which directories
-- The linked issue and its requirements
-- Whether a work plan exists (`.agent/work-plans/issue-*/plan.md` in the PR's target repo)
+- The linked issue and its requirements (or `--no-progress` if no issue applies)
+- Whether a work plan exists (`.agent/work-plans/issue-*/plan.md`)
 
 Read the **full content** of each changed file (not just the diff hunks) to
 understand surrounding context.
@@ -153,6 +204,13 @@ Report each finding as:
 - File, line number, tool name, message
 - Skip findings on lines not touched by this PR (context-only lines)
 
+**`--skip-static` flag** (both modes): skip this specialist entirely.
+Useful when pre-commit was clean and the user wants a faster review, or
+when the user has already run linters separately. Note that skipping
+this at Light tier leaves the review with no specialists; the silence
+filter will produce the "No findings" output, which is the documented
+behavior.
+
 #### 5b. Governance Specialist
 
 Load governance context:
@@ -179,14 +237,15 @@ For each: does the PR comply with the key requirement?
 something in the "If you change..." column. Are the corresponding "Also update..."
 items addressed? Mark each as Done or Missing.
 
-**Existing review comments**: Check for unresolved human and bot comments:
+**Existing review comments** (PR mode only): Check for unresolved human
+and bot comments:
 
 ```bash
 .agent/scripts/fetch_pr_reviews.sh --pr <N>
 ```
 
 Note unresolved human comments (high priority), valid bot findings, and false
-positives.
+positives. Skip this sub-step in branch mode — there's no PR yet.
 
 #### 5c. Plan Drift Specialist
 
@@ -234,20 +293,26 @@ keys used by the script: `claude-code` → `claude`, `gemini-cli` → `gemini`,
 `codex-cli` → `codex`, `copilot-cli` → `copilot`. The canonical keys are:
 `gemini`, `codex`, `claude`, `copilot`.
 
-For each non-caller agent, launch the cross-model review script:
+For each non-caller agent, launch the cross-model review script. Use
+`--pr <N>` in PR mode and `--branch [<ref>]` in branch mode (mutually
+exclusive — passing both is a hard error).
 
 ```bash
-# Example: Claude is the caller, dispatch gemini, codex, and copilot
-# Use --repo when the PR is in a different repo than the current directory
+# PR mode — example: Claude is the caller, dispatch gemini, codex, copilot
 .agent/scripts/cross_model_review.sh --pr <N> --agent gemini --repo owner/repo
 .agent/scripts/cross_model_review.sh --pr <N> --agent codex --repo owner/repo
 .agent/scripts/cross_model_review.sh --pr <N> --agent copilot --repo owner/repo
+
+# Branch mode — runs locally, no --repo needed in most cases
+.agent/scripts/cross_model_review.sh --branch --agent gemini
+.agent/scripts/cross_model_review.sh --branch <base> --agent codex
+.agent/scripts/cross_model_review.sh --branch --agent copilot --no-progress  # skill worktrees
 ```
 
-Pass `--repo <owner/repo>` when the PR lives in a different repo than the
-current working directory (e.g., reviewing a project PR from the workspace
-tree). Pass `--work-dir <path>` to place artifacts in a specific worktree
-instead of the current `git rev-parse --show-toplevel`.
+Pass `--repo <owner/repo>` (PR mode) when the PR lives in a different repo
+than the current working directory (e.g., reviewing a project PR from the
+workspace tree). Pass `--work-dir <path>` to place artifacts in a specific
+worktree instead of the current `git rev-parse --show-toplevel`.
 
 The script auto-detects the execution mode: tmux (background) when available,
 sync (blocking) when tmux is unavailable or in sandboxed environments. Use
@@ -286,6 +351,8 @@ Collect all findings from all dispatched specialists and filter:
 
 ### 7. Produce the report
 
+PR-mode header:
+
 ```markdown
 ## Code Review: #<N> — <title>
 
@@ -295,6 +362,31 @@ Collect all findings from all dispatched specialists and filter:
 **Files changed**: <count> (+<additions> -<deletions>)
 **Review depth**: <Light|Standard|Deep> (reason: <primary signal>)
 **Context**: <status of review-context.yaml — fresh / stale / not found>
+```
+
+Branch-mode header (replace **PR** with **Branch**/**Base**, and the
+title-line PR number with the branch name):
+
+```markdown
+## Code Review (Pre-Push): <branch-name>
+
+**Branch**: <branch-name> at `<short-sha>`
+**Base**: <base-ref>
+**Issue**: #<issue> — <issue-title>  <!-- or "Skipped (--no-progress)" -->
+**Repo**: workspace | <project-repo>
+**Files changed**: <count> (+<additions> -<deletions>)
+**Review depth**: <Light|Standard|Deep> (reason: <primary signal>)
+**Context**: <status of review-context.yaml — fresh / stale / not found>
+```
+
+The body sections (Must-Fix, Suggestions, Governance, Plan Adherence,
+Cross-Model Reviews, Existing Review Comments, Summary, Recommended
+Actions) are identical between modes — except **Existing Review Comments**
+is omitted in branch mode (no PR yet).
+
+PR-mode template body:
+
+```markdown
 
 ### Must-Fix
 
@@ -374,10 +466,20 @@ No governance concerns for a change of this scope.
 No issues found. LGTM.
 ```
 
+**Branch-mode equivalents**: for both the Light condensed and No-findings
+formats, swap the title line for `## Code Review (Pre-Push): <branch-name>`
+and replace the `**PR**: <url>` line with
+`**Branch**: <name> at <sha>` and `**Base**: <base-ref>`. Other content
+unchanged.
+
 ### 8. Persist review summary to progress file
 
-After outputting the report to the conversation, append a "Local Review"
-step to `progress.md` so findings persist across sessions.
+After outputting the report to the conversation, append a review-step
+entry to `progress.md` so findings persist across sessions.
+
+**Skip this entire step** if branch mode was invoked with
+`--no-progress` — that flag explicitly opts out of progress.md writes
+(skill worktrees and one-off branches without an issue context).
 
 **Locate or create progress.md**: Use the issue number resolved in step 1.
 Determine which repo owns the linked issue (workspace repo for workspace
@@ -397,17 +499,23 @@ issue: <issue>
 # Issue #<issue> — <issue title>
 ```
 
-Append this step entry:
+Append this step entry. Use `## Local Review` for PR mode and
+`## Local Review (Pre-Push)` for branch mode so the same issue can carry
+both a pre-push and a post-PR entry on its timeline without one
+overwriting the other:
 
 ```markdown
 
-## Local Review
+## Local Review              <!-- PR mode -->
+## Local Review (Pre-Push)   <!-- branch mode -->
 **Status**: complete
 **When**: <YYYY-MM-DD HH:MM>
 **By**: <agent name> (<model>)
 **Verdict**: <approved|changes-requested>
 
-**PR**: #<N> at `<short-sha>`
+**PR**: #<N> at `<short-sha>`        <!-- PR mode -->
+**Branch**: <name> at `<short-sha>`  <!-- branch mode -->
+**Base**: <base-ref>                 <!-- branch mode -->
 **Depth**: <tier> (reason: <signal>)
 **Must-fix**: <count> | **Suggestions**: <count>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,7 @@ Scripts marked **(source)** must be sourced; all others should be executed.
 | `.agent/scripts/validate_workspace.py` | Validate project/ configuration |
 | `.agent/scripts/detect_agent_identity.sh` | Auto-detect agent framework + model |
 | `.agent/scripts/fetch_pr_reviews.sh` | Fetch all PR reviews and CI status |
-| `.agent/scripts/cross_model_review.sh` | Cross-model adversarial review (`--repo`, `--work-dir` for cross-repo use) |
+| `.agent/scripts/cross_model_review.sh` | Cross-model adversarial review for a PR (`--pr <N>`) or local branch (`--branch [<ref>]`); `--no-progress` for skill worktrees; `--repo`, `--work-dir` for cross-repo use |
 
 ## References (Read When Needed, Not Upfront)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,7 +93,7 @@ would flag, PRs pass on first try.
 | AI slop detection in design review | #61 | done | gstack | Check for generic AI patterns (hero sections, card grids, stock imagery) |
 | Diff-aware test targeting | #53 | done | gstack | Map git diff to affected test targets, focus QA on what changed |
 | Two-mode push policy | — | planned | 2026-04-19 session | Mode 1 push-early vs Mode 2 push-when-ready; doc change + `unpushed_branches.sh` helper |
-| Add branch mode to /review-code | #3 | planned | 2026-04-19 session | Pre-push local review via `/review-code --branch <ref>`; `cross_model_review.sh --branch` too. Subsumes prior "review-branch skill" scope of #3. Must work for workspace AND project from day one |
+| Add branch mode to /review-code | #3 | done | 2026-04-19 session | Pre-push local review via `/review-code --branch <ref>`; `cross_model_review.sh --branch` too. Subsumes prior "review-branch skill" scope of #3. Must work for workspace AND project from day one |
 | Feed shell-surface misses back into /review-code | — | planned | 2026-04-19 session | Specific patterns: echo-concat (bash -n accepts), `set -u` + `$1` before check, flag-as-value parsing, gh-failure fall-through. Formalize the Copilot-miss capture loop |
 | Flag script/skill changes without tests | #136 | planned | — | review-code enhancement |
 | Verification-before-completion skill | #29 | planned | superpowers | Observable verification before marking tasks done |


### PR DESCRIPTION
Closes #3

## Summary

Adds branch mode to `/review-code` so the existing review pipeline can run on a local branch diff before the PR exists. PR mode unchanged. One reviewer with two entry points (per the rescoping decision recorded on the issue):

- `/review-code <pr-number>` — post-push review of an open PR (existing behavior)
- `/review-code --branch [<base-ref>]` — local pre-push self-review against a base ref

Both modes share specialists (static, governance, plan-drift, Claude adversarial, cross-model adversarial), depth classification, silence filter, report format, and progress.md persistence. They differ only in diff source (`git diff` vs `gh pr diff`), issue-number resolution (branch name vs `Closes` keyword), and the "existing review comments" sub-step (skipped pre-push).

## What's in this PR

- **New** `.agent/scripts/_resolve_default_branch.sh` — sourced helper. Resolution order: per-project manifest hook (inert today; comment-marked for #172) -> `git symbolic-ref refs/remotes/origin/HEAD` -> `main`. Validates the resolved ref is reachable, normalizing to `origin/<branch>` if local is absent.
- **`.agent/scripts/cross_model_review.sh`** — `--branch [<ref>]` (mutually exclusive with `--pr`), `--no-progress` (skill worktrees / one-off branches). Branch-mode prompt header swaps `Title/URL/PR Number` for `Title/Branch/Base/HEAD`. Branch-mode diff via `git diff <base>...HEAD`. Issue-number resolution from a tightened `^feature/[Ii][Ss][Ss][Uu][Ee]-([1-9][0-9]*)(-|$)` regex.
- **`.claude/skills/review-code/SKILL.md`** — Modes section, Step 1 forked into PR/branch sub-steps, Step 5b "Existing review comments" marked PR-only, Step 8 progress header differentiated (`## Local Review (Pre-Push)` vs `## Local Review`), `--skip-static` and `--no-progress` documented.
- **`.agent/knowledge/review_depth_classification.md`** — generalized "PR metadata" -> "diff metadata (PR or branch)"; branch-mode invocations under User Override.
- **`.agent/AGENT_ONBOARDING.md`** + **`AGENTS.md`** — one-line note about the two modes; script reference row mentions `--branch` / `--no-progress`.

## Architectural decisions captured during planning

1. Default base ref: dynamic via new helper; manifest hook reserved for #172.
2. Static analysis: on by default in both modes; `--skip-static` toggles either.
3. Branch parse failure: hard error with `--no-progress` opt-in (matches #72/#147/#149 strictness pattern).
4. `--pr` + `--branch`: mutually exclusive.
5. Self-test: same PR.

Plan + decision logs in `.agent/work-plans/issue-3/`.

## Self-test outcomes

Self-test (Deep tier; gemini + codex + Claude adversarial subagent in parallel) caught two real bugs that would have shipped:

- **`set -u` immediate abort under `--branch`**: `TARGET_LABEL` referenced `BRANCH_NAME` before metadata gather. (`cf4060b`)
- **Unusable base on remote-only refs**: `--branch <ref>` validated `origin/<ref>` but didn't normalize `BASE_REF`. (`cf4060b`)

Plus regex tightening (`feature/issue-3foo` -> silent capture of `3`; `feature/issue-03` -> leading-zero misroute) promoted to must-fix per the #149 lesson, and tmux session-name collision under `--no-progress`. Seven additional doc/clarity findings addressed inline.

Full review log: `progress.md` under `## Local Review (Pre-Push)`. Verdict: approved.

## Test plan

- [x] Pre-commit hooks pass (shellcheck, others) on every commit
- [x] Smoke test: `cross_model_review.sh --branch --agent gemini` runs end-to-end clean post-fix
- [x] Regex edge cases verified — `feature/issue-3foo`, `feature/issue-03`, `feature/issuelabs-3` rejected; `feature/issue-3-fix`, `feature/ISSUE-3-foo` accepted
- [ ] Once merged, first real downstream exercise on the next workspace PR

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`