### PR TITLE
hook: block cat/head/tail/find/sed against files per tool-mapping rules

### DIFF
--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -131,6 +131,23 @@ assert_blocks "cat backslash-escaped ;"        'cat file\;bar.txt'
 # Inline `-e SCRIPT` form should still block (equivalent to bare-script form).
 assert_blocks "sed -n -e inline script"        'sed -n -e "5,10p" file.log'
 assert_blocks "sed -n -e single-quoted"        "sed -n -e '5p' file.txt"
+# Wrapper / path / env-assignment bypasses: HEAD detection now peels
+# leading wrappers and takes basename. Bare-wrapper forms only — flag-
+# bearing forms like `sudo -u user cat` remain a documented limitation.
+assert_blocks "absolute-path cat"              "/bin/cat README.md"
+assert_blocks "absolute-path head"             "/usr/bin/head -n 5 file.log"
+assert_blocks "absolute-path sed -n"           "/usr/bin/sed -n '5p' file.txt"
+assert_blocks "sudo cat"                       "sudo cat /etc/hosts"
+assert_blocks "command cat"                    "command cat file.txt"
+assert_blocks "env cat"                        "env cat file.txt"
+assert_blocks "nohup cat"                      "nohup cat file.txt"
+assert_blocks "time cat"                       "time cat file.txt"
+assert_blocks "single VAR= cat"                "FOO=1 cat file.txt"
+assert_blocks "multiple VAR= cat"              "FOO=1 BAR=2 cat file.txt"
+assert_blocks "stacked wrappers"               "sudo command cat file.txt"
+assert_blocks "wrapper + path"                 "sudo /bin/cat file.txt"
+assert_blocks "VAR= + wrapper + cat"           "FOO=1 sudo cat file.txt"
+assert_blocks "sudo find no operational flag"  "sudo find /etc -name foo"
 # End-of-options (`--`) handling: positional args after `--` must still block
 # even when they start with `-`. Closes the bypass/false-positive gap surfaced
 # by Copilot.

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -72,6 +72,11 @@ assert_blocks "head -n N file"                 "head -n 50 log.txt"
 assert_blocks "head file (no count)"           "head file.txt"
 assert_blocks "tail -N file"                   "tail -100 log.txt"
 assert_blocks "tail -n N file"                 "tail -n 200 log.txt"
+# Bare numeric filename: coreutils treats `head 123` as reading file `123`,
+# not as a count. Previously exempted as numeric → bypassed the block.
+assert_blocks "head numeric filename"          "head 123"
+assert_blocks "tail numeric filename"          "tail 2024"
+assert_blocks "head -n 5 plus numeric file"    "head -n 5 2024"
 assert_blocks "find -name"                     "find . -name '*.ts'"
 assert_blocks "find -type -name"               "find . -type f -name '*.md'"
 assert_blocks "find no args (just path)"       "find ."
@@ -98,13 +103,20 @@ assert_blocks "find bare path"                 "find /etc"
 assert_blocks "find single arg path"           "find ."
 assert_blocks "find no args (implicit .)"      "find"
 # Quoted-metacharacter bypass: shell metachars (`;`, `<`, `>`) inside
-# single-quoted sed scripts/regexes must NOT trigger the compound/redirect
-# early-out. Previously `sed -n '1p;2p' file` passed through.
+# single- OR double-quoted sed scripts/regexes must NOT trigger the
+# compound/redirect early-out. Previously `sed -n '1p;2p' file` (single)
+# and `sed -n "1p;2p" file` (double) both passed through.
 assert_blocks "sed -n with ; in script"        "sed -n '1p;2p' file"
 assert_blocks "sed -n with ; in regex"         "sed -n '/foo;bar/p' file.log"
 assert_blocks "sed -n with <,> in script"      "sed -n 's/<a>/<b>/p' file.html"
 assert_blocks "sed -n with ; on real file"     "sed -n '1p;2p' README.md"
 assert_blocks "sed -i with ; in script"        "sed -i 's/a/b/;s/c/d/' file.txt"
+# Double-quoted variants of the same bypass cases:
+assert_blocks "sed -n with ; in dq script"     'sed -n "1p;2p" README.md'
+assert_blocks "sed -n with <,> in dq script"   'sed -n "s/<a>/<b>/p" file.html'
+assert_blocks "sed -i with ; in dq script"     'sed -i "s/a/b/;s/c/d/" file.txt'
+# Filename containing a metachar inside double quotes (literal, not redirect)
+assert_blocks "cat dq filename with >"         'cat "file>bar.txt"'
 # End-of-options (`--`) handling: positional args after `--` must still block
 # even when they start with `-`. Closes the bypass/false-positive gap surfaced
 # by Copilot.
@@ -127,6 +139,9 @@ assert_allows "cat with heredoc"               "cat <<EOF > out.md"
 assert_allows "cat 'quoted' | grep"            "cat 'foo' | grep bar"
 assert_allows "sed -n 'script' | head"         "sed -n '1,5p' file | head"
 assert_allows "compound with quoted script"    "echo a | sed -n '1p;2p'"
+# Double-quoted command substitution must still trigger early-out
+assert_allows "cat \"\$(...)\" preserved"      'cat "$(echo file)"'
+assert_allows "cat \`...\` in dq preserved"    'cat "`echo file`"'
 assert_allows "head with pipe"                 "git log | head -5"
 assert_allows "tail with pipe"                 "git log | tail -5"
 assert_allows "find with pipe"                 "find . | head -10"

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -131,6 +131,10 @@ assert_blocks "cat backslash-escaped ;"        'cat file\;bar.txt'
 # Inline `-e SCRIPT` form should still block (equivalent to bare-script form).
 assert_blocks "sed -n -e inline script"        'sed -n -e "5,10p" file.log'
 assert_blocks "sed -n -e single-quoted"        "sed -n -e '5p' file.txt"
+# GNU sed long forms equivalent to -n
+assert_blocks "sed --quiet inline script"      "sed --quiet '5p' file.txt"
+assert_blocks "sed --silent inline script"     "sed --silent '5p' file.log"
+assert_blocks "sed --quiet on README.md"       "sed --quiet '1,10p' README.md"
 # Wrapper / path / env-assignment bypasses: HEAD detection now peels
 # leading wrappers and takes basename. Bare-wrapper forms only — flag-
 # bearing forms like `sudo -u user cat` remain a documented limitation.
@@ -180,6 +184,9 @@ assert_allows "snippet with carriage return"   "$(printf 'cat foo\rls bar')"
 # to us, so Read/Grep can't substitute. Pass through.
 assert_allows "sed -n -f external script"      "sed -n -f script.sed file.log"
 assert_allows "sed -nf combined cluster"       "sed -nf script.sed file.log"
