### PR TITLE
hook(log-tool-use): widen input_summary cap 200 → 2000 bytes

### DIFF
--- a/.claude/hooks/log-tool-use.sh
+++ b/.claude/hooks/log-tool-use.sh
@@ -28,7 +28,10 @@ INPUT=$(cat)
     TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
     CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
     PERM_MODE=$(echo "$INPUT" | jq -r '.permission_mode // "unknown"')
-    INPUT_SUMMARY=$(echo "$INPUT" | jq -c '.tool_input' | head -c 200)
+    # 2000-byte cap on input_summary. Earlier value (200) clipped ~40% of Bash
+    # entries mid-command, blunting permission-pattern analysis. 2000 captures
+    # typical heredoc bodies and `python3 -c` scripts intact.
+    INPUT_SUMMARY=$(echo "$INPUT" | jq -c '.tool_input' | head -c 2000)
 
     jq -n -c \
       --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \


### PR DESCRIPTION
## Summary

Part of #197 (item 1 of 3 — log truncation widening).

The `PreToolUse` logging hook caps `input_summary` at 200 bytes. In the recent permission-pattern analysis (driving #195 / #196), **1,193 of 2,955 (40%)** Bash entries had their `command` field truncated mid-string, blunting the analyzer and forcing tolerant-heuristic fallback. Bumping the cap to 2000 bytes captures typical heredoc bodies and `python3 -c` scripts intact while keeping the log file size growth comfortable.

## Change

`.claude/hooks/log-tool-use.sh` — one-line change on the `head -c` cap, plus a 3-line comment explaining why.

```diff
-    INPUT_SUMMARY=$(echo "$INPUT" | jq -c '.tool_input' | head -c 200)
+    # 2000-byte cap on input_summary. Earlier value (200) clipped ~40% of Bash
+    # entries mid-command, blunting permission-pattern analysis. 2000 captures
+    # typical heredoc bodies and `python3 -c` scripts intact.
+    INPUT_SUMMARY=$(echo "$INPUT" | jq -c '.tool_input' | head -c 2000)
```

## Verification

- [x] **Acceptance criterion** (from #197): 500-byte heredoc command passes through end-to-end with the full command intact. Confirmed via unit test against a copy of the hook with `LOG_FILE` overridden to a tempfile.
- [x] **Boundary test**: a 2500-byte command truncates the inner JSON at the new ceiling, and the outer JSONL line stays well-formed (because `INPUT_SUMMARY` is JSON-string-encoded by `jq --arg`, not pasted raw).
- [x] `pre-commit run --files .claude/hooks/log-tool-use.sh` — passes (shellcheck included).

## Log-file growth

Current size: ~2 MB / 6 weeks. Worst-case 10× growth → ~20 MB / 6 weeks. Trivial.

## Why "Part of" not "Closes"

#197 is an umbrella tracking three independent items:
1. **This PR** — log truncation widening
2. `gh_create_pr.sh` wrapper (deferred)
3. PreToolUse nudge hook for `cat`/`head`/`tail`/`find`/`sed` (deferred — has open design questions)

Closing the umbrella prematurely would lose the tracker for items 2 and 3. After merge, item 1's checkbox in the issue body should be ticked.

---

**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
