### PR TITLE
Replace gh pr checks --watch busy-poll with native Monitor in merge flows

### DIFF
--- a/.agent/knowledge/agent_wait_patterns.md
+++ b/.agent/knowledge/agent_wait_patterns.md
@@ -1,0 +1,74 @@
+# Agent Wait Patterns
+
+How agent flows should wait for external events (CI completion, tmux
+session exit, background subagent finish, file appearance, network
+service ready). Different mechanisms suit different contexts; pick the
+one that matches the caller's framework.
+
+## When to use `Monitor`
+
+`Monitor` is a Claude Code SDK tool that streams events from a
+background process — each line on stdout becomes a notification, and
+the wait completes when the process exits. It's event-driven from the
+agent's perspective, not a busy-poll.
+
+**Use `Monitor` when:**
+
+- The caller is a **Claude Code agent** (not a shell script, not a
+  Codex/Gemini/Copilot session) — `Monitor` is a tool, not a CLI, so
+  only Claude Code can invoke it.
+- The wait is for a **bounded external event** that produces output as
+  it progresses (CI checks, build runs, test runs, agent dispatch).
+- You want the wait to not consume in-context tokens while idle —
+  `Monitor` notifies on activity, so the agent doesn't have to
+  re-prompt itself periodically.
+
+**Concrete example** — waiting for CI on a just-pushed commit during a
+triage-fix-merge cycle:
+
+```
+# Bash, run in background
+gh pr checks <N> --watch --fail-fast
+
+# Then in the agent flow, instead of busy-poll:
+Monitor(processId=<bg-id>)
+# returns when gh exits; non-zero exit = check failed; abort the merge
+```
+
+## When to fall back to busy-poll
+
+`gh pr checks --watch` (or any other foreground blocking call) is the
+right choice in:
+
+- **Shell scripts.** `merge_pr.sh`, `cross_model_review.sh`, anything
+  bash. `Monitor` is a Claude Code tool; bash can't call it. The
+  blocking `--watch` form works for every framework.
+- **Sandboxed / non-interactive environments.** CI runs, automated
+  pipelines, anything where there's no Claude Code session to use
+  `Monitor` from.
+- **Other agent frameworks.** Codex, Gemini, Copilot sessions calling
+  the same workspace scripts use the busy-poll path. The script-level
+  wait works for them transparently.
+
+## Decision quick-reference
+
+| Caller | Recommended wait |
+|--------|------------------|
+| Claude Code agent (interactive) | `Monitor` over a background `gh pr checks --watch` (or similar) |
+| `merge_pr.sh` (bash) | `gh pr checks --watch --fail-fast` directly |
+| `cross_model_review.sh` polling tmux session output | tmux session-status check (existing busy-poll, OK as-is) |
+| Codex / Gemini agents calling workspace scripts | The script's bash busy-poll fires for them automatically |
+| CI / sandboxed pipeline | The script's bash busy-poll fires for them automatically |
+
+## See also
+
+- `.agent/scripts/merge_pr.sh` — uses `gh pr checks --watch --fail-fast`
+  internally; works for every caller (issue #186)
+- `.agent/scripts/cross_model_review.sh` — the tmux session approach
+  for cross-model adversarial dispatch; busy-poll on session status is
+  fine since it's tmux-internal
+- Workspace ROADMAP "Reduce Agent Coordination Overhead" — broader
+  context for the wait/event-driven theme
+- Issue #187 — Routines + GitHub triggers spike; if Routines lands, some
+  of these wait patterns get replaced by event-driven Routines fired by
+  GitHub events instead of polled by the caller

--- a/.agent/scripts/merge_pr.sh
+++ b/.agent/scripts/merge_pr.sh
@@ -16,10 +16,26 @@
 #
 # Steps:
 #   1. Roadmap update (commit + push to feature branch before merge)
-#   2. Merge the PR (--merge strategy)
-#   3. Remove the worktree (cd to root first; fails safely if uncommitted changes)
-#   4. Delete local and remote branches
-#   5. Pull main to sync (workspace and project repos)
+#   2. Wait for CI on the (possibly new) HEAD before merging (--no-wait skips)
+#   3. Merge the PR (--merge strategy)
+#   4. Remove the worktree (cd to root first; fails safely if uncommitted changes)
+#   5. Delete local and remote branches
+#   6. Pull main to sync (workspace and project repos)
+#
+# Manual verification of the wait step (issue #186):
+#   1. On any open PR branch in this repo, push a trivial commit:
+#        git commit --allow-empty -m "poke ci"
+#        git push
+#   2. Immediately run:
+#        make merge-pr PR=<N>
+#   3. Expected: script prints "Waiting for CI..." and blocks until checks
+#      complete, then merges.
+#   4. Without the wait step (pre-#186), step 2 would have errored
+#      "Pull Request is not mergeable" instantly.
+#
+#   An automated equivalent would need to mock gh pr checks --watch
+#   (drift risk) or spin throwaway PRs (network + auth dependencies);
+#   declined as out of scope for #186.
 #
 # Exit codes:
 #   0 — success
@@ -36,6 +52,9 @@ source "$SCRIPT_DIR/_issue_helpers.sh"
 PR_NUMBER=""
 WORKTREE_TYPE=""
 NO_ROADMAP_UPDATE=false
+NO_WAIT=false
+
+USAGE="Usage: $0 --pr <N> [--type workspace|project] [--no-roadmap-update] [--no-wait]"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -47,16 +66,18 @@ while [[ $# -gt 0 ]]; do
             WORKTREE_TYPE="$2"; shift 2 ;;
         --no-roadmap-update)
             NO_ROADMAP_UPDATE=true; shift ;;
+        --no-wait)
+            NO_WAIT=true; shift ;;
         *)
             echo "ERROR: Unknown argument: $1" >&2