+# --quiet/--silent + -f still allowed (external script content unknown)
+assert_allows "sed --quiet -f external"        "sed --quiet -f script.sed file.log"
+assert_allows "sed --silent -f external"       "sed --silent -f script.sed file.log"
 assert_allows "head with pipe"                 "git log | head -5"
 assert_allows "tail with pipe"                 "git log | tail -5"
 assert_allows "find with pipe"                 "find . | head -10"

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Tests for .claude/hooks/block-bash-tool-mapping.sh
+#
+# Run: bash .agent/scripts/tests/test_block_bash_tool_mapping.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${SCRIPT_DIR}/../../../.claude/hooks/block-bash-tool-mapping.sh"
+
+if [[ ! -x "$HOOK" ]]; then
+    echo "FATAL: hook not found or not executable at $HOOK"
+    exit 1
+fi
+
+# Tests need a writable HOME so the sidecar log doesn't pollute the real one
+TMP_HOME=$(mktemp -d /tmp/tool-mapping-test-XXXXXX)
+trap 'rm -rf "$TMP_HOME"' EXIT
+mkdir -p "$TMP_HOME/.claude"
+
+PASS=0
+FAIL=0
+
+run_hook() {
+    # $1 = command-string ; echoes nothing ; returns hook exit code
+    local cmd="$1"
+    local input
+    input=$(jq -n --arg cmd "$cmd" '{
+        session_id: "test", tool_name: "Bash",
+        tool_input: {command: $cmd, description: "test"},
+        cwd: "/tmp", permission_mode: "default"
+    }')
+    # shellcheck disable=SC2034
+    local exit_code
+    HOME="$TMP_HOME" bash "$HOOK" <<< "$input"
+}
+
+assert_blocks() {
+    local label="$1" cmd="$2"
+    local rc
+    run_hook "$cmd" >/dev/null 2>&1
+    rc=$?
+    if [[ "$rc" -eq 2 ]]; then
+        echo "  PASS [block]:   $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL [block]:   $label  (expected exit 2, got $rc)"
+        echo "     command: $cmd"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_allows() {
+    local label="$1" cmd="$2"
+    local rc
+    run_hook "$cmd" >/dev/null 2>&1
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        echo "  PASS [allow]:   $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL [allow]:   $label  (expected exit 0, got $rc)"
+        echo "     command: $cmd"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo
+echo "=== Block cases ==="
+assert_blocks "cat single file"                "cat README.md"
+assert_blocks "cat multiple files"             "cat src/a.ts src/b.ts"
+assert_blocks "head -N file (short flag)"      "head -5 file.md"
+assert_blocks "head -n N file"                 "head -n 50 log.txt"
+assert_blocks "head file (no count)"           "head file.txt"
+assert_blocks "tail -N file"                   "tail -100 log.txt"
+assert_blocks "tail -n N file"                 "tail -n 200 log.txt"
+assert_blocks "find -name"                     "find . -name '*.ts'"
+assert_blocks "find -type -name"               "find . -type f -name '*.md'"
+assert_blocks "find no args (just path)"       "find ."
+assert_blocks "sed -n line print"              "sed -n '40,80p' file.txt"
+assert_blocks "sed -n single line"             "sed -n 5p file"
+assert_blocks "sed -i in-place"                "sed -i 's/x/y/' file.txt"
+assert_blocks "sed -i with extension"          "sed -i.bak 's/x/y/' file.txt"
+assert_blocks "sed --in-place long form"       "sed --in-place 's/x/y/' file.txt"
+
+echo
+echo "=== Allow cases (early-outs: pipes/redirects/heredocs) ==="
+assert_allows "cat with pipe"                  "cat foo | grep bar"
+assert_allows "cat with redirect"              "cat foo > out.txt"
+assert_allows "cat with heredoc"               "cat <<EOF > out.md"
+assert_allows "head with pipe"                 "git log | head -5"
+assert_allows "tail with pipe"                 "git log | tail -5"
+assert_allows "find with pipe"                 "find . | head -10"
+assert_allows "sed with pipe"                  "echo hi | sed 's/i/o/'"
+assert_allows "compound command (&&)"          "cd /tmp && cat file"
+assert_allows "command substitution"           "cat \$(echo file.txt)"
+
+echo
+echo "=== Allow cases (special-mode flags) ==="
+assert_allows "head -c byte mode"              "head -c 100 file.bin"
+assert_allows "head -c attached form"          "head -c100 file.bin"
+assert_allows "head --bytes long form"         "head --bytes=100 file.bin"
+assert_allows "tail -f follow"                 "tail -f /var/log/syslog"
+assert_allows "tail -F retry follow"           "tail -F /var/log/syslog"
+assert_allows "tail --follow"                  "tail --follow=name /var/log/x"
+assert_allows "find with -exec"                "find . -name '*.tmp' -exec rm {} +"
+assert_allows "find with -delete"              "find . -name '*.tmp' -delete"
+assert_allows "find with -mtime"               "find . -mtime -7"
+assert_allows "find with -size"                "find . -size +1M"
+assert_allows "find with -newer"               "find . -newer ref.txt"
+assert_allows "find -print0"                   "find . -print0"
+assert_allows "sed stream substitution"        "sed 's/x/y/' file"
+assert_allows "sed without flags or file"      "sed"
+
+echo
+echo "=== Allow cases (unrelated commands) ==="
+assert_allows "plain echo"                     "echo hello"
+assert_allows "git log"                        "git log -5"
+assert_allows "make target"                    "make test"
+assert_allows "python script"                  "python3 script.py"
+assert_allows "empty command"                  ""
+
+echo
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -128,6 +128,9 @@ assert_blocks "cat dq filename with >"         'cat "file>bar.txt"'
 assert_blocks "cat backslash-escaped >"        'cat file\>bar.txt'
 assert_blocks "cat backslash-escaped |"        'cat file\|bar.txt'
 assert_blocks "cat backslash-escaped ;"        'cat file\;bar.txt'
+# Inline `-e SCRIPT` form should still block (equivalent to bare-script form).
+assert_blocks "sed -n -e inline script"        'sed -n -e "5,10p" file.log'
+assert_blocks "sed -n -e single-quoted"        "sed -n -e '5p' file.txt"
 # End-of-options (`--`) handling: positional args after `--` must still block
 # even when they start with `-`. Closes the bypass/false-positive gap surfaced
 # by Copilot.
@@ -153,6 +156,13 @@ assert_allows "compound with quoted script"    "echo a | sed -n '1p;2p'"
 # Double-quoted command substitution must still trigger early-out
 assert_allows "cat \"\$(...)\" preserved"      'cat "$(echo file)"'
 assert_allows "cat \`...\` in dq preserved"    'cat "`echo file`"'
+# Newline (multi-line bash snippet) is a statement separator — compound.
+assert_allows "multi-line snippet"             "$(printf 'cat foo\nls bar')"
+assert_allows "snippet with carriage return"   "$(printf 'cat foo\rls bar')"
+# `sed -n -f script.sed file` runs an external script; content unknown
+# to us, so Read/Grep can't substitute. Pass through.
+assert_allows "sed -n -f external script"      "sed -n -f script.sed file.log"
+assert_allows "sed -nf combined cluster"       "sed -nf script.sed file.log"
 assert_allows "head with pipe"                 "git log | head -5"
 assert_allows "tail with pipe"                 "git log | tail -5"
 assert_allows "find with pipe"                 "find . | head -10"

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -97,6 +97,14 @@ assert_blocks "sed -niE combined with -E"      "sed -niE 's/x/y/' file.txt"
 assert_blocks "find bare path"                 "find /etc"
 assert_blocks "find single arg path"           "find ."
 assert_blocks "find no args (implicit .)"      "find"
+# Quoted-metacharacter bypass: shell metachars (`;`, `<`, `>`) inside
+# single-quoted sed scripts/regexes must NOT trigger the compound/redirect
+# early-out. Previously `sed -n '1p;2p' file` passed through.
+assert_blocks "sed -n with ; in script"        "sed -n '1p;2p' file"
+assert_blocks "sed -n with ; in regex"         "sed -n '/foo;bar/p' file.log"
+assert_blocks "sed -n with <,> in script"      "sed -n 's/<a>/<b>/p' file.html"
+assert_blocks "sed -n with ; on real file"     "sed -n '1p;2p' README.md"
+assert_blocks "sed -i with ; in script"        "sed -i 's/a/b/;s/c/d/' file.txt"
 # End-of-options (`--`) handling: positional args after `--` must still block
 # even when they start with `-`. Closes the bypass/false-positive gap surfaced
 # by Copilot.
@@ -114,6 +122,11 @@ echo "=== Allow cases (early-outs: pipes/redirects/heredocs) ==="
 assert_allows "cat with pipe"                  "cat foo | grep bar"
 assert_allows "cat with redirect"              "cat foo > out.txt"
 assert_allows "cat with heredoc"               "cat <<EOF > out.md"
+# Confirm the single-quote stripping doesn't break legitimate compound commands
+# that happen to have quoted args next to unquoted metacharacters.
+assert_allows "cat 'quoted' | grep"            "cat 'foo' | grep bar"
+assert_allows "sed -n 'script' | head"         "sed -n '1,5p' file | head"
+assert_allows "compound with quoted script"    "echo a | sed -n '1p;2p'"
 assert_allows "head with pipe"                 "git log | head -5"
 assert_allows "tail with pipe"                 "git log | tail -5"
 assert_allows "find with pipe"                 "find . | head -10"

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -30,8 +30,6 @@ run_hook() {
         tool_input: {command: $cmd, description: "test"},
         cwd: "/tmp", permission_mode: "default"
     }')
-    # shellcheck disable=SC2034
-    local exit_code
     HOME="$TMP_HOME" bash "$HOOK" <<< "$input"
 }
 

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -79,9 +79,25 @@ assert_blocks "find -type -name"               "find . -type f -name '*.md'"
 assert_blocks "find no args (just path)"       "find ."
 assert_blocks "sed -n line print"              "sed -n '40,80p' file.txt"
 assert_blocks "sed -n single line"             "sed -n 5p file"
+# Regression cases for the broken char-class heuristic. Each of these uses a
+# real-world filename that contains lowercase 's', 'd', or 'p' — characters
+# that the original heuristic mistook for sed-script tokens, causing
+# false-negatives on the marquee case.
+assert_blocks "sed -n on README.md"            "sed -n '5,10p' README.md"
+assert_blocks "sed -n on notes.md"             "sed -n '5,10p' notes.md"
+assert_blocks "sed -n on package.json"         "sed -n '1,20p' package.json"
+assert_blocks "sed -n on src/main.rs"          "sed -n 5p src/main.rs"
+assert_blocks "sed -ne combined cluster"       "sed -ne '5,10p' README.md"
 assert_blocks "sed -i in-place"                "sed -i 's/x/y/' file.txt"
 assert_blocks "sed -i with extension"          "sed -i.bak 's/x/y/' file.txt"
 assert_blocks "sed --in-place long form"       "sed --in-place 's/x/y/' file.txt"
+# Combined-cluster in-place forms — these previously bypassed has_sed_inplace.
+assert_blocks "sed -ni combined cluster"       "sed -ni 's/x/y/' file.txt"
+assert_blocks "sed -in combined cluster"       "sed -in 's/x/y/' file.txt"
+assert_blocks "sed -niE combined with -E"      "sed -niE 's/x/y/' file.txt"
+# Bare-find enumeration (documented as broader than just -name searches)
+assert_blocks "find bare path"                 "find /etc"
+assert_blocks "find single arg path"           "find ."
 
 echo
 echo "=== Allow cases (early-outs: pipes/redirects/heredocs) ==="
@@ -111,6 +127,10 @@ assert_allows "find with -newer"               "find . -newer ref.txt"
 assert_allows "find -print0"                   "find . -print0"
 assert_allows "sed stream substitution"        "sed 's/x/y/' file"
 assert_allows "sed without flags or file"      "sed"
+# sed -n alone with one non-flag token = script only, stdin source (would be
+# piped in real use → early-outed; this synthetic standalone test confirms
+# the non-flag-count branch correctly distinguishes script-only from script+file).
+assert_allows "sed -n script only (stdin)"     "sed -n '5p'"
 
 echo
 echo "=== Allow cases (unrelated commands) ==="

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -8,6 +8,11 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="${SCRIPT_DIR}/../../../.claude/hooks/block-bash-tool-mapping.sh"
 
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FATAL: jq is required to run these tests (and by the hook itself)" >&2
+    exit 1
+fi
+
 if [[ ! -x "$HOOK" ]]; then
     echo "FATAL: hook not found or not executable at $HOOK"
     exit 1

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -96,6 +96,7 @@ assert_blocks "sed -niE combined with -E"      "sed -niE 's/x/y/' file.txt"
 # Bare-find enumeration (documented as broader than just -name searches)
 assert_blocks "find bare path"                 "find /etc"
 assert_blocks "find single arg path"           "find ."
+assert_blocks "find no args (implicit .)"      "find"
 # End-of-options (`--`) handling: positional args after `--` must still block
 # even when they start with `-`. Closes the bypass/false-positive gap surfaced
 # by Copilot.

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -96,6 +96,17 @@ assert_blocks "sed -niE combined with -E"      "sed -niE 's/x/y/' file.txt"
 # Bare-find enumeration (documented as broader than just -name searches)
 assert_blocks "find bare path"                 "find /etc"
 assert_blocks "find single arg path"           "find ."
+# End-of-options (`--`) handling: positional args after `--` must still block
+# even when they start with `-`. Closes the bypass/false-positive gap surfaced
+# by Copilot.
+assert_blocks "cat -- -file (dash filename)"   "cat -- -file"
+assert_blocks "cat -- README.md"               "cat -- README.md"
+assert_blocks "head -- -file"                  "head -- -file"
+assert_blocks "head 5 -- -file"                "head 5 -- -file"
+assert_blocks "tail -- -log"                   "tail -- -log"
+assert_blocks "find -- -delete (as path)"      "find -- -delete"
+assert_blocks "sed -n -- '5p' -input"          "sed -n -- '5p' -input"
+assert_blocks "sed -i -- 's/x/y/' -input"      "sed -i -- 's/x/y/' -input"
 
 echo
 echo "=== Allow cases (early-outs: pipes/redirects/heredocs) ==="
@@ -129,6 +140,13 @@ assert_allows "sed without flags or file"      "sed"
 # piped in real use → early-outed; this synthetic standalone test confirms
 # the non-flag-count branch correctly distinguishes script-only from script+file).
 assert_allows "sed -n script only (stdin)"     "sed -n '5p'"
+# `sed -- 'SCRIPT' -input` is plain stream substitution (no -i/-n before --),
+# so it should fall through. The leading `-` on the filename must NOT trigger
+# has_sed_inplace because it's a positional arg, not a flag.
+assert_allows "sed -- stream sub w/ dash file" "sed -- 's/x/y/' -input"
+# head/tail with `--` and a byte-mode flag before `--`
+assert_allows "head -c -- file"                "head -c 100 -- file.bin"
+assert_allows "tail -f -- file"                "tail -f -- /var/log/x"
 
 echo
 echo "=== Allow cases (unrelated commands) ==="

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -148,6 +148,8 @@ assert_allows "find with -mtime"               "find . -mtime -7"
 assert_allows "find with -size"                "find . -size +1M"
 assert_allows "find with -newer"               "find . -newer ref.txt"
 assert_allows "find -print0"                   "find . -print0"
+assert_allows "find --help"                    "find --help"
+assert_allows "find --version"                 "find --version"
 assert_allows "sed stream substitution"        "sed 's/x/y/' file"
 assert_allows "sed without flags or file"      "sed"
 # sed -n alone with one non-flag token = script only, stdin source (would be

--- a/.agent/scripts/tests/test_block_bash_tool_mapping.sh
+++ b/.agent/scripts/tests/test_block_bash_tool_mapping.sh
@@ -122,6 +122,12 @@ assert_blocks "sed -n with <,> in dq script"   'sed -n "s/<a>/<b>/p" file.html'
 assert_blocks "sed -i with ; in dq script"     'sed -i "s/a/b/;s/c/d/" file.txt'
 # Filename containing a metachar inside double quotes (literal, not redirect)
 assert_blocks "cat dq filename with >"         'cat "file>bar.txt"'
+# Backslash-escaped metacharacters are literal in bash, not redirects.
+# Previously `cat file\>bar.txt` bypassed the block because `>` triggered
+# the compound early-out before backslash-escapes were stripped.
+assert_blocks "cat backslash-escaped >"        'cat file\>bar.txt'
+assert_blocks "cat backslash-escaped |"        'cat file\|bar.txt'
+assert_blocks "cat backslash-escaped ;"        'cat file\;bar.txt'
 # End-of-options (`--`) handling: positional args after `--` must still block
 # even when they start with `-`. Closes the bypass/false-positive gap surfaced
 # by Copilot.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -51,3 +51,14 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 
 ### Actions
 - [x] Add `--` end-of-options handling — fixed in `d735122`. Split TOKENS into FLAG_ARGS (pre-`--`) and POS_ARGS (post-`--`, always positional). Closes both gaps: `cat -- -file` now blocks; `sed -- 'expr' -input` now falls through. 11 regression tests added; 65/65 pass.
+
+## External Review (re-triage 2)
+**Status**: complete
+**When**: 2026-05-11 14:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `e31ce0b` — 1 new Copilot review (2 comments)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Align `find` docs with bare-find blocking — fixed in `c2cfdd3`. Updated CLAUDE.md and hook header from `find <path> [...]` to `find [path] [...]` (path optional, bare `find` defaults to `.`). Added `find` (no args) test; 66/66 pass.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -50,4 +50,4 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 **CI**: all-pass (8/8)
 
 ### Actions
-- [ ] (Low priority) Add `--` end-of-options handling, OR document the gap in the hook's pass-through docstring. Heuristic gap: `cat -- -file` bypasses block; `sed -- SCRIPT -input` false-positives `has_sed_inplace`. Real but pathological (requires filenames starting with `-`). — `.claude/hooks/block-bash-tool-mapping.sh:56`
+- [x] Add `--` end-of-options handling — fixed in `d735122`. Split TOKENS into FLAG_ARGS (pre-`--`) and POS_ARGS (post-`--`, always positional). Closes both gaps: `cat -- -file` now blocks; `sed -- 'expr' -input` now falls through. 11 regression tests added; 65/65 pass.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -28,3 +28,15 @@ issue: 197
 
 ### Cross-model
 Not dispatched this pass — Claude adversarial findings substantive enough to fix first; re-review after.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-11 13:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 — 2 review(s), 2 valid, 0 false positives (4 stale-but-addressed, 1 plan-file artifact skipped)
+**CI**: all-pass (8/8)
+
+### Actions
+- [ ] Harden `LOG_FILE="${HOME}/..."` against unset `HOME` (use `${HOME:-/tmp}` or drop `set -u`) — `.claude/hooks/block-bash-tool-mapping.sh:31`
+- [ ] Remove unused `local exit_code` + SC2034 suppression — `.agent/scripts/tests/test_block_bash_tool_mapping.sh:33-34`

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -110,3 +110,14 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 - [x] Add `command -v jq` guard at top of test script for clear missing-dep error — fixed in `8f7c803`.
 - [x] Split CLAUDE.md Tool Mapping row to match hook's granular sed behavior (`sed -i`/`awk -i` → Edit; `sed -n` → Read/Grep) — fixed in `8f7c803`.
 - [n/a] Heredoc leading-space concern: **false positive**. Verified with `cat -A` — stderr is left-aligned, no indentation.
+
+## External Review (re-triage 7)
+**Status**: complete
+**When**: 2026-05-12 09:45
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `4ea18fe` — 1 new Copilot review (1 comment)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Move `umask`/`mkdir -p` into `emit_block()` so allowed Bash calls and non-Bash tool calls never touch `~/.claude/` — fixed in `f406daa`. Verified empirically: allowed `echo hello` leaves test $HOME empty.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -169,3 +169,15 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 
 ### Actions
 - [x] Normalize HEAD against wrappers, env-assignments, and path prefix — fixed in `95682e3`. Closes bypasses: `/bin/cat`, `sudo cat`, `command cat`, `env cat`, `nohup cat`, `time cat`, `FOO=1 cat`, stacked wrappers, etc. 14 regression tests added; 108/108 pass. Documented limitation: wrapper-with-flags forms (`sudo -u user cat`) still bypass — per-wrapper flag tables would be disproportionate for a nudge hook.
+
+## External Review (re-triage 12)
+**Status**: complete
+**When**: 2026-05-12 10:55
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `454570e` — 1 new Copilot review (2 comments)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Catch GNU sed `--quiet`/`--silent` long forms (equivalent to `-n`) — fixed in `594870c`. Added `has_sed_quiet` helper; `-f` exemption preserved. 5 regression tests added; 113/113 pass.
+- [x] Drop "nudge" wording in wrapper-flags comment (Copilot has flagged this framing repeatedly) — fixed in `594870c`. Replaced with plain trade-off description.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -38,5 +38,5 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 **CI**: all-pass (8/8)
 
 ### Actions
-- [ ] Harden `LOG_FILE="${HOME}/..."` against unset `HOME` (use `${HOME:-/tmp}` or drop `set -u`) — `.claude/hooks/block-bash-tool-mapping.sh:31`
-- [ ] Remove unused `local exit_code` + SC2034 suppression — `.agent/scripts/tests/test_block_bash_tool_mapping.sh:33-34`
+- [x] Harden `LOG_FILE="${HOME}/..."` against unset `HOME` — fixed in `dc52801` (`${HOME:-/tmp}`)
+- [x] Remove unused `local exit_code` + SC2034 suppression — fixed in `67d576c`

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -1,0 +1,30 @@
+---
+issue: 197
+---
+
+# Issue #197 — claude permissions: reduce prompt friction (umbrella) — log truncation, gh_create_pr.sh wrapper, tool-mapping nudge hook
+
+## Local Review
+**Status**: complete
+**When**: 2026-05-10 05:55
+**By**: Claude Code Agent (claude-opus-4-7)
+**Verdict**: changes-requested
+
+**PR**: #200 at `20992ab`
+**Depth**: Deep (reason: enforcement files + 329 lines + security-relevant)
+**Must-fix**: 3 | **Suggestions**: 3
+
+### Findings
+- [ ] (must-fix) `sed -n 'EXPR' <file>` heuristic uses char-class `[pPdDsSyYqQ;{}]` to detect sed-script vs file path, but those chars are present in nearly every real filename (README.md, notes.md, package.json, src/main.rs all bypass). Headline case broken — test fixtures used `file.txt`/`log.txt`/`file` which lack the chars, masking the bug. — `.claude/hooks/block-bash-tool-mapping.sh:178`
+- [ ] (must-fix) Combined short-flag `-ni` bypasses in-place detection (`has_sed_inplace` only checks `-i`, `-i.*`, `-i[!-]*`, `--in-place`). `sed -ni 's/x/y/' file.txt` writes in-place but is allowed. — `.claude/hooks/block-bash-tool-mapping.sh:158`
+- [ ] (must-fix) Bare `find <path>` blocks, broader than CLAUDE.md's documented `find PATH -name PAT` framing. Either narrow trigger or update doc (recommend update doc — bare-find enumeration is what Glob is for). — `.claude/hooks/block-bash-tool-mapping.sh:134`
+- [ ] (suggestion) Add tests using real filenames (`README.md`, `notes.md`, `src/main.rs`, `package.json`) for `sed -n`, and `sed -ni`/`sed -in` combined-flag tests. — `.agent/scripts/tests/test_block_bash_tool_mapping.sh`
+- [ ] (suggestion) Block message advertises bypass ("add a pipe or redirect"). Honest but could be tightened. — `.claude/hooks/block-bash-tool-mapping.sh:emit_block`
+- [ ] (suggestion) `mkdir -p "$(dirname "$LOG_FILE")"` before sidecar-log append so logging works on a fresh `~/.claude/` setup. — `.claude/hooks/block-bash-tool-mapping.sh:log`
+
+### Governance concerns
+- "A change includes its consequences" — test fixtures didn't include realistic filenames, hiding a marquee bug
+- "Test what breaks" — 43 tests but fixture-name coincidence avoided exercising the broken char-class
+
+### Cross-model
+Not dispatched this pass — Claude adversarial findings substantive enough to fix first; re-review after.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -15,12 +15,12 @@ issue: 197
 **Must-fix**: 3 | **Suggestions**: 3
 
 ### Findings
-- [ ] (must-fix) `sed -n 'EXPR' <file>` heuristic uses char-class `[pPdDsSyYqQ;{}]` to detect sed-script vs file path, but those chars are present in nearly every real filename (README.md, notes.md, package.json, src/main.rs all bypass). Headline case broken — test fixtures used `file.txt`/`log.txt`/`file` which lack the chars, masking the bug. — `.claude/hooks/block-bash-tool-mapping.sh:178`
-- [ ] (must-fix) Combined short-flag `-ni` bypasses in-place detection (`has_sed_inplace` only checks `-i`, `-i.*`, `-i[!-]*`, `--in-place`). `sed -ni 's/x/y/' file.txt` writes in-place but is allowed. — `.claude/hooks/block-bash-tool-mapping.sh:158`
-- [ ] (must-fix) Bare `find <path>` blocks, broader than CLAUDE.md's documented `find PATH -name PAT` framing. Either narrow trigger or update doc (recommend update doc — bare-find enumeration is what Glob is for). — `.claude/hooks/block-bash-tool-mapping.sh:134`
-- [ ] (suggestion) Add tests using real filenames (`README.md`, `notes.md`, `src/main.rs`, `package.json`) for `sed -n`, and `sed -ni`/`sed -in` combined-flag tests. — `.agent/scripts/tests/test_block_bash_tool_mapping.sh`
-- [ ] (suggestion) Block message advertises bypass ("add a pipe or redirect"). Honest but could be tightened. — `.claude/hooks/block-bash-tool-mapping.sh:emit_block`
-- [ ] (suggestion) `mkdir -p "$(dirname "$LOG_FILE")"` before sidecar-log append so logging works on a fresh `~/.claude/` setup. — `.claude/hooks/block-bash-tool-mapping.sh:log`
+- [x] (must-fix) `sed -n 'EXPR' <file>` heuristic uses char-class `[pPdDsSyYqQ;{}]` to detect sed-script vs file path — broken on real filenames. Fixed in 9227e26 by replacing with non-flag-token count (script + file = 2 → block). — `.claude/hooks/block-bash-tool-mapping.sh:178`
+- [x] (must-fix) Combined short-flag `-ni` bypasses in-place detection. Fixed in 9227e26: `has_sed_inplace` now matches `-*i*` against any single-dash cluster. — `.claude/hooks/block-bash-tool-mapping.sh:158`
+- [x] (must-fix) Bare `find <path>` blocks broader than doc claimed. Resolved in 9227e26 by updating CLAUDE.md and stderr message to match actual behavior (Glob covers bare-path enumeration too). — `.claude/hooks/block-bash-tool-mapping.sh:134`
+- [x] (suggestion) Added 11 regression tests in 9227e26: sed -n against README.md/notes.md/package.json/src/main.rs, sed -ni/-in/-niE combined clusters, bare find /etc and find ., sed -n script-only (stdin allow). — `.agent/scripts/tests/test_block_bash_tool_mapping.sh`
+- [ ] (suggestion) Block message advertises bypass ("add a pipe or redirect"). Honest but could be tightened. Deferred — low priority. — `.claude/hooks/block-bash-tool-mapping.sh:emit_block`
+- [x] (suggestion) `mkdir -p "$(dirname "$LOG_FILE")"` added in 9227e26. — `.claude/hooks/block-bash-tool-mapping.sh:log`
 
 ### Governance concerns
 - "A change includes its consequences" — test fixtures didn't include realistic filenames, hiding a marquee bug

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -62,3 +62,14 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 
 ### Actions
 - [x] Align `find` docs with bare-find blocking — fixed in `c2cfdd3`. Updated CLAUDE.md and hook header from `find <path> [...]` to `find [path] [...]` (path optional, bare `find` defaults to `.`). Added `find` (no args) test; 66/66 pass.
+
+## External Review (re-triage 3)
+**Status**: complete
+**When**: 2026-05-11 14:20
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `4d7f408` — 1 new Copilot review (3 comments, same root cause)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Strip single-quoted regions before compound/redirect early-out — fixed in `eeb96f4`. Marquee bypass closed: `sed -n '1p;2p' README.md` now blocks (was exiting 0). 8 regression tests added; 74/74 pass. Known approximation: literal `>`/`<`/`;` inside double quotes still bypass (rare; documented inline).

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -158,3 +158,14 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 
 ### Actions
 - [x] Reword the operational-find list in the hook header docstring as illustrative ("e.g. ...") rather than exhaustive — fixed in `d7caa1e`. Avoids drift as the code's allowlist grows.
+
+## External Review (re-triage 11)
+**Status**: complete
+**When**: 2026-05-12 10:40
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `674c28c` — 1 new Copilot review (1 comment, multiple bypasses)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Normalize HEAD against wrappers, env-assignments, and path prefix — fixed in `95682e3`. Closes bypasses: `/bin/cat`, `sudo cat`, `command cat`, `env cat`, `nohup cat`, `time cat`, `FOO=1 cat`, stacked wrappers, etc. 14 regression tests added; 108/108 pass. Documented limitation: wrapper-with-flags forms (`sudo -u user cat`) still bypass — per-wrapper flag tables would be disproportionate for a nudge hook.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -40,3 +40,14 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 ### Actions
 - [x] Harden `LOG_FILE="${HOME}/..."` against unset `HOME` — fixed in `dc52801` (`${HOME:-/tmp}`)
 - [x] Remove unused `local exit_code` + SC2034 suppression — fixed in `67d576c`
+
+## External Review (re-triage)
+**Status**: complete
+**When**: 2026-05-11 13:45
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `903be0c` — 1 new Copilot review (1 comment)
+**CI**: all-pass (8/8)
+
+### Actions
+- [ ] (Low priority) Add `--` end-of-options handling, OR document the gap in the hook's pass-through docstring. Heuristic gap: `cat -- -file` bypasses block; `sed -- SCRIPT -input` false-positives `has_sed_inplace`. Real but pathological (requires filenames starting with `-`). — `.claude/hooks/block-bash-tool-mapping.sh:56`

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -147,3 +147,14 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 - [x] Add newline/CR to compound early-out — fixed in `255c0a5`. Multi-line bash snippets (`cat foo\nls bar`) no longer treated as simple cat. Test added.
 - [x] Skip sed `-n` block when `-f` is present (external sed script — content unknown) — fixed in `255c0a5`. `-e` inline still blocks. 2 -f allow tests + 2 -e block tests added.
 - [x] Update CLAUDE.md "Enforced by hook" + hook header to call out the `-e` block / `-f` pass-through nuance — fixed in `255c0a5`.
+
+## External Review (re-triage 10)
+**Status**: complete
+**When**: 2026-05-12 10:25
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `ea82982` — 1 new Copilot review (1 comment)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Reword the operational-find list in the hook header docstring as illustrative ("e.g. ...") rather than exhaustive — fixed in `d7caa1e`. Avoids drift as the code's allowlist grows.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -84,3 +84,15 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 
 ### Actions
 - [x] Allow `find --help`/`--version` (informational, not enumeration) and rewrite the misleading "nudge, not a parser" comment to match block-on-match behavior — fixed in `c0f7616`. 2 regression tests added; 76/76 pass.
+
+## External Review (re-triage 5)
+**Status**: complete
+**When**: 2026-05-11 14:50
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `ad67a10` — 1 new Copilot review (2 comments)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Extend quote-stripping to double-quoted regions (when free of `$(`/backticks) — fixed in `bacc64b`. Closes `sed -n "1p;2p" file` bypass. Preserves `cat "$(cmd)"` early-out.
+- [x] Make `head`/`tail` numeric exemption stateful — fixed in `bacc64b`. `head 123` now blocks (was bypassing as "count"); only numeric tokens immediately after `-n`/`--lines`/`-c`/`--bytes` are exempted. 9 regression tests added; 85/85 pass.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -73,3 +73,14 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 
 ### Actions
 - [x] Strip single-quoted regions before compound/redirect early-out — fixed in `eeb96f4`. Marquee bypass closed: `sed -n '1p;2p' README.md` now blocks (was exiting 0). 8 regression tests added; 74/74 pass. Known approximation: literal `>`/`<`/`;` inside double quotes still bypass (rare; documented inline).
+
+## External Review (re-triage 4)
+**Status**: complete
+**When**: 2026-05-11 14:35
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `f850f79` — 1 new Copilot review (2 comments)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Allow `find --help`/`--version` (informational, not enumeration) and rewrite the misleading "nudge, not a parser" comment to match block-on-match behavior — fixed in `c0f7616`. 2 regression tests added; 76/76 pass.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -134,3 +134,16 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 - [x] Strip backslash-escape pairs (`\X`) from COMPOUND_CHECK before metachar early-out — fixed in `091656f`. Closes `cat file\>bar.txt` bypass (was exit 0).
 - [x] Fix CLAUDE.md awk row: `awk -i` is gawk's include-library flag, not in-place. Move awk to its own broad row (`awk (any)` → Edit); keep sed granular — fixed in `091656f`.
 - [x] Simplify `"${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"` to `"${FLAG_ARGS[@]}"` (7 occurrences); safe under `set -u` on bash 4.4+ — fixed in `091656f`. 88/88 pass.
+
+## External Review (re-triage 9)
+**Status**: complete
+**When**: 2026-05-12 10:15
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `c9a23c5` — 1 new Copilot review (3 comments)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Add newline/CR to compound early-out — fixed in `255c0a5`. Multi-line bash snippets (`cat foo\nls bar`) no longer treated as simple cat. Test added.
+- [x] Skip sed `-n` block when `-f` is present (external sed script — content unknown) — fixed in `255c0a5`. `-e` inline still blocks. 2 -f allow tests + 2 -e block tests added.
+- [x] Update CLAUDE.md "Enforced by hook" + hook header to call out the `-e` block / `-f` pass-through nuance — fixed in `255c0a5`.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -96,3 +96,17 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 ### Actions
 - [x] Extend quote-stripping to double-quoted regions (when free of `$(`/backticks) — fixed in `bacc64b`. Closes `sed -n "1p;2p" file` bypass. Preserves `cat "$(cmd)"` early-out.
 - [x] Make `head`/`tail` numeric exemption stateful — fixed in `bacc64b`. `head 123` now blocks (was bypassing as "count"); only numeric tokens immediately after `-n`/`--lines`/`-c`/`--bytes` are exempted. 9 regression tests added; 85/85 pass.
+
+## External Review (re-triage 6)
+**Status**: complete
+**When**: 2026-05-12 09:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `cdcc90e` — 1 new Copilot review (4 comments: 3 valid, 1 false positive)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Defer `umask`/`mkdir -p` until after the Bash check (hook is wildcard PreToolUse so was running for every tool call) — fixed in `8f7c803`.
+- [x] Add `command -v jq` guard at top of test script for clear missing-dep error — fixed in `8f7c803`.
+- [x] Split CLAUDE.md Tool Mapping row to match hook's granular sed behavior (`sed -i`/`awk -i` → Edit; `sed -n` → Read/Grep) — fixed in `8f7c803`.
+- [n/a] Heredoc leading-space concern: **false positive**. Verified with `cat -A` — stderr is left-aligned, no indentation.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -121,3 +121,16 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 
 ### Actions
 - [x] Move `umask`/`mkdir -p` into `emit_block()` so allowed Bash calls and non-Bash tool calls never touch `~/.claude/` — fixed in `f406daa`. Verified empirically: allowed `echo hello` leaves test $HOME empty.
+
+## External Review (re-triage 8)
+**Status**: complete
+**When**: 2026-05-12 10:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #200 at `4e5b841` — 1 new Copilot review (3 comments)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Strip backslash-escape pairs (`\X`) from COMPOUND_CHECK before metachar early-out — fixed in `091656f`. Closes `cat file\>bar.txt` bypass (was exit 0).
+- [x] Fix CLAUDE.md awk row: `awk -i` is gawk's include-library flag, not in-place. Move awk to its own broad row (`awk (any)` → Edit); keep sed granular — fixed in `091656f`.
+- [x] Simplify `"${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"` to `"${FLAG_ARGS[@]}"` (7 occurrences); safe under `set -u` on bash 4.4+ — fixed in `091656f`. 88/88 pass.

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -37,8 +37,6 @@
 
 set -u
 LOG_FILE="${HOME:-/tmp}/.claude/tool-mapping-blocks.jsonl"
-umask 077
-mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 
 INPUT=$(cat)
 
@@ -49,6 +47,13 @@ fi
 
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
 [[ "$TOOL" != "Bash" ]] && exit 0
+
+# Defer logging-dir setup until we know this is a Bash call. The hook is
+# wired as a wildcard PreToolUse in .claude/settings.json, so it runs for
+# Read/Edit/Write/etc. too; doing this work earlier would create
+# ~/.claude/ on every non-Bash tool call for no reason.
+umask 077
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 [[ -z "$COMMAND" ]] && exit 0

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -13,6 +13,10 @@
 #   find [path] [...]                    → Glob (any non-operational find,
 #                                          including bare `find` which defaults to .)
 #   sed -n 'SCRIPT' <file>               → Read with offset/limit (or Grep)
+#                                          (also blocks `sed -n -e SCRIPT file`;
+#                                          `sed -n -f script.sed file` passes
+#                                          through — external script content is
+#                                          unknown to us)
 #   sed -i ... <file>                    → Edit
 #                                          (incl. combined-cluster forms: -ni, -in, --in-place)
 #
@@ -107,9 +111,11 @@ while (( i < n )); do
     i=$((i + 1))
 done
 
-# Early-out: any compound/redirect/subshell construct → allow
+# Early-out: any compound/redirect/subshell construct → allow.
+# Newlines and carriage returns count as statement separators (a multi-line
+# Bash snippet is a sequence of independent commands, not a "simple read").
 case "$COMPOUND_CHECK" in
-    *\|*|*\>*|*\<*|*\&\&*|*\;*|*\$\(*|*\`*) exit 0 ;;
+    *\|*|*\>*|*\<*|*\&\&*|*\;*|*\$\(*|*\`*|*$'\n'*|*$'\r'*) exit 0 ;;
 esac
 
 # Tokenize on whitespace; quoting is approximate (good enough for flag detection)
@@ -307,7 +313,13 @@ case "$HEAD" in
         # across both halves: non-flag tokens before `--` + every token after
         # `--`. Script + file = 2 positional → block. Script alone means
         # stdin (would have a pipe → already early-outed).
-        if has_short_flag_letter n "${FLAG_ARGS[@]}"; then
+        #
+        # Exempt -f: `sed -n -f script.sed file` runs an external sed script
+        # whose contents are unknown to us; Read/Grep can't replicate it.
+        # `-e 'SCRIPT'` is functionally equivalent to the bare-script form,
+        # so we keep blocking it.
+        if has_short_flag_letter n "${FLAG_ARGS[@]}" \
+           && ! has_short_flag_letter f "${FLAG_ARGS[@]}"; then
             non_flag_count=$(count_non_flag_args "${FLAG_ARGS[@]}")
             total_positional=$((non_flag_count + ${#POS_ARGS[@]}))
             if [[ "$total_positional" -ge 2 ]]; then

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -53,8 +53,23 @@ TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 [[ -z "$COMMAND" ]] && exit 0
 
+# Strip single-quoted regions ('...') so metachars inside quoted sed
+# scripts/regexes (e.g. `sed -n '1p;2p' file`, `sed -n 's/<x>//p' file`)
+# don't false-trigger the compound/redirect early-out below. Double-quoted
+# regions are left intact so `"$(...)"` command substitution still
+# triggers early-out correctly. Tradeoff: literal `>`/`<`/`;` inside
+# double quotes (e.g. `cat "file>bar"`) will still early-out — that's
+# acceptable since this hook is a nudge, not a parser.
+COMPOUND_CHECK="$COMMAND"
+while [[ "$COMPOUND_CHECK" == *\'*\'* ]]; do
+    before="${COMPOUND_CHECK%%\'*}"
+    after_first="${COMPOUND_CHECK#*\'}"
+    after_second="${after_first#*\'}"
+    COMPOUND_CHECK="${before}${after_second}"
+done
+
 # Early-out: any compound/redirect/subshell construct → allow
-case "$COMMAND" in
+case "$COMPOUND_CHECK" in
     *\|*|*\>*|*\<*|*\&\&*|*\;*|*\$\(*|*\`*) exit 0 ;;
 esac
 

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -9,11 +9,11 @@
 # Patterns blocked:
 #   cat <file> ...                       → Read
 #   head [-n] N <file>                   → Read with limit
-#   tail [-n] N <file>                   → Read (tail-relative not supported; use Read with offset)
-#   find <path> [-name|-iname|-type|-path] ...
-#                                        → Glob
-#   sed -n 'EXPR' <file>                 → Read with offset/limit (or Grep for /regex/)
+#   tail [-n] N <file>                   → Read with offset
+#   find <path> [...]                    → Glob (any non-operational find)
+#   sed -n 'SCRIPT' <file>               → Read with offset/limit (or Grep)
 #   sed -i ... <file>                    → Edit
+#                                          (incl. combined-cluster forms: -ni, -in, --in-place)
 #
 # Pass-through (early-out):
 #   anything containing | > < << <<< >> && || ; $( ` (compound/redirect/subshell)
@@ -21,7 +21,7 @@
 #   tail -c ... / tail -f / tail -F      (byte/follow modes)
 #   find ... -exec/-execdir/-delete/-mtime/-mmin/-cmin/-amin/-size/-newer/-prune/-print0/-fls/-ls
 #                                        (operational find)
-#   sed without -i and without -n        (often a stream substitution stage; ambiguous)
+#   sed without -i and without -n        (stream substitution stage)
 #   anything not starting with cat/head/tail/find/sed
 #
 # Side-effects: logs each block to ~/.claude/tool-mapping-blocks.jsonl so we
@@ -30,6 +30,7 @@
 set -u
 LOG_FILE="${HOME}/.claude/tool-mapping-blocks.jsonl"
 umask 077
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 
 INPUT=$(cat)
 
@@ -68,8 +69,8 @@ $2
 
 CLAUDE.md tool mapping:
   cat / head / tail <file>  → Read
-  find PATH [-name PAT]     → Glob
-  sed -n 'EXPR' <file>      → Read (with offset/limit) or Grep
+  find PATH [...]           → Glob
+  sed -n 'SCRIPT' <file>    → Read (with offset/limit) or Grep
   sed -i ... <file>         → Edit
 
 Pipes, redirects, heredocs, and operational flags (head -c, tail -f,
@@ -91,25 +92,42 @@ EOF
     exit 2
 }
 
-has_exact_flag() {
-    # $1 = exact-match flag (e.g. -n); rest = tokens
-    local flag="$1"; shift
+has_short_flag_letter() {
+    # Returns 0 if any single-dash short-flag cluster contains $1.
+    # Examples for letter 'n': -n, -ne, -ni, -nE all match. --inplace does not.
+    local letter="$1"; shift
     local t
     for t in "$@"; do
-        [[ "$t" == "$flag" ]] && return 0
+        case "$t" in
+            --*) ;;
+            -*"$letter"*) return 0 ;;
+        esac
     done
     return 1
 }
 
 has_sed_inplace() {
-    # sed's in-place flag forms: -i, -i.bak, -iEXT, --in-place, --in-place=EXT
+    # sed's in-place flag: -i, -i.bak, -iEXT, combined-cluster forms (-ni, -in, -niE),
+    # and long form --in-place / --in-place=EXT.
     local t
     for t in "$@"; do
         case "$t" in
-            -i|-i.*|-i[!-]*|--in-place|--in-place=*) return 0 ;;
+            --in-place|--in-place=*) return 0 ;;
+            --*) ;;
+            -*i*) return 0 ;;
         esac
     done
     return 1
