### PR TITLE
/start-task: drop $ARGUMENTS quotes, bracket with set -f/+f, document boundary limits

### DIFF
--- a/.agent/work-plans/issue-188/plan.md
+++ b/.agent/work-plans/issue-188/plan.md
@@ -14,7 +14,7 @@ The issue body was reviewed via `/review-issue`; the recommended-fix shape and t
 
 ## Approach
 
-1. **Drop the quotes around `$ARGUMENTS`** in both `worktree_enter.sh` and `worktree_create.sh` invocations in `start-task/SKILL.md`. Two-line change in step 3 of the skill body.
+1. **Drop the quotes around `$ARGUMENTS`** in both `worktree_enter.sh` and `worktree_create.sh` invocations in `start-task/SKILL.md` *and* bracket the invocation block with `set -f` / `set +f` so shell glob expansion is disabled while word-splitting is enabled. Without the bracket, values containing `*`, `?`, `[`, `]` (e.g. `--branch main*`, `--plan-file /tmp/*.md`) would be expanded against the cwd before reaching the script. The bracket is ~2 extra lines and matches the workspace "completeness" principle (fix the surface rather than document a footgun).
 
 2. **Rewrite the "Argument handling" section** to be honest about what slash-command argument forwarding can and cannot do. Today's wording claims the quoting "preserves spacing within a single value (e.g. `--branch \"feature/foo bar\"`)" — false. Replace with: typical case (multiple flags, no embedded whitespace) works; embedded-whitespace cases aren't supported (slash-command boundary flattens user-supplied quotes); shell-metacharacter values still warrant a refusal-or-warn pattern.
 
@@ -28,7 +28,7 @@ The issue body was reviewed via `/review-issue`; the recommended-fix shape and t
 
 | File | Change |
 |------|--------|
-| `.claude/skills/start-task/SKILL.md` | Drop quotes around `$ARGUMENTS` (step 3, two occurrences); rewrite "Argument handling" section; add embedded-whitespace bullet to "When not to use"; add new "Manual verification" section |
+| `.claude/skills/start-task/SKILL.md` | Drop quotes around `$ARGUMENTS` (step 3, two occurrences); add `set -f` / `set +f` bracket around the invocation block; rewrite "Argument handling" section; add embedded-whitespace bullet to "When not to use"; add new "Manual verification" section |
 
 That's it. Single file, ~30 LOC of edits.
 
@@ -59,11 +59,12 @@ That's it. Single file, ~30 LOC of edits.
 
 ## Decisions
 