-            echo "Usage: $0 --pr <N> [--type workspace|project] [--no-roadmap-update]" >&2
+            echo "$USAGE" >&2
             exit 2 ;;
     esac
 done
 
 if [[ -z "$PR_NUMBER" ]]; then
     echo "ERROR: --pr <N> is required" >&2
-    echo "Usage: $0 --pr <N> [--type workspace|project] [--no-roadmap-update]" >&2
+    echo "$USAGE" >&2
     exit 2
 fi
 
@@ -315,7 +336,35 @@ else
     echo "  Roadmap update skipped (--no-roadmap-update)"
 fi
 
-# --- Step 2: Merge ---
+# --- Step 2: Wait for CI ---
+# When the roadmap-update step pushes a fresh commit, the new commit's
+# CI hasn't started yet — `gh pr merge` below would fail with
+# "Pull Request is not mergeable" until checks complete. Avoid the
+# manual `gh pr checks --watch` round-trip by waiting here. --no-wait
+# skips when the user knows CI is already green.
+#
+# `--fail-fast` exits as soon as any check fails (gh exit 8) so we
+# don't waste time waiting for the rest. The error path captures gh's
+# exit code, surfaces the PR URL, and aborts the merge with context.
+if [[ "$NO_WAIT" == false ]]; then
+    echo "  Waiting for CI..."
+    if gh pr checks "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --watch --fail-fast; then
+        echo "  ✅ CI checks passed"
+    else
+        _wait_rc=$?
+        _pr_url=$(gh pr view "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --json url --jq '.url' 2>/dev/null || echo "")
+        {
+            echo "ERROR: CI checks failed (gh exit $_wait_rc)"
+            [[ -n "$_pr_url" ]] && echo "  See: $_pr_url"
+            echo "  Fix the failure and re-run, or pass --no-wait to skip the CI wait."
+        } >&2
+        exit 1
+    fi
+else
+    echo "  CI wait skipped (--no-wait)"
+fi
+
+# --- Step 3: Merge ---
 # GH_REPO_ARGS was set during PR resolution above (-R <project-remote> for
 # project PRs, empty for workspace PRs). Don't re-resolve.
 echo "  Merging PR..."
@@ -325,7 +374,7 @@ if ! gh pr merge "$PR_NUMBER" "${GH_REPO_ARGS[@]}" --merge; then
 fi
 echo "  ✅ PR merged"
 
-# --- Step 3: Remove worktree ---
+# --- Step 4: Remove worktree ---
 if [[ -n "$WORKTREE_TYPE" ]]; then
     echo "  Removing worktree..."
     # Must run from root, not from inside the worktree
@@ -337,7 +386,7 @@ if [[ -n "$WORKTREE_TYPE" ]]; then
     fi
 fi
 
-# --- Step 4: Delete branches ---
+# --- Step 5: Delete branches ---
 echo "  Cleaning up branches..."
 # Use [[ -e ]] (not [[ -d ]]) to handle submodule layouts where project/.git
 # is a file containing `gitdir:` rather than a directory.
@@ -349,7 +398,7 @@ fi
 git -C "$BRANCH_REPO" branch -d "$PR_BRANCH" 2>/dev/null && echo "  ✅ Local branch deleted" || true
 git -C "$BRANCH_REPO" push origin --delete "$PR_BRANCH" 2>/dev/null && echo "  ✅ Remote branch deleted" || true
 
-# --- Step 5: Sync ---
+# --- Step 6: Sync ---
 echo "  Syncing main..."
 git pull --ff-only
 echo "  ✅ Workspace synced"

--- a/.agent/work-plans/issue-186/plan.md
+++ b/.agent/work-plans/issue-186/plan.md
@@ -1,0 +1,158 @@
+# Plan: Replace gh pr checks --watch busy-poll with native Monitor in merge flows
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/186
+
+## Context
+
+The friction the issue targets — having to manually `gh pr checks --watch`
+twice per merge cycle — shows up in two distinct surfaces:
+
+**Surface 1 (script-internal):** `merge_pr.sh` pushes a roadmap-update
+commit (line 306) and *immediately* attempts `gh pr merge` (line 322), with
+no wait step in between. CI on the roadmap commit hasn't completed →
+`Pull Request is not mergeable` → user runs `gh pr checks --watch` manually
+→ retries `make merge-pr`. Hit twice in this session (PRs #185 and #182).
+
+**Surface 2 (agent-side):** During triage-fix-merge cycles, agents (this
+session, today) ran `gh pr checks --watch` directly between fix-push and
+merge-retry — pure busy-poll in the agent's bash flow.
+
+**Architectural note that re-shapes the plan:** `Monitor` is a Claude Code
+SDK *tool*, not a CLI. It cannot be invoked from `merge_pr.sh` (or any
+shell). So "Monitor adoption" lives only on Surface 2 (agent-side), not
+Surface 1 (script-side). Surface 1 still needs a fix — but it's a plain
+bash `gh pr checks --watch` insertion, not a `Monitor` adoption. The two
+surfaces merit different mechanisms.
+
+## Approach
+
+1. **Surface 1 — `merge_pr.sh`: add internal wait between roadmap push and
+   merge attempt.** Insert a `gh pr checks --watch` (likely `--fail-fast`)
+   call immediately after the roadmap commit's `git push` succeeds. This
+   is bash; works for *any* caller (manual, Claude Code, Codex, Gemini,
+   sandboxed CI). Removes the "manual second invocation" pain entirely.
+   Add a `--no-wait` flag to skip when the user knows CI is already green.
+
+2. **Surface 2 — knowledge doc for the agent-side Monitor pattern.** New
+   `.agent/knowledge/agent_wait_patterns.md` (or similar) describing when
+   to use `Monitor` (Claude Code agents waiting for external events: CI,
+   tmux sessions, background subagents) vs busy-poll fallback (other
+   frameworks, scripts). Concrete examples for the common cases. No code
+   change in this surface — just guidance for future agent flows.
+
+3. **Smoke test for the script-side wait.** Add a script (probably
+   `.agent/scripts/test_merge_pr_wait.sh` or a bats-style file) that
+   verifies the wait step actually fires. If end-to-end automation is
+   awkward (needs a live PR + gh auth), document manual verification as a
+   procedure in the script's header comment per acceptance criterion 4 of
+   the issue.
+
+4. **Documentation cascade.** Update `AGENTS.md` script-reference table
+   row for `merge_pr.sh` (last touched in PR #185 for `cross_model_review.sh`'s
+   `--branch`/`--no-progress`; now needs an addendum). Update the script's
+   header comment block. Cross-reference the new knowledge doc.
+
+5. **Framework-adapter check.** Per the issue's framework-portability
+   acceptance criterion: `merge_pr.sh`'s wait works for all frameworks
+   transparently (it's bash). Adapter files (`CODEX.md`,
+   `.agent/instructions/gemini-cli.instructions.md`,
+   `.github/copilot-instructions.md`) probably need no change since the
+   bash flow is identical. Verify by grep; add notes only if any adapter
+   describes the merge flow in detail today.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.agent/scripts/merge_pr.sh` | Add wait-for-CI step after the roadmap push (~line 308) and before the merge attempt (~line 322); add `--no-wait` flag; update header comment |
+| `.agent/knowledge/agent_wait_patterns.md` (new) | Document Monitor-vs-busy-poll pattern for agent flows; reference from `merge_pr.sh` and `cross_model_review.sh` indirectly via see-also |
+| `AGENTS.md` | Update `merge_pr.sh` script-reference row to mention wait behaviour and `--no-wait` |
+| `.agent/scripts/test_merge_pr_wait.sh` (new, optional) | Smoke test for the wait path; if full automation isn't feasible, fall back to a documented manual-verification procedure in `merge_pr.sh`'s header |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Script wait step prints status (`Waiting for CI on roadmap commit...`); user sees what's being awaited |
+| Capture decisions, not just implementations | This plan's Open Questions captures the Surface-1 vs Surface-2 split |
+| A change includes its consequences | Script + AGENTS.md script-reference + knowledge doc updated together |
+| Only what's needed | Minimal merge_pr.sh diff (~10 LOC); knowledge doc is short pattern reference |
+| Test what breaks | Smoke test in scope (acceptance criterion 4 of the issue); manual verification fallback if needed |
+| Workspace vs project separation | Workspace-only |
+| Workspace improvements cascade | `merge_pr.sh` works for both repo types unchanged; wait benefits both |
+| Primary framework first, portability where free | Script-side bash works everywhere; agent-side `Monitor` is Claude-Code-only with documented busy-poll fallback (matches issue's framework-portability AC) |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Working in `worktrees/workspace/issue-workspace-186/` |
+| 0003 — Project-agnostic workspace | Yes | Workspace-only change |
+| 0006 — Shared AGENTS.md | Yes | AGENTS.md row updated; framework adapters checked for cross-references (likely no-op) |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `merge_pr.sh` | `AGENTS.md` script-reference table | Yes (file 3) |
+| Add a new knowledge doc | (standalone reference; no cascading deps) | Yes (file 2) |
+
+## Open Questions
+
+These are the architectural decisions worth your eyes before implement.
+Numbered so you can answer "1=A, 2=B, ..." or override individually.
+
+1. **Surface-1 vs Surface-2 vs both.** Three options:
+   - **(a) Both** (Recommended): script-side `gh pr checks --watch` in
+     `merge_pr.sh` *plus* agent-side knowledge doc for the `Monitor` pattern.
+     Script fix solves today's pain immediately for everyone; knowledge doc
+     captures the pattern for future agent-flow uses (without requiring a
+     code change to consume it).
+   - **(b) Script-side only**: just add the wait to `merge_pr.sh`. Simpler
+     PR; defer the agent-side `Monitor` knowledge doc until a concrete
+     agent-flow use case appears.
+   - **(c) Agent-side only**: no script change; build a `/merge-pr`
+     slash command that wraps `merge_pr.sh` and uses `Monitor` for the
+     wait. Larger architectural change; `merge_pr.sh` stays wait-less for
+     non-Claude agents (still the manual-second-invocation pain for them).
+
+   Option **(a)** matches the issue's scope ("merge flows" + framework
+   portability), gives the immediate win, and leaves room for follow-up.
+
+2. **Wait timeout / fail-fast behaviour.** `gh pr checks --watch` defaults
+   to "wait forever". Three reasonable choices for the script:
+   - **(a) `--fail-fast`** (Recommended): exits on first failed check;
+     the script then aborts the merge with a useful error pointing at the
+     failed check. Saves time on busted CI runs.
+   - **(b) Plain `--watch`**: wait until all checks complete, then merge
+     if green or fail with a generic error if not.
+   - **(c) Wrapped in `timeout`**: e.g. `timeout 10m gh pr checks --watch`.
+     Defends against runaway CI but introduces another knob.
+
+3. **Smoke-test feasibility.** The wait path is hard to test end-to-end
+   without a live PR. Three options:
+   - **(a) Document manual verification** (Recommended for first cut):
+     a script-header procedure that explains how to reproduce today's
+     failure mode in a sandbox, and verify the fix avoids it. Low cost,
+     honest about test-automation limits.
+   - **(b) Mocked smoke test**: stub `gh pr checks --watch` with a
+     scripted success/failure sequence. Decent coverage; some risk of
+     drift from real `gh` behaviour.
+   - **(c) Real-PR smoke test**: spin a throwaway PR each run. High
+     fidelity; needs network, gh auth, and PR-cleanup logic.
+
+## Estimated Scope
+
+Single PR. Roughly:
+- `merge_pr.sh` changes: ~15 LOC (wait step + flag + minor reshape)
+- New knowledge doc: ~80 LOC (pattern overview + 2-3 examples)
+- AGENTS.md update: ~1 LOC (script-reference row)
+- Optional smoke test: ~30 LOC if mocked, or ~5 LOC of header documentation if manual-only
+
+Total ~100-130 LOC. Same-PR scope; no breakdown needed.
+
+## Implementation Notes
+
+_(populated during implement phase per skill convention)_

--- a/.agent/work-plans/issue-186/plan.md
+++ b/.agent/work-plans/issue-186/plan.md
@@ -99,49 +99,44 @@ surfaces merit different mechanisms.
 | `merge_pr.sh` | `AGENTS.md` script-reference table | Yes (file 3) |
 | Add a new knowledge doc | (standalone reference; no cascading deps) | Yes (file 2) |
 
-## Open Questions
+## Decisions
 
-These are the architectural decisions worth your eyes before implement.
-Numbered so you can answer "1=A, 2=B, ..." or override individually.
+Captured 2026-05-09 during plan review with Roland. Each decision was asked
+one at a time with concrete previews; recommendations were taken on all
+three.
 
-1. **Surface-1 vs Surface-2 vs both.** Three options:
-   - **(a) Both** (Recommended): script-side `gh pr checks --watch` in
-     `merge_pr.sh` *plus* agent-side knowledge doc for the `Monitor` pattern.
-     Script fix solves today's pain immediately for everyone; knowledge doc
-     captures the pattern for future agent-flow uses (without requiring a
-     code change to consume it).
-   - **(b) Script-side only**: just add the wait to `merge_pr.sh`. Simpler
-     PR; defer the agent-side `Monitor` knowledge doc until a concrete
-     agent-flow use case appears.
-   - **(c) Agent-side only**: no script change; build a `/merge-pr`
-     slash command that wraps `merge_pr.sh` and uses `Monitor` for the
-     wait. Larger architectural change; `merge_pr.sh` stays wait-less for
-     non-Claude agents (still the manual-second-invocation pain for them).
+1. **Surface scope: both.** Script-side `gh pr checks --watch` in
+   `merge_pr.sh` *plus* a new `.agent/knowledge/agent_wait_patterns.md`
+   knowledge doc for the agent-side `Monitor` pattern. The script fix
+   solves the manual-second-invocation pain for *every* framework
+   immediately; the knowledge doc captures the agent-side pattern as
+   durable guidance for future Claude Code flows (no consumer required
+   today). Matches the issue's framework-portability AC and the
+   workspace's "Workspace improvements cascade to projects" principle.
 
-   Option **(a)** matches the issue's scope ("merge flows" + framework
-   portability), gives the immediate win, and leaves room for follow-up.
+2. **Wait behaviour: `--fail-fast`.** `gh pr checks --watch --fail-fast`
+   exits on the first failed check; the script then aborts the merge
+   with a useful error pointing at the failed check (and its run URL).
+   Saves time on busted CI runs; clear exit-code handling (gh exits 8
+   on first-fail). The script translates the failure into a clear
+   merge-aborted message rather than letting `set -e` swallow context.
 
-2. **Wait timeout / fail-fast behaviour.** `gh pr checks --watch` defaults
-   to "wait forever". Three reasonable choices for the script:
-   - **(a) `--fail-fast`** (Recommended): exits on first failed check;
-     the script then aborts the merge with a useful error pointing at the
-     failed check. Saves time on busted CI runs.
-   - **(b) Plain `--watch`**: wait until all checks complete, then merge
-     if green or fail with a generic error if not.
-   - **(c) Wrapped in `timeout`**: e.g. `timeout 10m gh pr checks --watch`.
-     Defends against runaway CI but introduces another knob.
+3. **Smoke test: documented manual verification.** ~5 LOC procedure in
+   `merge_pr.sh`'s header explaining how to reproduce today's failure
+   mode (push a poke commit, run `make merge-pr` immediately) and verify
+   the fix avoids it. Honest about test-automation limits — automating
+   this would require mocking `gh pr checks --watch` (drift risk) or
+   spinning throwaway PRs (network + auth dependencies). Out-of-scope
+   for #186; revisit if regression risk grows.
 
-3. **Smoke-test feasibility.** The wait path is hard to test end-to-end
-   without a live PR. Three options:
-   - **(a) Document manual verification** (Recommended for first cut):
-     a script-header procedure that explains how to reproduce today's
-     failure mode in a sandbox, and verify the fix avoids it. Low cost,
-     honest about test-automation limits.
-   - **(b) Mocked smoke test**: stub `gh pr checks --watch` with a
-     scripted success/failure sequence. Decent coverage; some risk of
-     drift from real `gh` behaviour.
-   - **(c) Real-PR smoke test**: spin a throwaway PR each run. High
-     fidelity; needs network, gh auth, and PR-cleanup logic.
+### Resulting flag surface (script-side)
+
+| Flag | Meaning |
+|------|---------|
+| `--no-wait` | Skip the new internal CI wait (for cases where the user knows CI is green) |
+| `--no-roadmap-update` | (existing) skip the roadmap auto-update step |
+| `--type workspace\|project` | (existing) override auto-detection |
+| `--pr <N>` | (existing) PR number; required |
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-186/progress.md
+++ b/.agent/work-plans/issue-186/progress.md
@@ -37,3 +37,66 @@ previews. Outcomes (see plan.md `## Decisions` for detail):
 
 Plan refined: Open Questions section replaced with Decisions; flag
 surface table added showing the new `--no-wait` flag.
+
+## Implement
+**Status**: complete (pending self-test)
+**When**: 2026-05-09 15:50
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Three commits across three logical pieces:
+
+- `8efa4bd` — new `.agent/knowledge/agent_wait_patterns.md` (Surface 2)
+- `2129e5e` — `merge_pr.sh` wait + `--no-wait` flag + header (Surface 1)
+- `5712812` — `AGENTS.md` script-reference row update (cascade)
+
+### Decisions
+
+Local choices made during implement that weren't pre-decided in plan
+review. Skim and redirect anything that's wrong before self-test.
+
+1. **Step renumbering, not "Step 1.5".** Inline `# --- Step N: ---`
+   comments shifted (Merge: 2→3, Remove worktree: 3→4, Delete
+   branches: 4→5, Sync: 5→6) so the new wait can be Step 2 rather
+   than 1.5. Consistent integer numbering reads better than 1.5; the
+   churn is comment-only.
+
+2. **USAGE string extracted to a single variable.** Was duplicated in
+   the unknown-arg branch and the missing-`--pr` branch. Same
+   refactor pattern as cross_model_review.sh in #3 — drift between
+   the two strings was a latent bug surface.
+
+3. **Wait error message structure.** Three pieces of information per
+   failure: `gh exit <code>` (so debug knows the failure class), PR
+   URL (so the user can click through to the failed run without
+   re-deriving), and the `--no-wait` escape hatch (so a known-broken
+   CI doesn't block the merge if the user explicitly accepts it).
+
+4. **Local-var naming with leading underscore** (`_wait_rc`,
+   `_pr_url`) — matches existing convention in this script
+   (`_WT_REPO`, `_WT_ROOT`, `_WT_BRANCH`). Not strictly necessary in
+   bash but visually scopes "this is a local helper, not a global".
+
+5. **No cross-link from `merge_pr.sh` to the knowledge doc.**
+   Considered adding a `# See: .agent/knowledge/agent_wait_patterns.md`
+   comment in the script header; declined. The doc is
+   self-discoverable in the knowledge dir; bidirectional linking adds
+   a sync dependency without much payoff. The doc itself does
+   reference back to `merge_pr.sh` (consumer-side reference).
+
+6. **Knowledge doc includes a `cross_model_review.sh` row marked
+   "OK as-is".** That script's tmux session-status busy-poll is
+   explicitly out-of-scope for #186 (matches plan AC). Documenting
+   why prevents future readers from refactoring it on auto-pilot.
+
+7. **Knowledge doc notes the #187 (Routines) connection in "See
+   also".** If Routines lands, some of these wait patterns get
+   replaced by event-driven Routines fired by GitHub events. Surfaces
+   the relationship without committing to either path now.
+
+### What's next
+
+Self-test (per plan): run the new wait path against a real merge.
+Since this PR (#189) will merge eventually, the smoke test could be
+"the next `make merge-pr` invocation in this session demonstrates the
+wait fires correctly". Otherwise the documented manual-verification
+procedure in `merge_pr.sh`'s header is the standing reference.

--- a/.agent/work-plans/issue-186/progress.md
+++ b/.agent/work-plans/issue-186/progress.md
@@ -19,3 +19,21 @@ script-side `gh pr checks --watch` insertion to fix the manual-second-
 invocation pain for everyone, plus a knowledge doc for the agent-side
 `Monitor` pattern. Three Open Questions surfaced for approval before
 implement.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-09 15:25
+**By**: Claude Code Agent (claude-opus-4-7) + Roland
+
+Walked the three architectural decisions one at a time with concrete
+previews. Outcomes (see plan.md `## Decisions` for detail):
+
+1. Surface scope: **both** — script-side bash wait in `merge_pr.sh`
+   plus new `agent_wait_patterns.md` knowledge doc.
+2. Wait behaviour: **`--fail-fast`** — exit on first failed check, abort
+   merge with clear context.
+3. Smoke test: **documented manual verification** — ~5 LOC procedure
+   in script header; automation declined as out-of-scope for #186.
+
+Plan refined: Open Questions section replaced with Decisions; flag
+surface table added showing the new `--no-wait` flag.

--- a/.agent/work-plans/issue-186/progress.md
+++ b/.agent/work-plans/issue-186/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 186
+---
+
+# Issue #186 — Replace gh pr checks --watch busy-poll with native Monitor in merge flows
+
+## Plan
+**Status**: complete
+**When**: 2026-05-09 14:55
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Plan file: `.agent/work-plans/issue-186/plan.md`.
+
+The issue's title implies "swap busy-poll for `Monitor`", but `Monitor` is
+a Claude Code SDK tool that bash can't invoke — so the script-side
+(`merge_pr.sh`) and agent-side (knowledge doc / future slash command)
+surfaces need different mechanisms. Plan recommends doing both:
+script-side `gh pr checks --watch` insertion to fix the manual-second-
+invocation pain for everyone, plus a knowledge doc for the agent-side
+`Monitor` pattern. Three Open Questions surfaced for approval before
+implement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,7 +341,7 @@ Scripts marked **(source)** must be sourced; all others should be executed.
 | `.agent/scripts/check_branch_updates.sh` | Check if branch is behind default |
 | `.agent/scripts/gh_create_issue.sh` | Create issue with label validation (`GITBUG_CREATE=1` for offline) |
 | `.agent/scripts/revert_feature.sh` | Revert all commits for an issue |
-| `.agent/scripts/merge_pr.sh` | Merge PR (auto-updates roadmap), remove worktree, delete branch, sync main |
+| `.agent/scripts/merge_pr.sh` | Merge PR (auto-updates roadmap, waits for CI on the latest HEAD before merging), remove worktree, delete branch, sync main; `--no-wait` to skip the CI wait |
 | `.agent/scripts/update_roadmap.sh` | Auto-update roadmap status for completed issues |
 | `.agent/scripts/sync_project.py` | Sync workspace + project repos |
 | `.agent/scripts/validate_workspace.py` | Validate project/ configuration |


### PR DESCRIPTION
Closes #186

## Summary

Adds an internal CI wait step to `merge_pr.sh` between the roadmap-update push and the merge attempt, so `make merge-pr` no longer fails `Pull Request is not mergeable` when CI on the just-pushed roadmap commit hasn't completed yet (today's session hit this twice). New `.agent/knowledge/agent_wait_patterns.md` knowledge doc captures the agent-side `Monitor` vs busy-poll pattern for future reference.

Two-surface fix: bash wait works for every framework (manual user, Claude Code, Codex, Gemini); the knowledge doc is durable guidance for Claude Code agent flows that want to use `Monitor` directly.

## What's in this PR

- **`.agent/scripts/merge_pr.sh`** — added Step 2: `gh pr checks --watch --fail-fast` between the roadmap-push (Step 1) and the merge (Step 3, renumbered). Adds `--no-wait` flag to skip when CI is known-green. On check failure, surfaces gh exit code + PR URL + `--no-wait` escape hatch in the error message.
- **`.agent/scripts/merge_pr.sh`** header — manual-verification procedure documented (push poke commit, run merge-pr immediately, expect "Waiting for CI..." block). Automated equivalent declined as out-of-scope per plan decision 3.
- **`.agent/knowledge/agent_wait_patterns.md`** — new knowledge doc explaining when to use `Monitor` (Claude Code agents) vs busy-poll fallback (scripts, other frameworks). Decision quick-reference table; cross-references to `merge_pr.sh` and #187 (Routines spike).
- **`AGENTS.md`** — script-reference row for `merge_pr.sh` mentions the wait behaviour and `--no-wait` flag.

## Architectural decisions captured during planning

1. Surface scope: **both** — bash wait in `merge_pr.sh` (works for every framework) plus new knowledge doc for the agent-side `Monitor` pattern.
2. Wait behaviour: **`--fail-fast`** — exit on first failed check; surface PR URL + escape hatch in error.
3. Smoke test: **documented manual verification** — automation would require mocking `gh` or spinning throwaway PRs; declined as out-of-scope.

Plan + decision logs in `.agent/work-plans/issue-186/`.

## Self-test

This PR's own merge will exercise the new wait step. When `make merge-pr PR=189` runs:
1. Roadmap-update step pushes a commit on top of `feature/issue-186`
2. New Step 2 (`gh pr checks --watch --fail-fast`) waits for CI on that commit
3. Once green, merge proceeds

Real dogfood — the wait step exercises itself on the way to landing.

## Test plan

- [x] Pre-commit + shellcheck clean on all 5 implement commits
- [x] Bash syntax check passes
- [x] Manual-verification procedure documented in `merge_pr.sh` header (per plan decision 3)
- [ ] Live: `make merge-pr PR=189` prints "Waiting for CI..." and blocks until checks complete before attempting merge
- [ ] Failure path: surfaced via the `--no-wait` escape hatch and the documented procedure

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`