+}
+
+count_non_flag_args() {
+    # Counts tokens that don't start with '-'. Used to detect "script + file"
+    # in `sed -n SCRIPT FILE` (two non-flag tokens past `sed`).
+    local count=0 t
+    for t in "$@"; do
+        [[ "$t" != -* ]] && count=$((count + 1))
+    done
+    echo "$count"
 }
 
 # ---- per-command rules ------------------------------------------------------
@@ -146,7 +164,7 @@ case "$HEAD" in
         ;;
 
     find)
-        # Allow operational find
+        # Allow operational find (commands that do more than enumerate files)
         for tok in "${TOKENS[@]:1}"; do
             case "$tok" in
                 -exec|-execdir|-ok|-okdir|-delete|-mtime|-mmin|-cmin|-amin| \
@@ -156,26 +174,27 @@ case "$HEAD" in
                     ;;
             esac
         done
-        # Anything else (typical: find . -name '*.ts' or find . -type f -name *.md)
-        emit_block "find for file search blocked." \
+        # Anything else (bare `find PATH`, `find . -name ...`, `find . -type f`)
+        # is filesystem enumeration → Glob.
+        emit_block "find for file enumeration blocked." \
             "Use the Glob tool instead."
         ;;
 
     sed)
-        # Block in-place edit (any -i / -i.bak / --in-place form)
+        # Block in-place edit (any -i form, including combined short-flag clusters)
         if has_sed_inplace "${TOKENS[@]:1}"; then
             emit_block "sed -i (in-place edit) blocked." \
                 "Use the Edit tool instead."
         fi