-Resolved during `/review-issue` on this issue — no Open Questions remaining for the user. Captured here for the implementer's reference:
+Resolved during `/review-issue` and `/review-plan` on this issue — no Open Questions remaining for the user. Captured here for the implementer's reference:
 
 1. **Fix shape: drop the quotes around `$ARGUMENTS`** (Option C from the original issue body's menu). `read -ra` array-read was considered and rejected — bash IFS-based word splitting fragments embedded-whitespace values the same way as unquoted expansion.
-2. **Embedded-whitespace case is unsolvable at the slash-command boundary** — by the time `$ARGUMENTS` arrives in the skill body it's a flat string with no quote-preservation. The fix accepts this limitation honestly and documents it in "When not to use."
-3. **Smoke test: documented manual verification only** — no automated test. Slash-command bodies are markdown instructions, not standalone executables; end-to-end testing needs a Claude Code SDK harness we don't have set up. Same rationale as `merge_pr.sh`'s manual verification in #186.
+2. **Glob expansion suppressed via `set -f` / `set +f` bracket** (decided during `/review-plan`). Unquoted `$ARGUMENTS` enables both word-splitting (wanted) and glob expansion (footgun on values with `*`, `?`, `[`, `]`). The bracket disables the latter while preserving the former. Costs ~2 lines; aligns with "completeness" (fix the surface, don't document around it).
+3. **Embedded-whitespace case is unsolvable at the slash-command boundary** — by the time `$ARGUMENTS` arrives in the skill body it's a flat string with no quote-preservation. The fix accepts this limitation honestly and documents it in "When not to use."
+4. **Smoke test: documented manual verification only** — no automated test. Slash-command bodies are markdown instructions, not standalone executables; end-to-end testing needs a Claude Code SDK harness we don't have set up. Same rationale as `merge_pr.sh`'s manual verification in #186.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-188/plan.md
+++ b/.agent/work-plans/issue-188/plan.md
@@ -1,0 +1,74 @@
+# Plan: /start-task: $ARGUMENTS quoting breaks every multi-flag invocation
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/188
+
+## Context
+
+PR #182 introduced `/start-task` as a slash command. Its skill body invokes `worktree_enter.sh` and `worktree_create.sh` with `"$ARGUMENTS"` — quoted. The quoting was added in commit `cc23db5` to address a `/review-issue` finding ("`$ARGUMENTS` interpolation is unquoted — values with spaces or shell metacharacters break"), but it overcorrected: the quotes turn the user's flags into a single positional argument, so every multi-flag invocation fails immediately with `Error: Unknown option --issue 186 --type workspace`.
+
+Confirmed by today's session — first real downstream exercise of `/start-task` (running `/start-task --issue 186 --type workspace` for the plan-task on #186) hit the bug; falling back to the manual `worktree_create.sh` + `EnterWorktree` flow was a ~30-second detour.
+
+The issue body was reviewed via `/review-issue`; the recommended-fix shape and the smoke-test framing came out of that review. Most architectural decisions are resolved already.
+
+## Approach
+
+1. **Drop the quotes around `$ARGUMENTS`** in both `worktree_enter.sh` and `worktree_create.sh` invocations in `start-task/SKILL.md`. Two-line change in step 3 of the skill body.
+
+2. **Rewrite the "Argument handling" section** to be honest about what slash-command argument forwarding can and cannot do. Today's wording claims the quoting "preserves spacing within a single value (e.g. `--branch \"feature/foo bar\"`)" — false. Replace with: typical case (multiple flags, no embedded whitespace) works; embedded-whitespace cases aren't supported (slash-command boundary flattens user-supplied quotes); shell-metacharacter values still warrant a refusal-or-warn pattern.
+
+3. **Add an embedded-whitespace bullet to "When not to use"**: "Values containing embedded whitespace (e.g. `--branch \"feature/foo bar\"`). Slash-command argument forwarding flattens user-supplied quotes; the inner whitespace will not be preserved across the boundary. Call `worktree_create.sh` directly for those cases."
+
+4. **Add a "Manual verification" section** to `start-task/SKILL.md` modelled on the procedure that landed in `merge_pr.sh`'s header in #186. Step-by-step that exercises the typical-case multi-flag invocation and confirms behaviour. Acknowledges automation is out of scope (no Claude Code SDK test harness available).
+
+5. **No CLAUDE.md / AGENT_ONBOARDING.md updates needed.** Both reference `/start-task` only by name; the flag interface is unchanged from the user's perspective (broken multi-flag invocations now work; single-flag invocations were never broken). Verify by grep before committing.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/start-task/SKILL.md` | Drop quotes around `$ARGUMENTS` (step 3, two occurrences); rewrite "Argument handling" section; add embedded-whitespace bullet to "When not to use"; add new "Manual verification" section |
+
+That's it. Single file, ~30 LOC of edits.
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Bug fix improves error visibility — today's failure mode is `Error: Unknown option --issue 186 --type workspace` which is opaque; the fix removes the failure |
+| Capture decisions, not just implementations | Issue body and `/review-issue` comment capture the design rationale (Option C selected, `read -ra` rejected with reason) |
+| A change includes its consequences | Single skill file affected; consequences-map row "framework skill → adapter file" checked — no edits needed since flag interface is preserved |
+| Only what's needed | Minimal fix; doesn't expand `/start-task`'s feature surface |
+| Test what breaks | Manual-verification procedure documented per AC #4; automated equivalent declined honestly (same as #186's smoke test framing) |
+| Workspace vs project separation | Workspace-only |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Working in `worktrees/workspace/issue-workspace-188/` |
+| 0003 — Project-agnostic workspace | Yes | Workspace-only change |
+| 0006 — Shared AGENTS.md | No | Skill is Claude-Code-only by design (per its frontmatter); other framework adapters don't reference its flag interface |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `.claude/skills/start-task/SKILL.md` | CLAUDE.md / `.agent/AGENT_ONBOARDING.md` if flag interface changes | N/A — flag interface is unchanged from user perspective; only broken behaviour is fixed |
+
+## Decisions
+
+Resolved during `/review-issue` on this issue — no Open Questions remaining for the user. Captured here for the implementer's reference:
+
+1. **Fix shape: drop the quotes around `$ARGUMENTS`** (Option C from the original issue body's menu). `read -ra` array-read was considered and rejected — bash IFS-based word splitting fragments embedded-whitespace values the same way as unquoted expansion.
+2. **Embedded-whitespace case is unsolvable at the slash-command boundary** — by the time `$ARGUMENTS` arrives in the skill body it's a flat string with no quote-preservation. The fix accepts this limitation honestly and documents it in "When not to use."
+3. **Smoke test: documented manual verification only** — no automated test. Slash-command bodies are markdown instructions, not standalone executables; end-to-end testing needs a Claude Code SDK harness we don't have set up. Same rationale as `merge_pr.sh`'s manual verification in #186.
+
+## Estimated Scope
+
+Single PR. ~30 LOC across the skill file. No new tests (manual-verification procedure documented in SKILL.md per AC #4). No CLAUDE.md / AGENTS.md updates needed.
+
+## Implementation Notes
+
+_(populated during implement phase per skill convention)_

--- a/.agent/work-plans/issue-188/progress.md
+++ b/.agent/work-plans/issue-188/progress.md
@@ -112,9 +112,9 @@ dogfood.
 **Must-fix**: 1 | **Suggestions**: 2
 
 ### Findings
-- [ ] (must-fix) Line 70 sentence claims "after fix shipped in this PR for `worktree_enter.sh`" but that fix shipped in PR #180 (`d7d8fa8`); reword — `.claude/skills/start-task/SKILL.md:70`
-- [ ] (suggestion) "Argument handling" shell-metacharacter warning is technically inaccurate — bash doesn't re-expand variable contents; tighten to concrete failure mode — `.claude/skills/start-task/SKILL.md:31`
-- [ ] (suggestion) Line 70 stdout-vs-stderr claim is over-broad — true only for not-found path, not Unknown-option path which still writes to stdout. Either narrow the claim or open follow-up to route Unknown-option to stderr in `worktree_enter.sh` — `.claude/skills/start-task/SKILL.md:70`
+- [x] (must-fix) Line 70 sentence claims "after fix shipped in this PR for `worktree_enter.sh`" but that fix shipped in PR #180 (`d7d8fa8`); reworded — `.claude/skills/start-task/SKILL.md:70` (`9b5429d`)
+- [x] (suggestion) "Argument handling" shell-metacharacter warning is technically inaccurate — bash doesn't re-expand variable contents; tightened to downstream-handling risk — `.claude/skills/start-task/SKILL.md:31` (`9b5429d`)
+- [x] (suggestion) Line 70 stdout-vs-stderr claim narrowed; Unknown-option asymmetry called out with cross-reference to follow-up #194 — `.claude/skills/start-task/SKILL.md:70` (`9b5429d`)
 
 ### Notes
 - Bash semantics verified correct by adversarial trace.

--- a/.agent/work-plans/issue-188/progress.md
+++ b/.agent/work-plans/issue-188/progress.md
@@ -16,3 +16,27 @@ from `/review-issue` discussion); rewrite "Argument handling" honestly;
 add embedded-whitespace bullet to "When not to use"; add manual-
 verification procedure (same pattern as merge_pr.sh in #186). Single
 file, ~30 LOC. No Open Questions — design resolved during issue review.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-09 17:45
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Three findings — one substantive, two minor:
+
+1. **Glob expansion footgun** (substantive): unquoted `$ARGUMENTS`
+   enables glob expansion on values containing `*`, `?`, `[`, `]`
+   (e.g. `--branch main*`, `--plan-file /tmp/*.md`). Plan accepts
+   this implicitly. Recommend either bracketing the invocation with
+   `set -f` / `set +f` (small + robust) or documenting the
+   limitation alongside the embedded-whitespace one. Lean `set -f`.
+2. **"verified via grep" claim was unverified** at the time the
+   plan was written; turned out correct on actual verification.
+   Minor process note.
+3. **Manual verification section placement and content** not pinned
+   down in the plan; reasonable defaults exist (after "Argument
+   handling"; cover --issue+--type and --skill+--type cases).
+   Resolvable inline during implement.
+
+Recommended action before implement: resolve finding #1 (glob
+handling). Findings #2 and #3 close themselves during execution.

--- a/.agent/work-plans/issue-188/progress.md
+++ b/.agent/work-plans/issue-188/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 188
+---
+
+# Issue #188 — /start-task: $ARGUMENTS quoting breaks every multi-flag invocation
+
+## Plan
+**Status**: complete
+**When**: 2026-05-09 17:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Plan file: `.agent/work-plans/issue-188/plan.md`.
+
+Drop the quotes around `$ARGUMENTS` in `start-task/SKILL.md` (Option C
+from `/review-issue` discussion); rewrite "Argument handling" honestly;
+add embedded-whitespace bullet to "When not to use"; add manual-
+verification procedure (same pattern as merge_pr.sh in #186). Single
+file, ~30 LOC. No Open Questions — design resolved during issue review.

--- a/.agent/work-plans/issue-188/progress.md
+++ b/.agent/work-plans/issue-188/progress.md
@@ -40,3 +40,62 @@ Three findings — one substantive, two minor:
 
 Recommended action before implement: resolve finding #1 (glob
 handling). Findings #2 and #3 close themselves during execution.
+
+## Implement
+**Status**: complete (pending self-test)
+**When**: 2026-05-09 18:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Single commit (`d7b5b80`) — 5 edits to `.claude/skills/start-task/SKILL.md`,
++30/-3 LOC. Pre-commit clean.
+
+### Decisions
+
+Local choices made during implement that weren't pre-decided in the
+plan or plan-review. Skim before self-test.
+
+1. **Manual verification section placement: between Steps and Exit
+   semantics.** Plan-review finding #3 left this open. Alternatives
+   were before "Why not just call EnterWorktree directly?" or at
+   the top of file. Chose lifecycle order: Steps → Manual
+   verification (proves Steps work) → Exit semantics. The "post-
+   action verification" reads naturally after the action it
+   verifies.
+
+2. **`set +f` placement: first statement of each branch (not after
+   the if/elif/else block).** A trailing `set +f` after the block
+   wouldn't fire on the `else exit 1` path. Per-branch placement is
+   uniform and exits clean.
+
+3. **Argument-handling rewrite shape: three-paragraph form.** Plan
+   said "rewrite to be honest" without prescribing structure. Chose
+   intro paragraph + two-bullet limitation list (embedded
+   whitespace, shell metacharacters) for readability. Single dense
+   paragraph would have been shorter but harder to scan.
+
+4. **Shell-metacharacter framing in the new Argument-handling
+   section.** Kept the original advice ("agent should warn the
+   user and refuse") but updated framing to acknowledge that
+   globbing is now disabled while other metacharacters (`;`, `$`,
+   backticks) still warrant care. Honest about residual risk
+   instead of implying the bracket solves all sharp edges.
+
+5. **Manual verification: included a "structural check" item.**
+   Testing glob suppression against real files would be fragile
+   (depends on cwd contents). Inspect-the-source check ("confirm
+   `set -f`/`set +f` bracket is intact") is a valid form of
+   verification and matches how the workspace already verifies
+   other structural properties. Avoids the smoke-test churn issue.
+
+6. **Inline comment about `set +f` placement** in the bash code:
+   "Restored in every branch exit" — so future maintainers don't
+   wonder why each branch starts with `set +f` rather than seeing
+   one trailing line.
+
+### What's next
+
+Self-test: invoke `/start-task --issue <test-N> --type workspace`
+or `--skill research --type workspace` from the main tree. Most
+realistic test is the next worktree creation in this session — if
+that fails, the fix didn't take. The session itself becomes the
+dogfood.

--- a/.agent/work-plans/issue-188/progress.md
+++ b/.agent/work-plans/issue-188/progress.md
@@ -99,3 +99,26 @@ or `--skill research --type workspace` from the main tree. Most
 realistic test is the next worktree creation in this session — if
 that fails, the fix didn't take. The session itself becomes the
 dogfood.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-09 18:25
+**By**: Claude Code Agent (claude-opus-4-7) + Claude adversarial subagent
+**Verdict**: changes-requested (3 small doc findings)
+
+**Branch**: `feature/issue-188` at `b1a1ce3`
+**Base**: `main`
+**Depth**: Standard (reason: governance-file override; line count inflated by `plan.md`/`progress.md` tracking artifacts, primary signal is the `SKILL.md` edit)
+**Must-fix**: 1 | **Suggestions**: 2
+
+### Findings
+- [ ] (must-fix) Line 70 sentence claims "after fix shipped in this PR for `worktree_enter.sh`" but that fix shipped in PR #180 (`d7d8fa8`); reword — `.claude/skills/start-task/SKILL.md:70`
+- [ ] (suggestion) "Argument handling" shell-metacharacter warning is technically inaccurate — bash doesn't re-expand variable contents; tighten to concrete failure mode — `.claude/skills/start-task/SKILL.md:31`
+- [ ] (suggestion) Line 70 stdout-vs-stderr claim is over-broad — true only for not-found path, not Unknown-option path which still writes to stdout. Either narrow the claim or open follow-up to route Unknown-option to stderr in `worktree_enter.sh` — `.claude/skills/start-task/SKILL.md:70`
+
+### Notes
+- Bash semantics verified correct by adversarial trace.
+- Plan adherence clean (all 5 planned edits landed; no drift).
+- Static analysis: no profile for `.md` files; report explicit per skill convention.
+- Cross-model dispatch skipped (Standard tier).
+- All three findings are doc/comment polish, ~5 minutes to fix inline.

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -28,7 +28,7 @@ Replace the two-step `worktree_create.sh && source worktree_enter.sh` ceremony w
 Two limitations of slash-command argument forwarding worth knowing:
 
 - **Embedded whitespace in a value is not preserved.** `/start-task --branch "feature/foo bar"` flattens to `--branch feature/foo bar` at the slash-command boundary, then word-splits into three tokens. There is no recovery mechanism at this layer. For values with embedded whitespace, call `worktree_create.sh` directly. (Listed in "When not to use" above.)
-- **Shell metacharacters in values** (`;`, `$`, backticks) remain a concern even with globbing disabled — they could still execute under unquoted expansion in certain command-substitution shapes. The agent should warn the user and refuse rather than blindly execute when these appear.
+- **Shell metacharacters in values** (`;`, `$`, backticks) reach the underlying scripts as literal characters. With `set -f` disabling glob expansion and bash not re-expanding variable contents, direct injection at the slash-command boundary isn't the concern; the actual risk is downstream — these characters can have unexpected meanings to the scripts that consume the values (as branch names, file paths, or in error messages). For values that need metacharacters, call `worktree_create.sh` directly with proper shell quoting.
 
 ## Steps
 
@@ -67,7 +67,7 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 
 ### 3. Resolve the worktree path (existing → create-new fallback)
 
-Exit-code-checked idiom — error text from the "not found" path goes to stderr (after fix shipped in this PR for `worktree_enter.sh`), so `2>/dev/null` actually suppresses it:
+Exit-code-checked idiom — error text from the "not found" path goes to stderr, so `2>/dev/null` suppresses it. The `worktree_enter.sh` "Unknown option" path still writes to stdout (caught harmlessly by the elif chain when it overwrites `$WT`); see #194 for routing that to stderr too.
 
 ```bash
 # Disable glob expansion for the unquoted $ARGUMENTS expansion below.

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -19,10 +19,16 @@ Replace the two-step `worktree_create.sh && source worktree_enter.sh` ceremony w
 - The session is **already inside a worktree.** EnterWorktree refuses in that case. Step 1 below detects this and stops; tell the user to exit the current worktree first.
 - You want a worktree without entering it (e.g., creating one for another agent). Call `worktree_create.sh` directly.
 - The framework is **not Claude Code.** Codex / Gemini agents stay on the existing `worktree_create.sh` + `worktree_enter.sh --print-path` / `--shell-snippet` flow. This command depends on the native `EnterWorktree` tool.
+- **Values containing embedded whitespace** (e.g. `--branch "feature/foo bar"`). Slash-command argument forwarding flattens user-supplied quotes; the inner whitespace will not be preserved across the boundary. Call `worktree_create.sh` directly for those cases.
 
 ## Argument handling
 
-`$ARGUMENTS` contains the user's flags exactly as typed. The bash idioms below quote `"$ARGUMENTS"` to preserve spacing within a single value (e.g. `--branch "feature/foo bar"`). For values containing shell metacharacters (`;`, `$`, backticks, etc.), the agent should warn the user and refuse rather than blindly execute.
+`$ARGUMENTS` contains the user's flags exactly as typed, as a flat string. The bash idioms below pass it **unquoted** so the shell word-splits it into separate flag tokens — this is what makes the typical multi-flag case (`--issue 188 --type workspace`) work. The invocation block is bracketed with `set -f` / `set +f` to suppress glob expansion: without the bracket, values containing `*`, `?`, or `[` (e.g. `--branch main*`, `--plan-file /tmp/*.md`) would expand against the cwd before reaching the script.
+
+Two limitations of slash-command argument forwarding worth knowing:
+
+- **Embedded whitespace in a value is not preserved.** `/start-task --branch "feature/foo bar"` flattens to `--branch feature/foo bar` at the slash-command boundary, then word-splits into three tokens. There is no recovery mechanism at this layer. For values with embedded whitespace, call `worktree_create.sh` directly. (Listed in "When not to use" above.)
+- **Shell metacharacters in values** (`;`, `$`, backticks) remain a concern even with globbing disabled — they could still execute under unquoted expansion in certain command-substitution shapes. The agent should warn the user and refuse rather than blindly execute when these appear.
 
 ## Steps
 
@@ -64,13 +70,22 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 Exit-code-checked idiom — error text from the "not found" path goes to stderr (after fix shipped in this PR for `worktree_enter.sh`), so `2>/dev/null` actually suppresses it:
 
 ```bash
-if WT=$(.agent/scripts/worktree_enter.sh "$ARGUMENTS" --print-path 2>/dev/null); then
+# Disable glob expansion for the unquoted $ARGUMENTS expansion below.
+# Word-splitting still happens (so `--issue 188 --type workspace` becomes
+# 4 args), but glob characters in values (e.g. `--branch main*`,
+# `--plan-file *.md`) won't expand against the cwd. Restored in every
+# branch exit.
+set -f
+if WT=$(.agent/scripts/worktree_enter.sh $ARGUMENTS --print-path 2>/dev/null); then
+    set +f
     # Worktree already exists for this issue/skill.
     :
-elif WT=$(.agent/scripts/worktree_create.sh "$ARGUMENTS" --print-path-only); then
+elif WT=$(.agent/scripts/worktree_create.sh $ARGUMENTS --print-path-only); then
+    set +f
     # New worktree created; $WT is the path.
     :
 else
+    set +f
     # Creation failed. The script already wrote its error to stderr.
     # Surface the error to the user verbatim and STOP. Do not call EnterWorktree.
     #
@@ -109,6 +124,18 @@ After EnterWorktree returns successfully, briefly tell the user:
 - Which worktree they're now in (issue/skill, branch)
 - Whether it was newly created or pre-existing (you know from step 3 — the `if` branch hit means existing, `elif` means new)
 - Any setup messages the underlying scripts printed (e.g., "Branch is up to date with origin")
+
+## Manual verification
+
+After changes to this skill, run these checks from a fresh main-tree session to confirm behaviour. End-to-end automation would require a Claude Code SDK test harness; declined as out-of-scope (issue #188).
+
+1. **Typical case** — `/start-task --issue <test-N> --type workspace`. Expected: step 3's `elif` fires; new worktree created at `worktrees/workspace/issue-workspace-<test-N>/`; `EnterWorktree` succeeds; session lands in the new worktree.
+
+2. **Skill case** — `/start-task --skill research --type workspace`. Same flow with a skill-worktree path (`worktrees/workspace/skill-research-<TS>/`).
+
+3. **Re-entry case** — exit the worktree from check 1 (`ExitWorktree(action="keep")`), then re-run the same `/start-task --issue <test-N> --type workspace`. Expected: step 3's `if` branch fires (existing worktree found); no new creation; `EnterWorktree` returns to it.
+
+4. **Glob safety (structural check)** — inspect step 3 of this skill body and confirm `set -f` precedes the `if` block and `set +f` is restored in each of the three branches. Without these, an invocation containing values like `--branch main*` or `--plan-file *.md` would glob-expand against the cwd before reaching the script. The bracket makes the failure mode structurally impossible.
 
 ## Exit semantics
 


### PR DESCRIPTION
Closes #188

## Summary

Fixes the `/start-task` slash command quoting bug discovered during today's session — `"$ARGUMENTS"` quoting (added in PR #182) over-corrected and broke every multi-flag invocation. The fix unquotes the variable and brackets the invocation block with `set -f` / `set +f` to suppress glob expansion (the side effect of unquoted expansion we don't want).

Single-file change to `.claude/skills/start-task/SKILL.md`, ~30 LOC of substantive edits. No CLAUDE.md / AGENT_ONBOARDING.md updates needed (verified via grep — both reference the skill only by name; the user-facing flag interface is preserved).

## What's in this PR

- **Drop quotes around `$ARGUMENTS`** in the two `worktree_*.sh` invocations in step 3 — `--issue 188 --type workspace` now reaches the script as 4 argv tokens instead of 1.
- **Bracket the invocation block with `set -f` / `set +f`** — disables glob expansion while preserving word-splitting (decided during `/review-plan`).
- **Rewrite "Argument handling"** to be honest about what slash-command boundary can and can't preserve.
- **Add embedded-whitespace bullet** to "When not to use".
- **Add "Manual verification" section** with 4 checks (typical, skill, re-entry, structural).

## Architectural decisions captured during planning

1. **Fix shape**: drop quotes (Option C from issue body's menu). `read -ra` rejected — no improvement on embedded-whitespace, adds bash-array indirection.
2. **Glob handling**: `set -f` / `set +f` bracket (decided during `/review-plan`). Matches "completeness" principle.
3. **Embedded-whitespace case**: unsolvable at the slash-command boundary; documented honestly in "When not to use".
4. **Smoke test**: documented manual verification only; automation declined as out-of-scope (slash-command bodies need a Claude Code SDK harness we don't have).

Plan + decision logs in `.agent/work-plans/issue-188/`.

## Local review

`/review-code --branch` adversarial pass surfaced three doc-accuracy findings (none structural):
- Misleading "in this PR" wording on line 70 → reworded
- Imprecise shell-metacharacter warning on line 31 → tightened to downstream-risk framing
- Over-broad stdout/stderr claim on line 70 → narrowed; follow-up issue #194 filed for the underlying `worktree_enter.sh` Unknown-option-to-stderr fix

All addressed inline (`9b5429d`). Bash semantics verified correct by adversarial trace: `--issue 188 --type workspace` reaches the script as 4 argv tokens; `set -f` blocks glob; `set +f` restored in all three branches.

## Self-test

The fix exercises itself naturally on the next `/start-task` invocation in any subsequent session. The manual-verification procedure documented in `start-task/SKILL.md` covers what to check.

## Test plan

- [x] Pre-commit + shellcheck clean on all 7 commits
- [x] Bash syntax + bracket placement verified by grep and manual inspection
- [x] Manual-verification procedure documented in SKILL.md per AC #4
- [x] `/review-code --branch` run; findings addressed inline
- [ ] Live: next `/start-task --issue X --type workspace` invocation post-merge succeeds end-to-end

## Related

- Closes #188
- Will exercise #186's new internal CI wait in `merge_pr.sh` on its own merge
- Follow-up #194 — `worktree_enter.sh` Unknown-option to stderr (out of scope here; surfaced by `/review-code` on this PR)
- PR #182 (closed #180) — introduced `/start-task`; over-corrected the quoting in commit `cc23db5`

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`