-        # Block -n print-mode (sed -n 'EXPR' file) when a file arg is present
-        if has_exact_flag -n "${TOKENS[@]:1}"; then
-            # Find the last non-flag, non-quoted-script token; if it's a file path, block
-            LAST="${TOKENS[-1]:-}"
-            # Heuristic: a "file" looks like a path/identifier without sed metachars
-            if [[ -n "$LAST" && "$LAST" != -* ]] && \
-               ! [[ "$LAST" =~ [pPdDsSyYqQ\;\{\}] ]] && \
-               ! [[ "$LAST" =~ ^[\'\"] ]]; then
-                emit_block "sed -n 'EXPR' <file> blocked." \
+        # Block -n print-mode (sed -n 'SCRIPT' FILE) by counting non-flag tokens
+        # past sed. Script + file = 2 non-flag tokens; script alone (1) means
+        # stdin (which would have a pipe → already early-outed) and we allow.
+        # Combined-cluster forms like `sed -ne SCRIPT FILE` are caught because
+        # the cluster matches has_short_flag_letter 'n' and SCRIPT/FILE both
+        # don't start with '-'.
+        if has_short_flag_letter n "${TOKENS[@]:1}"; then
+            if [[ "$(count_non_flag_args "${TOKENS[@]:1}")" -ge 2 ]]; then
+                emit_block "sed -n 'SCRIPT' <file> blocked." \
                     "Use the Read tool with offset/limit (or Grep for /regex/)."
             fi
         fi

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -122,7 +122,34 @@ esac
 
 # Tokenize on whitespace; quoting is approximate (good enough for flag detection)
 read -ra TOKENS <<< "$COMMAND"
-HEAD="${TOKENS[0]:-}"
+
+# Normalize the head of the command so simple invocation wrappers don't
+# bypass the block. Two peeling rules and a basename strip:
+#   1) Leading `VAR=value` env-assignment tokens (`FOO=1 cat file`)
+#   2) Bare wrapper commands (`sudo cat`, `command cat`, `env cat`, etc.)
+#   3) Basename of the resulting head (`/bin/cat` → `cat`)
+# Wrapper *flags* are NOT parsed — `sudo -u user cat file` and similar
+# forms remain a known bypass. Adding per-wrapper flag tables would be
+# disproportionate; this hook is a nudge, not a security boundary.
+head_idx=0
+while (( head_idx < ${#TOKENS[@]} )); do
+    tok="${TOKENS[$head_idx]}"
+    if [[ "$tok" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+        head_idx=$((head_idx + 1))
+        continue
+    fi
+    case "${tok##*/}" in
+        sudo|command|env|exec|nice|nohup|time|busybox|stdbuf|ionice|chrt)
+            head_idx=$((head_idx + 1))
+            continue
+            ;;
+    esac
+    break
+done
+# Rebuild TOKENS to start at the resolved head, then basename it.
+TOKENS=("${TOKENS[@]:$head_idx}")
+HEAD_FULL="${TOKENS[0]:-}"
+HEAD="${HEAD_FULL##*/}"
 
 case "$HEAD" in
     cat|head|tail|find|sed) ;;

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -28,7 +28,7 @@
 # can measure how often the hook fires.
 
 set -u
-LOG_FILE="${HOME}/.claude/tool-mapping-blocks.jsonl"
+LOG_FILE="${HOME:-/tmp}/.claude/tool-mapping-blocks.jsonl"
 umask 077
 mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -24,6 +24,13 @@
 #   sed without -i and without -n        (stream substitution stage)
 #   anything not starting with cat/head/tail/find/sed
 #
+# End-of-options (`--`) handling:
+#   Flag heuristics scan only tokens before `--`. Tokens after `--` are
+#   treated as positional args (files for cat/head/tail/sed, paths for find)
+#   regardless of leading `-`. So `cat -- -file` blocks (file read);
+#   `sed -- 's/x/y/' -input` falls through (no -i/-n flag before --);
+#   `find -- -delete` blocks (`-delete` after `--` is a path, not the op flag).
+#
 # Side-effects: logs each block to ~/.claude/tool-mapping-blocks.jsonl so we
 # can measure how often the hook fires.
 
@@ -58,6 +65,26 @@ case "$HEAD" in
     cat|head|tail|find|sed) ;;
     *) exit 0 ;;
 esac
+
+# Split args at the first `--` end-of-options marker.
+# FLAG_ARGS: tokens before `--`, scanned by flag heuristics.
+# POS_ARGS:  tokens after `--`, always treated as positional (file/path) args
+#            even if they start with `-`. When `--` is absent, FLAG_ARGS holds
+#            everything past the command name and POS_ARGS is empty.
+FLAG_ARGS=()
+POS_ARGS=()
+saw_dashdash=0
+for tok in "${TOKENS[@]:1}"; do
+    if [[ "$saw_dashdash" -eq 0 && "$tok" == "--" ]]; then
+        saw_dashdash=1
+        continue
+    fi
+    if [[ "$saw_dashdash" -eq 1 ]]; then
+        POS_ARGS+=("$tok")
+    else
+        FLAG_ARGS+=("$tok")
+    fi
+done
 
 # ---- helpers ----------------------------------------------------------------
 
@@ -136,15 +163,20 @@ case "$HEAD" in
     cat)
         # Block if any non-flag arg follows; cat can be used to emit a literal
         # without args (cat with stdin would pipe — already early-outed).
-        for tok in "${TOKENS[@]:1}"; do
+        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
             [[ "$tok" != -* ]] && \
                 emit_block "cat <file> blocked." "Use the Read tool instead."
         done
+        # Anything after `--` is a positional file arg, even if it starts with `-`.
+        if [[ "${#POS_ARGS[@]}" -gt 0 ]]; then
+            emit_block "cat <file> blocked." "Use the Read tool instead."
+        fi
         ;;
 
     head|tail)
-        # Allow byte mode (-c) and follow mode (-f/-F for tail)
-        for tok in "${TOKENS[@]:1}"; do
+        # Allow byte mode (-c) and follow mode (-f/-F for tail). Mode flags
+        # only count before `--`.
+        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
             case "$tok" in
                 -c|-c[0-9]*|--bytes|--bytes=*) exit 0 ;;
             esac
@@ -155,17 +187,23 @@ case "$HEAD" in
             fi
         done
         # Block if any non-flag, non-numeric arg follows (i.e., a file)
-        for tok in "${TOKENS[@]:1}"; do
+        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
             if [[ "$tok" != -* && ! "$tok" =~ ^[0-9]+$ ]]; then
                 emit_block "$HEAD <file> blocked." \
                     "Use the Read tool instead (limit/offset for partial reads)."
             fi
         done
+        # Anything after `--` is a positional file arg.
+        if [[ "${#POS_ARGS[@]}" -gt 0 ]]; then
+            emit_block "$HEAD <file> blocked." \
+                "Use the Read tool instead (limit/offset for partial reads)."
+        fi
         ;;
 
     find)
-        # Allow operational find (commands that do more than enumerate files)
-        for tok in "${TOKENS[@]:1}"; do
+        # Allow operational find (commands that do more than enumerate files).
+        # Operational predicates only count before `--`; after `--` they're paths.
+        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
             case "$tok" in
                 -exec|-execdir|-ok|-okdir|-delete|-mtime|-mmin|-cmin|-amin| \
                 -size|-newer|-newer*|-prune|-print0|-fls|-ls|-fprint|-fprint0| \
@@ -174,31 +212,34 @@ case "$HEAD" in
                     ;;
             esac
         done
-        # Anything else (bare `find PATH`, `find . -name ...`, `find . -type f`)
-        # is filesystem enumeration → Glob.
+        # Anything else (bare `find PATH`, `find . -name ...`, `find . -type f`,
+        # `find -- -delete` where -delete is now a path) is enumeration → Glob.
         emit_block "find for file enumeration blocked." \
             "Use the Glob tool instead."
         ;;
 
     sed)
-        # Block in-place edit (any -i form, including combined short-flag clusters)
-        if has_sed_inplace "${TOKENS[@]:1}"; then
+        # Block in-place edit (any -i form, including combined short-flag
+        # clusters). Flag heuristics only consider tokens before `--`.
+        if has_sed_inplace "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; then
             emit_block "sed -i (in-place edit) blocked." \
                 "Use the Edit tool instead."
         fi
-        # Block -n print-mode (sed -n 'SCRIPT' FILE) by counting non-flag tokens
-        # past sed. Script + file = 2 non-flag tokens; script alone (1) means
-        # stdin (which would have a pipe → already early-outed) and we allow.
-        # Combined-cluster forms like `sed -ne SCRIPT FILE` are caught because
-        # the cluster matches has_short_flag_letter 'n' and SCRIPT/FILE both
-        # don't start with '-'.
-        if has_short_flag_letter n "${TOKENS[@]:1}"; then
-            if [[ "$(count_non_flag_args "${TOKENS[@]:1}")" -ge 2 ]]; then
+        # Block -n print-mode (sed -n 'SCRIPT' FILE). Count positional args
+        # across both halves: non-flag tokens before `--` + every token after
+        # `--`. Script + file = 2 positional → block. Script alone means
+        # stdin (would have a pipe → already early-outed).
+        if has_short_flag_letter n "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; then
+            non_flag_count=$(count_non_flag_args "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}")
+            total_positional=$((non_flag_count + ${#POS_ARGS[@]}))
+            if [[ "$total_positional" -ge 2 ]]; then
                 emit_block "sed -n 'SCRIPT' <file> blocked." \
                     "Use the Read tool with offset/limit (or Grep for /regex/)."
             fi
         fi
-        # Plain sed without -i/-n falls through (often a stream substitution stage)
+        # Plain sed without -i/-n falls through (stream substitution stage).
+        # Note: `sed -- 's/x/y/' -input` falls through here even though `-input`
+        # looks flag-like — that's correct: no -i/-n present.
         ;;
 esac
 

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -10,7 +10,8 @@
 #   cat <file> ...                       → Read
 #   head [-n] N <file>                   → Read with limit
 #   tail [-n] N <file>                   → Read with offset
-#   find <path> [...]                    → Glob (any non-operational find)
+#   find [path] [...]                    → Glob (any non-operational find,
+#                                          including bare `find` which defaults to .)
 #   sed -n 'SCRIPT' <file>               → Read with offset/limit (or Grep)
 #   sed -i ... <file>                    → Edit
 #                                          (incl. combined-cluster forms: -ni, -in, --in-place)

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -53,15 +53,19 @@ TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 [[ -z "$COMMAND" ]] && exit 0
 
-# Strip single-quoted regions ('...') so metachars inside quoted sed
-# scripts/regexes (e.g. `sed -n '1p;2p' file`, `sed -n 's/<x>//p' file`)
-# don't false-trigger the compound/redirect early-out below. Double-quoted
-# regions are left intact so `"$(...)"` command substitution still
-# triggers early-out correctly. Tradeoff: literal `>`/`<`/`;` inside
-# double quotes (e.g. `cat "file>bar"`) will still early-out and allow
-# the call through. This is a deliberate approximation: full quote-aware
-# bash parsing would be disproportionate to the gain, and the
-# double-quoted-metachar pattern is rare in practice for cat/head/tail/sed.
+# Strip quoted regions from a working copy of $COMMAND before the
+# compound/redirect early-out so metachars inside quoted sed
+# scripts/regexes (e.g. `sed -n '1p;2p' file`, `sed -n "s/<x>//p" file`)
+# don't false-trigger an early-out.
+#
+# Single-quoted regions: always safe to strip (everything inside `'...'`
+# is literal in bash).
+#
+# Double-quoted regions: stripped only when they don't contain `$(` or
+# backticks. Inside `"..."` those constructs are still expanded by bash,
+# so `"$(cmd)"` must remain visible to the compound check. Plain
+# `"file>bar"` is safe to strip because `>`/`<`/`;` inside `"..."` are
+# literal characters, not redirections.
 COMPOUND_CHECK="$COMMAND"
 while [[ "$COMPOUND_CHECK" == *\'*\'* ]]; do
     before="${COMPOUND_CHECK%%\'*}"
@@ -69,6 +73,23 @@ while [[ "$COMPOUND_CHECK" == *\'*\'* ]]; do
     after_second="${after_first#*\'}"
     COMPOUND_CHECK="${before}${after_second}"
 done
+# Strip "safe" double-quoted regions (no command substitution inside).
+COMPOUND_TEMP="$COMPOUND_CHECK"
+COMPOUND_CHECK=""
+while [[ "$COMPOUND_TEMP" == *\"*\"* ]]; do
+    before="${COMPOUND_TEMP%%\"*}"
+    after_first="${COMPOUND_TEMP#*\"}"
+    dq_content="${after_first%%\"*}"
+    after_second="${after_first#*\"}"
+    if [[ "$dq_content" == *\$\(* || "$dq_content" == *\`* ]]; then
+        # Has command substitution — preserve so early-out can fire
+        COMPOUND_CHECK+="${before}\"${dq_content}\""
+    else
+        COMPOUND_CHECK+="$before"
+    fi
+    COMPOUND_TEMP="$after_second"
+done
+COMPOUND_CHECK+="$COMPOUND_TEMP"
 
 # Early-out: any compound/redirect/subshell construct → allow
 case "$COMPOUND_CHECK" in
@@ -204,12 +225,26 @@ case "$HEAD" in
                 esac
             fi
         done
-        # Block if any non-flag, non-numeric arg follows (i.e., a file)
+        # Block if any non-flag arg follows (i.e., a file). A bare numeric
+        # token is only a count when it follows -n / --lines / -c / --bytes;
+        # otherwise coreutils treats it as a filename (`head 123` reads file
+        # `123`). The legacy `-N` count form (e.g. `head -5 file`) starts
+        # with `-` and is already skipped by the non-flag test.
+        prev=""
         for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
-            if [[ "$tok" != -* && ! "$tok" =~ ^[0-9]+$ ]]; then
+            if [[ "$tok" =~ ^[0-9]+$ ]]; then
+                case "$prev" in
+                    -n|--lines|-c|--bytes)
+                        prev="$tok"
+                        continue
+                        ;;
+                esac
+            fi
+            if [[ "$tok" != -* ]]; then
                 emit_block "$HEAD <file> blocked." \
                     "Use the Read tool instead (limit/offset for partial reads)."
             fi
+            prev="$tok"
         done
         # Anything after `--` is a positional file arg.
         if [[ "${#POS_ARGS[@]}" -gt 0 ]]; then

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -58,8 +58,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 # don't false-trigger the compound/redirect early-out below. Double-quoted
 # regions are left intact so `"$(...)"` command substitution still
 # triggers early-out correctly. Tradeoff: literal `>`/`<`/`;` inside
-# double quotes (e.g. `cat "file>bar"`) will still early-out — that's
-# acceptable since this hook is a nudge, not a parser.
+# double quotes (e.g. `cat "file>bar"`) will still early-out and allow
+# the call through. This is a deliberate approximation: full quote-aware
+# bash parsing would be disproportionate to the gain, and the
+# double-quoted-metachar pattern is rare in practice for cat/head/tail/sed.
 COMPOUND_CHECK="$COMMAND"
 while [[ "$COMPOUND_CHECK" == *\'*\'* ]]; do
     before="${COMPOUND_CHECK%%\'*}"
@@ -217,10 +219,14 @@ case "$HEAD" in
         ;;
 
     find)
-        # Allow operational find (commands that do more than enumerate files).
-        # Operational predicates only count before `--`; after `--` they're paths.
+        # Allow operational find (commands that do more than enumerate files)
+        # and informational flags (`--help`, `--version`). Operational
+        # predicates only count before `--`; after `--` they're paths.
         for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
             case "$tok" in
+                --help|--version|-help|-version|--usage)
+                    exit 0
+                    ;;
                 -exec|-execdir|-ok|-okdir|-delete|-mtime|-mmin|-cmin|-amin| \
                 -size|-newer|-newer*|-prune|-print0|-fls|-ls|-fprint|-fprint0| \
                 -inum|-empty|-perm|-user|-group|-uid|-gid|-quit)

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# Block Bash patterns that should use dedicated tools per CLAUDE.md tool mapping.
+#
+# Configured as a PreToolUse hook. Blocks the call (exit 2 + stderr message)
+# when the agent reaches for cat/head/tail/find/sed against a file in a
+# context where Read/Glob/Edit would do the same job. Pipes, redirects,
+# heredocs, and special-mode flags pass through.
+#
+# Patterns blocked:
+#   cat <file> ...                       → Read
+#   head [-n] N <file>                   → Read with limit
+#   tail [-n] N <file>                   → Read (tail-relative not supported; use Read with offset)
+#   find <path> [-name|-iname|-type|-path] ...
+#                                        → Glob
+#   sed -n 'EXPR' <file>                 → Read with offset/limit (or Grep for /regex/)
+#   sed -i ... <file>                    → Edit
+#
+# Pass-through (early-out):
+#   anything containing | > < << <<< >> && || ; $( ` (compound/redirect/subshell)
+#   head -c ... / head -c                (byte mode)
+#   tail -c ... / tail -f / tail -F      (byte/follow modes)
+#   find ... -exec/-execdir/-delete/-mtime/-mmin/-cmin/-amin/-size/-newer/-prune/-print0/-fls/-ls
+#                                        (operational find)
+#   sed without -i and without -n        (often a stream substitution stage; ambiguous)
+#   anything not starting with cat/head/tail/find/sed
+#
+# Side-effects: logs each block to ~/.claude/tool-mapping-blocks.jsonl so we
+# can measure how often the hook fires.
+
+set -u
+LOG_FILE="${HOME}/.claude/tool-mapping-blocks.jsonl"
+umask 077
+
+INPUT=$(cat)
+
+# jq is required for input parsing; bail gracefully if absent
+if ! command -v jq &>/dev/null; then
+    exit 0
+fi
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
+[[ "$TOOL" != "Bash" ]] && exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+[[ -z "$COMMAND" ]] && exit 0
+
+# Early-out: any compound/redirect/subshell construct → allow
+case "$COMMAND" in
+    *\|*|*\>*|*\<*|*\&\&*|*\;*|*\$\(*|*\`*) exit 0 ;;
+esac
+
+# Tokenize on whitespace; quoting is approximate (good enough for flag detection)
+read -ra TOKENS <<< "$COMMAND"
+HEAD="${TOKENS[0]:-}"
+
+case "$HEAD" in
+    cat|head|tail|find|sed) ;;
+    *) exit 0 ;;
+esac
+
+# ---- helpers ----------------------------------------------------------------
+
+emit_block() {
+    # $1 = headline ; $2 = suggestion
+    cat >&2 <<EOF
+[tool-mapping] $1
+$2
+
+CLAUDE.md tool mapping:
+  cat / head / tail <file>  → Read
+  find PATH [-name PAT]     → Glob
+  sed -n 'EXPR' <file>      → Read (with offset/limit) or Grep
+  sed -i ... <file>         → Edit
+
+Pipes, redirects, heredocs, and operational flags (head -c, tail -f,
+find -exec/-delete/-mtime, etc.) pass through. To bypass intentionally,
+add a pipe or redirect — or just use the dedicated tool.
+EOF
+
+    # Log the block (best-effort; never fail the hook)
+    {
+        jq -n -c \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg head "$HEAD" \
+            --arg cmd "$COMMAND" \
+            --arg reason "$1" \
+            '{ts:$ts, head:$head, command:$cmd, reason:$reason}' \
+            >> "$LOG_FILE"
+    } 2>/dev/null || true
+
+    exit 2
+}
+
+has_exact_flag() {
+    # $1 = exact-match flag (e.g. -n); rest = tokens
+    local flag="$1"; shift
+    local t
+    for t in "$@"; do
+        [[ "$t" == "$flag" ]] && return 0
+    done
+    return 1
+}
+
+has_sed_inplace() {
+    # sed's in-place flag forms: -i, -i.bak, -iEXT, --in-place, --in-place=EXT
+    local t
+    for t in "$@"; do
+        case "$t" in
+            -i|-i.*|-i[!-]*|--in-place|--in-place=*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+# ---- per-command rules ------------------------------------------------------
+
+case "$HEAD" in
+    cat)
+        # Block if any non-flag arg follows; cat can be used to emit a literal
+        # without args (cat with stdin would pipe — already early-outed).
+        for tok in "${TOKENS[@]:1}"; do
+            [[ "$tok" != -* ]] && \
+                emit_block "cat <file> blocked." "Use the Read tool instead."
+        done
+        ;;
+
+    head|tail)
+        # Allow byte mode (-c) and follow mode (-f/-F for tail)
+        for tok in "${TOKENS[@]:1}"; do
+            case "$tok" in
+                -c|-c[0-9]*|--bytes|--bytes=*) exit 0 ;;
+            esac
+            if [[ "$HEAD" == tail ]]; then
+                case "$tok" in
+                    -f|-F|--follow|--follow=*|--retry) exit 0 ;;
+                esac
+            fi
+        done
+        # Block if any non-flag, non-numeric arg follows (i.e., a file)
+        for tok in "${TOKENS[@]:1}"; do
+            if [[ "$tok" != -* && ! "$tok" =~ ^[0-9]+$ ]]; then
+                emit_block "$HEAD <file> blocked." \
+                    "Use the Read tool instead (limit/offset for partial reads)."
+            fi
+        done
+        ;;
+
+    find)
+        # Allow operational find
+        for tok in "${TOKENS[@]:1}"; do
+            case "$tok" in
+                -exec|-execdir|-ok|-okdir|-delete|-mtime|-mmin|-cmin|-amin| \
+                -size|-newer|-newer*|-prune|-print0|-fls|-ls|-fprint|-fprint0| \
+                -inum|-empty|-perm|-user|-group|-uid|-gid|-quit)
+                    exit 0
+                    ;;
+            esac
+        done
+        # Anything else (typical: find . -name '*.ts' or find . -type f -name *.md)
+        emit_block "find for file search blocked." \
+            "Use the Glob tool instead."
+        ;;
+
+    sed)
+        # Block in-place edit (any -i / -i.bak / --in-place form)
+        if has_sed_inplace "${TOKENS[@]:1}"; then
+            emit_block "sed -i (in-place edit) blocked." \
+                "Use the Edit tool instead."
+        fi
+        # Block -n print-mode (sed -n 'EXPR' file) when a file arg is present
+        if has_exact_flag -n "${TOKENS[@]:1}"; then
+            # Find the last non-flag, non-quoted-script token; if it's a file path, block
+            LAST="${TOKENS[-1]:-}"
+            # Heuristic: a "file" looks like a path/identifier without sed metachars
+            if [[ -n "$LAST" && "$LAST" != -* ]] && \
+               ! [[ "$LAST" =~ [pPdDsSyYqQ\;\{\}] ]] && \
+               ! [[ "$LAST" =~ ^[\'\"] ]]; then
+                emit_block "sed -n 'EXPR' <file> blocked." \
+                    "Use the Read tool with offset/limit (or Grep for /regex/)."
+            fi
+        fi
+        # Plain sed without -i/-n falls through (often a stream substitution stage)
+        ;;
+esac
+
+exit 0

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -89,6 +89,24 @@ while [[ "$COMPOUND_TEMP" == *\"*\"* ]]; do
 done
 COMPOUND_CHECK+="$COMPOUND_TEMP"
 
+# Strip backslash-escape pairs from any remaining (unquoted) content.
+# In bash, `\X` outside quotes is always a literal X — `cat file\>bar.txt`
+# is `cat` reading one literal-named file, not a redirection. Without
+# stripping, `\>` here would false-trigger the early-out below.
+COMPOUND_TEMP="$COMPOUND_CHECK"
+COMPOUND_CHECK=""
+i=0
+n=${#COMPOUND_TEMP}
+while (( i < n )); do
+    ch="${COMPOUND_TEMP:$i:1}"
+    if [[ "$ch" == '\' ]]; then
+        i=$((i + 2))   # Skip backslash + the escaped char
+        continue
+    fi
+    COMPOUND_CHECK+="$ch"
+    i=$((i + 1))
+done
+
 # Early-out: any compound/redirect/subshell construct → allow
 case "$COMPOUND_CHECK" in
     *\|*|*\>*|*\<*|*\&\&*|*\;*|*\$\(*|*\`*) exit 0 ;;
@@ -205,7 +223,7 @@ case "$HEAD" in
     cat)
         # Block if any non-flag arg follows; cat can be used to emit a literal
         # without args (cat with stdin would pipe — already early-outed).
-        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
+        for tok in "${FLAG_ARGS[@]}"; do
             [[ "$tok" != -* ]] && \
                 emit_block "cat <file> blocked." "Use the Read tool instead."
         done
@@ -218,7 +236,7 @@ case "$HEAD" in
     head|tail)
         # Allow byte mode (-c) and follow mode (-f/-F for tail). Mode flags
         # only count before `--`.
-        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
+        for tok in "${FLAG_ARGS[@]}"; do
             case "$tok" in
                 -c|-c[0-9]*|--bytes|--bytes=*) exit 0 ;;
             esac
@@ -234,7 +252,7 @@ case "$HEAD" in
         # `123`). The legacy `-N` count form (e.g. `head -5 file`) starts
         # with `-` and is already skipped by the non-flag test.
         prev=""
-        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
+        for tok in "${FLAG_ARGS[@]}"; do
             if [[ "$tok" =~ ^[0-9]+$ ]]; then
                 case "$prev" in
                     -n|--lines|-c|--bytes)
@@ -260,7 +278,7 @@ case "$HEAD" in
         # Allow operational find (commands that do more than enumerate files)
         # and informational flags (`--help`, `--version`). Operational
         # predicates only count before `--`; after `--` they're paths.
-        for tok in "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; do
+        for tok in "${FLAG_ARGS[@]}"; do
             case "$tok" in
                 --help|--version|-help|-version|--usage)
                     exit 0
@@ -281,7 +299,7 @@ case "$HEAD" in
     sed)
         # Block in-place edit (any -i form, including combined short-flag
         # clusters). Flag heuristics only consider tokens before `--`.
-        if has_sed_inplace "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; then
+        if has_sed_inplace "${FLAG_ARGS[@]}"; then
             emit_block "sed -i (in-place edit) blocked." \
                 "Use the Edit tool instead."
         fi
@@ -289,8 +307,8 @@ case "$HEAD" in
         # across both halves: non-flag tokens before `--` + every token after
         # `--`. Script + file = 2 positional → block. Script alone means
         # stdin (would have a pipe → already early-outed).
-        if has_short_flag_letter n "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}"; then
-            non_flag_count=$(count_non_flag_args "${FLAG_ARGS[@]:+${FLAG_ARGS[@]}}")
+        if has_short_flag_letter n "${FLAG_ARGS[@]}"; then
+            non_flag_count=$(count_non_flag_args "${FLAG_ARGS[@]}")
             total_positional=$((non_flag_count + ${#POS_ARGS[@]}))
             if [[ "$total_positional" -ge 2 ]]; then
                 emit_block "sed -n 'SCRIPT' <file> blocked." \

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -24,8 +24,10 @@
 #   anything containing | > < << <<< >> && || ; $( ` (compound/redirect/subshell)
 #   head -c ... / head -c                (byte mode)
 #   tail -c ... / tail -f / tail -F      (byte/follow modes)
-#   find ... -exec/-execdir/-delete/-mtime/-mmin/-cmin/-amin/-size/-newer/-prune/-print0/-fls/-ls
-#                                        (operational find)
+#   find ... with any operational predicate, e.g. -exec / -delete / -mtime /
+#   -size / -newer / -prune / -ok / -fprint / -perm / -user / -quit ...
+#   (see the `find)` case below for the full allowlist; bare `--help` /
+#   `--version` also pass through)
 #   sed without -i and without -n        (stream substitution stage)
 #   anything not starting with cat/head/tail/find/sed
 #

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -13,7 +13,8 @@
 #   find [path] [...]                    → Glob (any non-operational find,
 #                                          including bare `find` which defaults to .)
 #   sed -n 'SCRIPT' <file>               → Read with offset/limit (or Grep)
-#                                          (also blocks `sed -n -e SCRIPT file`;
+#                                          (also blocks `sed -n -e SCRIPT file`
+#                                          and long-form `--quiet`/`--silent`;
 #                                          `sed -n -f script.sed file` passes
 #                                          through — external script content is
 #                                          unknown to us)
@@ -130,7 +131,7 @@ read -ra TOKENS <<< "$COMMAND"
 #   3) Basename of the resulting head (`/bin/cat` → `cat`)
 # Wrapper *flags* are NOT parsed — `sudo -u user cat file` and similar
 # forms remain a known bypass. Adding per-wrapper flag tables would be
-# disproportionate; this hook is a nudge, not a security boundary.
+# disproportionate to the gain for this small bypass class.
 head_idx=0
 while (( head_idx < ${#TOKENS[@]} )); do
     tok="${TOKENS[$head_idx]}"
@@ -242,6 +243,21 @@ has_sed_inplace() {
     return 1
 }
 
+has_sed_quiet() {
+    # Returns 0 if sed is in print-mode: short-flag `-n` (incl. clusters
+    # like `-ne`, `-nf`) OR GNU long forms `--quiet` / `--silent`.
+    if has_short_flag_letter n "$@"; then
+        return 0
+    fi
+    local t
+    for t in "$@"; do
+        case "$t" in
+            --quiet|--silent) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 count_non_flag_args() {
     # Counts tokens that don't start with '-'. Used to detect "script + file"
     # in `sed -n SCRIPT FILE` (two non-flag tokens past `sed`).
@@ -347,7 +363,7 @@ case "$HEAD" in
         # whose contents are unknown to us; Read/Grep can't replicate it.
         # `-e 'SCRIPT'` is functionally equivalent to the bare-script form,
         # so we keep blocking it.
-        if has_short_flag_letter n "${FLAG_ARGS[@]}" \
+        if has_sed_quiet "${FLAG_ARGS[@]}" \
            && ! has_short_flag_letter f "${FLAG_ARGS[@]}"; then
             non_flag_count=$(count_non_flag_args "${FLAG_ARGS[@]}")
             total_positional=$((non_flag_count + ${#POS_ARGS[@]}))

--- a/.claude/hooks/block-bash-tool-mapping.sh
+++ b/.claude/hooks/block-bash-tool-mapping.sh
@@ -48,13 +48,6 @@ fi
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
 [[ "$TOOL" != "Bash" ]] && exit 0
 
-# Defer logging-dir setup until we know this is a Bash call. The hook is
-# wired as a wildcard PreToolUse in .claude/settings.json, so it runs for
-# Read/Edit/Write/etc. too; doing this work earlier would create
-# ~/.claude/ on every non-Bash tool call for no reason.
-umask 077
-mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
-
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 [[ -z "$COMMAND" ]] && exit 0
 
@@ -149,8 +142,13 @@ find -exec/-delete/-mtime, etc.) pass through. To bypass intentionally,
 add a pipe or redirect — or just use the dedicated tool.
 EOF
 
-    # Log the block (best-effort; never fail the hook)
+    # Log the block (best-effort; never fail the hook). Logging-dir setup
+    # is deferred to here so it only runs when we're actually about to
+    # write — allowed Bash calls and non-Bash tool calls never touch
+    # ~/.claude/.
     {
+        umask 077
+        mkdir -p "$(dirname "$LOG_FILE")"
         jq -n -c \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg head "$HEAD" \

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -143,6 +143,11 @@
             "type": "command",
             "command": ".claude/hooks/log-tool-use.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-bash-tool-mapping.sh",
+            "timeout": 5
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ the dedicated tools are:
 | `ls`, `find` | Glob |
 | `grep`, `rg` | Grep |
 | `cat`, `head`, `tail` | Read |
-| `sed`, `awk` | Edit |
+| `sed -i`, `awk -i` | Edit |
+| `sed -n 'SCRIPT' <file>` | Read (offset/limit) or Grep |
 | `echo >`, heredoc redirection | Write |
 
 These are auto-approved and don't consume permission prompts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,10 @@ These are auto-approved and don't consume permission prompts.
 
 **Enforced by hook**: `.claude/hooks/block-bash-tool-mapping.sh` blocks
 Bash calls that match the simple cases — `cat <file>`, `head [-N] <file>`,
-`tail [-N] <file>`, `find <path> ...` (any filesystem enumeration without
-an operational flag), `sed -n 'SCRIPT' <file>`, and `sed -i ...` (including
-combined short-flag clusters like `-ni`). Pipes, redirects, heredocs, and
+`tail [-N] <file>`, `find [path] ...` (any filesystem enumeration without
+an operational flag, including bare `find` which defaults to `.`),
+`sed -n 'SCRIPT' <file>`, and `sed -i ...` (including combined short-flag
+clusters like `-ni`). Pipes, redirects, heredocs, and
 operational flags (`head -c`, `tail -f`, `find -exec/-delete/-mtime/...`,
 plain `sed 's/x/y/'` without `-i` or `-n`) pass through unchanged. Blocks
 are logged to `~/.claude/tool-mapping-blocks.jsonl` so we can measure how

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,14 @@ the dedicated tools are:
 These are auto-approved and don't consume permission prompts.
 
 **Enforced by hook**: `.claude/hooks/block-bash-tool-mapping.sh` blocks
-Bash calls that match the simple cases — `cat file`, `head -N file`,
-`tail -N file`, `find PATH -name PAT`, `sed -n 'EXPR' file`, `sed -i ...`.
-Pipes, redirects, heredocs, and operational flags (`head -c`, `tail -f`,
-`find -exec/-delete/-mtime`, `sed 's/x/y/'` without `-i`/`-n`) pass through
-unchanged. Blocks are logged to `~/.claude/tool-mapping-blocks.jsonl` so we
-can measure how often the hook fires.
+Bash calls that match the simple cases — `cat <file>`, `head [-N] <file>`,
+`tail [-N] <file>`, `find <path> ...` (any filesystem enumeration without
+an operational flag), `sed -n 'SCRIPT' <file>`, and `sed -i ...` (including
+combined short-flag clusters like `-ni`). Pipes, redirects, heredocs, and
+operational flags (`head -c`, `tail -f`, `find -exec/-delete/-mtime/...`,
+plain `sed 's/x/y/'` without `-i` or `-n`) pass through unchanged. Blocks
+are logged to `~/.claude/tool-mapping-blocks.jsonl` so we can measure how
+often the hook fires.
 
 ## Claude-Specific Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,9 @@ These are auto-approved and don't consume permission prompts.
 Bash calls that match the simple cases — `cat <file>`, `head [-N] <file>`,
 `tail [-N] <file>`, `find [path] ...` (any filesystem enumeration without
 an operational flag, including bare `find` which defaults to `.`),
-`sed -n 'SCRIPT' <file>`, and `sed -i ...` (including combined short-flag
-clusters like `-ni`). Pipes, redirects, heredocs, and
+`sed -n 'SCRIPT' <file>` (inline scripts, including `-e SCRIPT`; external
+`-f script.sed` passes through), and `sed -i ...` (including combined
+short-flag clusters like `-ni`). Pipes, redirects, heredocs, and
 operational flags (`head -c`, `tail -f`, `find -exec/-delete/-mtime/...`,
 plain `sed 's/x/y/'` without `-i` or `-n`) pass through unchanged. Blocks
 are logged to `~/.claude/tool-mapping-blocks.jsonl` so we can measure how

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ the dedicated tools are:
 
 These are auto-approved and don't consume permission prompts.
 
+**Enforced by hook**: `.claude/hooks/block-bash-tool-mapping.sh` blocks
+Bash calls that match the simple cases — `cat file`, `head -N file`,
+`tail -N file`, `find PATH -name PAT`, `sed -n 'EXPR' file`, `sed -i ...`.
+Pipes, redirects, heredocs, and operational flags (`head -c`, `tail -f`,
+`find -exec/-delete/-mtime`, `sed 's/x/y/'` without `-i`/`-n`) pass through
+unchanged. Blocks are logged to `~/.claude/tool-mapping-blocks.jsonl` so we
+can measure how often the hook fires.
+
 ## Claude-Specific Notes
 
 - Makefile `.PHONY` targets (excluding `help`) are available as `/make_*` slash commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ the dedicated tools are:
 | `ls`, `find` | Glob |
 | `grep`, `rg` | Grep |
 | `cat`, `head`, `tail` | Read |
-| `sed -i`, `awk -i` | Edit |
+| `sed -i ...` | Edit |
 | `sed -n 'SCRIPT' <file>` | Read (offset/limit) or Grep |
+| `awk` (any) | Edit |
 | `echo >`, heredoc redirection | Write |
 
 These are auto-approved and don't consume permission prompts.


### PR DESCRIPTION
## Summary

Part of #197 (item 3 of 3 — `PreToolUse` tool-mapping hook).

CLAUDE.md "Tool Mapping" has been documentation-only — Read over `cat`/`head`/`tail`, Glob over `find`, Edit over `sed`. The recent permission analysis showed agents reaching for the Bash forms anyway: **478 head + 243 tail + 128 cat + 76 find + 42 sed** invocations across 6 weeks. Per the workspace principle "enforcement over documentation," this PR turns the mapping into an enforced rule via a `PreToolUse` hook.

## How it works

When the agent runs a `Bash` tool call matching a simple file-mode invocation of one of the five commands, the hook exits 2 with a stderr message explaining what to use instead. Claude Code interprets non-zero exit + stderr as a denial — the tool call doesn't run, and the agent sees the guidance.

```
$ head -5 README.md   ← agent's call

[tool-mapping] head <file> blocked.
Use the Read tool instead (limit/offset for partial reads).

CLAUDE.md tool mapping:
  cat / head / tail <file>  → Read
  find PATH [-name PAT]     → Glob
  sed -n 'EXPR' <file>      → Read (with offset/limit) or Grep
  sed -i ... <file>         → Edit

Pipes, redirects, heredocs, and operational flags (head -c, tail -f,
find -exec/-delete/-mtime, etc.) pass through. To bypass intentionally,
add a pipe or redirect — or just use the dedicated tool.
```

## What blocks

| Pattern | Suggested tool |
|---------|----------------|
| `cat <file>` (one or more file args) | Read |
| `head [-n] N <file>` and bare `head <file>` | Read with limit |
| `tail [-n] N <file>` and bare `tail <file>` | Read with offset |
| `find PATH [-name/-iname/-type/-path] ...` (no operational flags) | Glob |
| `sed -n 'EXPR' <file>` | Read with offset/limit, or Grep for `/regex/` |
| `sed -i ... <file>` (incl. `-i.bak`, `--in-place`) | Edit |

## What passes through

Tightly scoped to avoid false positives. Early-outs:

- Any compound/redirect/subshell construct: `|`, `>`, `<`, `<<`, `<<<`, `>>`, `&&`, `||`, `;`, `$(...)`, `` ` ``
- `head -c` / `head --bytes` (byte mode — no Read equivalent)
- `tail -c` / `-f` / `-F` / `--follow` / `--retry`
- Operational `find`: `-exec`, `-execdir`, `-ok`, `-delete`, `-mtime`, `-mmin`, `-cmin`, `-amin`, `-size`, `-newer`, `-prune`, `-print0`, `-inum`, `-empty`, `-perm`, `-user`, `-group`, `-uid`, `-gid`, `-quit`, `-fls`, `-ls`
- `sed` without `-i` and without `-n` (stream-substitution stage)
- Commands not in {cat, head, tail, find, sed}

## Measurement

Every block writes a structured entry to `~/.claude/tool-mapping-blocks.jsonl`:

```json
{"ts":"2026-05-10T...","head":"head","command":"head -5 README.md","reason":"head <file> blocked."}
```

This lets us measure how often the hook fires and revisit the scope decision with data (e.g., expand to other commands, or tighten exceptions).

## Tests

`.agent/scripts/tests/test_block_bash_tool_mapping.sh` — 43 cases, all passing:

- **Block cases (15)**: each pattern from the table above, plus multi-file `cat`, bare `head file`, `find .`, `sed -i.bak`, `sed --in-place`.
- **Pipe/redirect early-outs (9)**: pipes through each command, redirects, heredocs, `&&` chains, `$(...)` substitution.
- **Special-flag allows (14)**: byte mode, follow modes, all the operational `find` flags, `sed` without `-i`/`-n`.
- **Unrelated commands (5)**: `echo`, `git log`, `make test`, `python3 script.py`, empty.

Run via `bash .agent/scripts/tests/test_block_bash_tool_mapping.sh`.

## Documentation

`CLAUDE.md` "Tool Mapping" section gains a note pointing at the hook and the bypass list.

## Wiring

Added to `.claude/settings.json` `PreToolUse` array alongside the existing `log-tool-use.sh`. Hooks run in order; the log hook still records every call (including blocked ones).

## Out of scope (deliberately)

- **Awk**: CLAUDE.md doesn't map `awk` to a dedicated tool, and `awk` has too many legitimate uses (one-line transforms in pipes). Not in scope.
- **Sed without `-i`/`-n`**: stream substitution piping or printing to stdout. Often a legitimate one-shot. The user can always switch to Edit when modifying a file.
- **`grep`/`rg`**: CLAUDE.md maps these to `Grep` but they're not in scope for this PR — separate decision since `grep` has more pipeline uses than the targeted commands.

## Test plan

- [x] All 43 unit tests pass
- [x] `pre-commit` passes on all touched files (shellcheck clean)
- [x] `jq -e .` parses `.claude/settings.json`
- [ ] After merge: spot-check a fresh agent session — `head -5 README.md` should be blocked; `head -5 README.md | grep foo` should pass; `head -c 100 file.bin` should pass.
- [ ] After merge: check `~/.claude/tool-mapping-blocks.jsonl` exists and accumulates entries.

---

**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
