### PR TITLE
feat(#197): gh_create_pr.sh wrapper — close umbrella item 2

### DIFF
--- a/.agent/scripts/gh_create_issue.sh
+++ b/.agent/scripts/gh_create_issue.sh
@@ -274,9 +274,11 @@ VALID_LABELS=$(jq -r '.labels[]' "$METADATA_FILE" 2>/dev/null) || {
 }
 
 # Validate each label
+# `--` terminates grep option parsing so labels starting with `-` are not
+# misread as flags (matters under ugrep / stricter grep).
 INVALID_LABELS=()
 for label in "${LABELS[@]}"; do
-    if ! echo "$VALID_LABELS" | grep -Fxq "$label"; then
+    if ! echo "$VALID_LABELS" | grep -Fxq -- "$label"; then
         INVALID_LABELS+=("$label")
     fi
 done

--- a/.agent/scripts/gh_create_pr.sh
+++ b/.agent/scripts/gh_create_pr.sh
@@ -71,13 +71,27 @@ if ! command -v jq &>/dev/null; then
     exit 3
 fi
 
+# Normalize joined-equals flag forms (--flag=VALUE → --flag VALUE) so the
+# downstream parse + rewrite logic only has to handle one shape per flag.
+# Without this, rewriting `ORIGINAL_ARGS[i]` for signature injection would
+# drop the `--body=` / `--body-file=` prefix.
+_RAW_ARGS=("$@")
+ORIGINAL_ARGS=()
+for arg in "${_RAW_ARGS[@]}"; do
+    case "$arg" in
+        --body=*)      ORIGINAL_ARGS+=(--body "${arg#*=}") ;;
+        --body-file=*) ORIGINAL_ARGS+=(--body-file "${arg#*=}") ;;
+        --repo=*)      ORIGINAL_ARGS+=(--repo "${arg#*=}") ;;
+        --label=*)     ORIGINAL_ARGS+=(--label "${arg#*=}") ;;
+        *)             ORIGINAL_ARGS+=("$arg") ;;
+    esac
+done
+
 # Parse command-line arguments. We need to know:
 #   - --label / -l values (for validation)
 #   - -R / --repo value (for repo-safety check)
 #   - --body / --body-file / --body-stdin (for signature injection)
 #   - --no-signature (skip footer)
-ORIGINAL_ARGS=("$@")
-
 LABELS=()
 EXPLICIT_REPO=""
 NO_SIGNATURE=false
@@ -100,10 +114,6 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
                 exit 2
             fi
             ;;
-        --repo=*)
-            EXPLICIT_REPO="${arg#*=}"
-            i=$((i + 1))
-            ;;
         --label|-l)
             if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
                 LABELS+=("${ORIGINAL_ARGS[$((i+1))]}")
@@ -111,10 +121,6 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
             else
                 i=$((i + 1))
             fi
-            ;;
-        --label=*)
-            LABELS+=("${arg#*=}")
-            i=$((i + 1))
             ;;
         --body)
             if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
@@ -125,11 +131,6 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
                 i=$((i + 1))
             fi
             ;;
-        --body=*)
-            BODY_TEXT="${arg#*=}"
-            BODY_ARG_INDEX=$i
-            i=$((i + 1))
-            ;;
         --body-file)
             if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
                 BODY_FILE_PATH="${ORIGINAL_ARGS[$((i+1))]}"
@@ -138,11 +139,6 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
             else
                 i=$((i + 1))
             fi
-            ;;
-        --body-file=*)
-            BODY_FILE_PATH="${arg#*=}"
-            BODY_FILE_ARG_INDEX=$i
-            i=$((i + 1))
             ;;
         --body-stdin)
             BODY_STDIN=true
@@ -199,15 +195,47 @@ if [ -z "$EXPLICIT_REPO" ]; then
     fi
 fi
 
+# --- Drain --body-stdin (always; wrapper-only flag) --------------------------
+# `--body-stdin` is not understood by `gh pr create`. Always rewrite it to
+# `--body-file <tmp>` regardless of signature decision; otherwise the flag
+# leaks through to gh and fails as "unknown flag".
+if [ "$BODY_STDIN" = true ]; then
+    STDIN_BODY_FILE=$(mktemp /tmp/gh_pr_body.XXXXXX.md)
+    trap 'rm -f "$STDIN_BODY_FILE"' EXIT
+    cat > "$STDIN_BODY_FILE"
+    NEW_ARGS=()
+    for arg in "${ORIGINAL_ARGS[@]}"; do
+        if [ "$arg" = "--body-stdin" ]; then
+            NEW_ARGS+=(--body-file "$STDIN_BODY_FILE")
+        else
+            NEW_ARGS+=("$arg")
+        fi
+    done
+    ORIGINAL_ARGS=("${NEW_ARGS[@]}")
+    BODY_FILE_PATH="$STDIN_BODY_FILE"
+    # Find the new --body-file value's index so signature injection can rewrite it.
+    for (( j=0; j<${#ORIGINAL_ARGS[@]}; j++ )); do
+        if [ "${ORIGINAL_ARGS[$j]}" = "--body-file" ]; then
+            BODY_FILE_ARG_INDEX=$((j + 1))
+            break
+        fi
+    done
+fi
+
 # --- AI signature injection --------------------------------------------------
 # Append the canonical signature footer unless:
 #   - --no-signature was passed
+#   - no body was provided at all (interactive `gh pr create` opens an editor)
 #   - body already contains **Authored-By**:
 # When signature is required but AGENT_NAME / AGENT_MODEL are unset,
 # hard-fail with instructions (workspace policy: PRs are signed).
 SIG_MARKER='**Authored-By**:'
 needs_signature() {
     [ "$NO_SIGNATURE" = true ] && return 1
+    # No body input at all → interactive editor mode → no injection
+    [ -z "$BODY_TEXT" ] && [ -z "$BODY_FILE_PATH" ] && return 1
+    # Already signed (catches stdin-drained content too, since BODY_FILE_PATH
+    # now points at the temp file)
     if [ -n "$BODY_TEXT" ]; then
         printf '%s' "$BODY_TEXT" | grep -Fq "$SIG_MARKER" && return 1
     elif [ -n "$BODY_FILE_PATH" ] && [ -f "$BODY_FILE_PATH" ]; then
@@ -233,30 +261,19 @@ if needs_signature; then
     if [ -n "$BODY_TEXT" ]; then
         ORIGINAL_ARGS[$BODY_ARG_INDEX]="${BODY_TEXT}${SIG_BLOCK}"
     elif [ -n "$BODY_FILE_PATH" ] && [ -f "$BODY_FILE_PATH" ]; then
-        SIGNED_BODY_FILE=$(mktemp /tmp/gh_pr_body.XXXXXX.md)
-        trap 'rm -f "$SIGNED_BODY_FILE"' EXIT
-        cp "$BODY_FILE_PATH" "$SIGNED_BODY_FILE"
-        printf '%s' "$SIG_BLOCK" >> "$SIGNED_BODY_FILE"
-        ORIGINAL_ARGS[$BODY_FILE_ARG_INDEX]="$SIGNED_BODY_FILE"
-    elif [ "$BODY_STDIN" = true ]; then
-        # Drain stdin, append signature, then convert --body-stdin to --body-file
-        SIGNED_BODY_FILE=$(mktemp /tmp/gh_pr_body.XXXXXX.md)
-        trap 'rm -f "$SIGNED_BODY_FILE"' EXIT
-        cat > "$SIGNED_BODY_FILE"
-        printf '%s' "$SIG_BLOCK" >> "$SIGNED_BODY_FILE"
-        # Rewrite ORIGINAL_ARGS: --body-stdin → --body-file <path>
-        NEW_ARGS=()
-        for arg in "${ORIGINAL_ARGS[@]}"; do
-            if [ "$arg" = "--body-stdin" ]; then
-                NEW_ARGS+=(--body-file "$SIGNED_BODY_FILE")
-            else
-                NEW_ARGS+=("$arg")
-            fi
-        done
-        ORIGINAL_ARGS=("${NEW_ARGS[@]}")
+        # Append directly to the existing temp file (for stdin) or copy+append
+        # for a user-provided body file. Either way, the on-disk file gets the
+        # signature and gh sees the same --body-file path.
+        if [ "$BODY_STDIN" = true ]; then
+            printf '%s' "$SIG_BLOCK" >> "$BODY_FILE_PATH"
+        else
+            SIGNED_BODY_FILE=$(mktemp /tmp/gh_pr_body.XXXXXX.md)
+            trap 'rm -f "$SIGNED_BODY_FILE" "${STDIN_BODY_FILE:-}"' EXIT
+            cp "$BODY_FILE_PATH" "$SIGNED_BODY_FILE"
+            printf '%s' "$SIG_BLOCK" >> "$SIGNED_BODY_FILE"
+            ORIGINAL_ARGS[$BODY_FILE_ARG_INDEX]="$SIGNED_BODY_FILE"
+        fi
     fi
-    # If no body was provided at all, we leave args alone; gh pr create
-    # will open an editor and the user can add the signature there.
 fi
 
 # Strip the wrapper-only flag before invoking gh

--- a/.agent/scripts/gh_create_pr.sh
+++ b/.agent/scripts/gh_create_pr.sh
@@ -116,12 +116,15 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
             fi
             ;;
         --label|-l)
-            if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
-                LABELS+=("${ORIGINAL_ARGS[$((i+1))]}")
-                i=$((i + 2))
-            else
-                i=$((i + 1))
+            # Mirror the missing-value handling on --body / --body-file /
+            # --repo: a trailing --label with no value silently passes
+            # through to gh and produces a generic CLI error.
+            if [ $((i + 1)) -ge ${#ORIGINAL_ARGS[@]} ]; then
+                echo "❌ Error: --label requires a value" >&2
+                exit 2
             fi
+            LABELS+=("${ORIGINAL_ARGS[$((i+1))]}")
+            i=$((i + 2))
             ;;
         --body)
             # Track flag presence separately from content so `--body ""`
@@ -167,6 +170,19 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
             ;;
     esac
 done
+
+# --- Mutually exclusive body sources -----------------------------------------
+# Multiple body sources would mean the wrapper signs one source while
+# `gh pr create` may use a different one (or error). Either outcome can
+# leave the PR unsigned, defeating the strict-policy stance.
+_BODY_SOURCE_COUNT=0
+[ "$BODY_FLAG_PRESENT" = true ]      && _BODY_SOURCE_COUNT=$((_BODY_SOURCE_COUNT + 1))
+[ -n "$BODY_FILE_PATH" ]             && _BODY_SOURCE_COUNT=$((_BODY_SOURCE_COUNT + 1))
+[ "$BODY_STDIN" = true ]             && _BODY_SOURCE_COUNT=$((_BODY_SOURCE_COUNT + 1))
+if [ "$_BODY_SOURCE_COUNT" -gt 1 ]; then
+    echo "❌ Error: --body, --body-file, and --body-stdin are mutually exclusive" >&2
+    exit 2
+fi
 
 # --- Repo-safety check (issue #72) -------------------------------------------
 # Prevent gh from targeting the wrong repo when running inside scratchpad

--- a/.agent/scripts/gh_create_pr.sh
+++ b/.agent/scripts/gh_create_pr.sh
@@ -40,9 +40,13 @@
 #
 # Exit codes:
 #   0 - Success
-#   1 - Invalid label detected
-#   2 - Invalid arguments (bad label, missing -R value, repo mismatch,
-#       or unset AGENT_NAME/AGENT_MODEL without --no-signature)
+#   1 - Invalid label value (label not in .agent/github_metadata.json)
+#   2 - Argument / usage errors:
+#         - missing value for -R/--repo, --label/-l, --body, or --body-file
+#         - more than one of {--body, --body-file, --body-stdin} provided
+#         - repo-safety mismatch (gh would target the wrong remote)
+#         - AGENT_NAME / AGENT_MODEL unset when a body is provided and
+#           --no-signature was not passed
 #   3 - Missing dependencies (gh, jq)
 
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then

--- a/.agent/scripts/gh_create_pr.sh
+++ b/.agent/scripts/gh_create_pr.sh
@@ -128,23 +128,31 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
             # is still recognized as non-interactive (would otherwise
             # collapse into the "no body provided → editor mode" branch
             # in needs_signature()).
+            #
+            # Reject missing value up-front (last-arg case) — otherwise the
+            # wrapper either hard-fails on missing identity (misleading) or
+            # silently drops signature injection and passes a value-less
+            # `--body` through to gh.
             BODY_FLAG_PRESENT=true
-            if [ $((i + 1)) -lt ${#ORIGINAL_ARGS[@]} ]; then
-                BODY_TEXT="${ORIGINAL_ARGS[$((i+1))]}"
-                BODY_ARG_INDEX=$((i + 1))
-                i=$((i + 2))
-            else
-                i=$((i + 1))
+            if [ $((i + 1)) -ge ${#ORIGINAL_ARGS[@]} ]; then
+                echo "❌ Error: --body requires a value" >&2
+                exit 2
             fi
+            BODY_TEXT="${ORIGINAL_ARGS[$((i+1))]}"
+            BODY_ARG_INDEX=$((i + 1))
+            i=$((i + 2))
             ;;
         --body-file)
-            if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
-                BODY_FILE_PATH="${ORIGINAL_ARGS[$((i+1))]}"
-                BODY_FILE_ARG_INDEX=$((i + 1))
-                i=$((i + 2))
-            else
-                i=$((i + 1))
+            # Same reasoning as --body: a trailing --body-file with no
+            # value silently became "no body file" before, which masks
+            # a clear CLI error from the caller.
+            if [ $((i + 1)) -ge ${#ORIGINAL_ARGS[@]} ]; then
+                echo "❌ Error: --body-file requires a value" >&2
+                exit 2
             fi
+            BODY_FILE_PATH="${ORIGINAL_ARGS[$((i+1))]}"
+            BODY_FILE_ARG_INDEX=$((i + 1))
+            i=$((i + 2))
             ;;
         --body-stdin)
             BODY_STDIN=true

--- a/.agent/scripts/gh_create_pr.sh
+++ b/.agent/scripts/gh_create_pr.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# Helper script for creating GitHub pull requests with AI signature
+# injection and repo-safety. Mirrors gh_create_issue.sh.
+#
+# Usage: gh_create_pr.sh [gh pr create options]
+#
+# Collapses the heredoc + mktemp + `gh pr create --body-file` + cleanup
+# sequence (which generates 2-3 permission prompts) into a single
+# allowlistable call. Auto-injects the AI signature footer when
+# AGENT_NAME / AGENT_MODEL are set.
+#
+# Examples:
+#   # Simple PR with inline body
+#   .agent/scripts/gh_create_pr.sh --title "Fix bug" --body "Description"
+#
+#   # PR with body from file
+#   .agent/scripts/gh_create_pr.sh --title "My PR" --body-file /tmp/body.md
+#
+#   # Body from stdin
+#   echo "PR body" | .agent/scripts/gh_create_pr.sh --title "T" --body-stdin
+#
+#   # Cross-repo
+#   .agent/scripts/gh_create_pr.sh -R rolker/agent_workspace --title T --body-file b.md
+#
+#   # Suppress signature (rare; mostly for revert PRs or human-authored)
+#   .agent/scripts/gh_create_pr.sh --title T --body B --no-signature
+#
+# Behavior:
+#   - AI signature footer (Authored-By / Model) is appended unless
+#     (a) --no-signature is passed, or
+#     (b) body already contains `**Authored-By**:` (case-sensitive)
+#   - AGENT_NAME and AGENT_MODEL env vars MUST be set when signature is
+#     to be added; missing vars hard-fail with instructions. Set via:
+#     source .agent/scripts/set_git_identity_env.sh "Name" "email" "<model>"
+#   - Labels are validated against .agent/github_metadata.json
+#   - Repo-safety: prevents gh from targeting the wrong repo when run
+#     from a scratchpad clone or other nested git repo (see issue #72)
+#   - Pass-through to `gh pr create` for everything else (--base, --head,
+#     --draft, --reviewer, --assignee, --milestone, etc.)
+#
+# Exit codes:
+#   0 - Success
+#   1 - Invalid label detected
+#   2 - Invalid arguments (bad label, missing -R value, repo mismatch,
+#       or unset AGENT_NAME/AGENT_MODEL without --no-signature)
+#   3 - Missing dependencies (gh, jq)
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Error: This script should be executed, not sourced."
+    echo "  Run: ${BASH_SOURCE[0]} $*"
+    return 1
+fi
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "❌ Error: Not in a git repository"
+    exit 3
+}
+
+METADATA_FILE="$REPO_ROOT/.agent/github_metadata.json"
+
+if ! command -v gh &>/dev/null; then
+    echo "❌ Error: 'gh' (GitHub CLI) is not installed or not in PATH"
+    echo "   Install from: https://cli.github.com/"
+    exit 3
+fi
+
+if ! command -v jq &>/dev/null; then
+    echo "❌ Error: 'jq' is not installed or not in PATH"
+    echo "   Install with: sudo apt-get install jq (or brew install jq)"
+    exit 3
+fi
+
+# Parse command-line arguments. We need to know:
+#   - --label / -l values (for validation)
+#   - -R / --repo value (for repo-safety check)
+#   - --body / --body-file / --body-stdin (for signature injection)
+#   - --no-signature (skip footer)
+ORIGINAL_ARGS=("$@")
+
+LABELS=()
+EXPLICIT_REPO=""
+NO_SIGNATURE=false
+BODY_TEXT=""
+BODY_FILE_PATH=""
+BODY_STDIN=false
+BODY_ARG_INDEX=-1
+BODY_FILE_ARG_INDEX=-1
+
+i=0
+while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
+    arg="${ORIGINAL_ARGS[$i]}"
+    case "$arg" in
+        -R|--repo)
+            if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
+                EXPLICIT_REPO="${ORIGINAL_ARGS[$((i+1))]}"
+                i=$((i + 2))
+            else
+                echo "❌ Error: -R/--repo requires a value (owner/repo)" >&2
+                exit 2
+            fi
+            ;;
+        --repo=*)
+            EXPLICIT_REPO="${arg#*=}"
+            i=$((i + 1))
+            ;;
+        --label|-l)
+            if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
+                LABELS+=("${ORIGINAL_ARGS[$((i+1))]}")
+                i=$((i + 2))
+            else
+                i=$((i + 1))
+            fi
+            ;;
+        --label=*)
+            LABELS+=("${arg#*=}")
+            i=$((i + 1))
+            ;;
+        --body)
+            if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
+                BODY_TEXT="${ORIGINAL_ARGS[$((i+1))]}"
+                BODY_ARG_INDEX=$((i + 1))
+                i=$((i + 2))
+            else
+                i=$((i + 1))
+            fi
+            ;;
+        --body=*)
+            BODY_TEXT="${arg#*=}"
+            BODY_ARG_INDEX=$i
+            i=$((i + 1))
+            ;;
+        --body-file)
+            if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
+                BODY_FILE_PATH="${ORIGINAL_ARGS[$((i+1))]}"
+                BODY_FILE_ARG_INDEX=$((i + 1))
+                i=$((i + 2))
+            else
+                i=$((i + 1))
+            fi
+            ;;
+        --body-file=*)
+            BODY_FILE_PATH="${arg#*=}"
+            BODY_FILE_ARG_INDEX=$i
+            i=$((i + 1))
+            ;;
+        --body-stdin)
+            BODY_STDIN=true
+            i=$((i + 1))
+            ;;
+        --no-signature)
+            NO_SIGNATURE=true
+            i=$((i + 1))
+            ;;
+        *)
+            i=$((i + 1))
+            ;;
+    esac
+done
+
+# --- Repo-safety check (issue #72) -------------------------------------------
+# Prevent gh from targeting the wrong repo when running inside scratchpad
+# clones or other nested git repos.
+if [ -z "$EXPLICIT_REPO" ]; then
+    _CURRENT_REMOTE=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")
+    _CURRENT_SLUG=$(echo "$_CURRENT_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+
+    _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    _WORKSPACE_ROOT="$(cd "$_SCRIPT_DIR/../.." && pwd)"
+    _WS_REMOTE=$(git -C "$_WORKSPACE_ROOT" remote get-url origin 2>/dev/null || echo "")
+    _WS_SLUG=$(echo "$_WS_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+
+    _PROJECT_SLUG=""
+    if [ -d "$_WORKSPACE_ROOT/project" ] && git -C "$_WORKSPACE_ROOT/project" rev-parse --is-inside-work-tree &>/dev/null; then
+        _PROJ_REMOTE=$(git -C "$_WORKSPACE_ROOT/project" remote get-url origin 2>/dev/null || echo "")
+        _PROJECT_SLUG=$(echo "$_PROJ_REMOTE" | sed -E 's#.*github\.com[:/]##' | sed 's/\.git$//')
+    fi
+
+    _SLUG_PATTERN='^[^/[:space:]]+/[^/[:space:]]+$'
+    _REPO_OK=false
+    if [ -n "$_CURRENT_SLUG" ] && [[ "$_CURRENT_SLUG" =~ $_SLUG_PATTERN ]]; then
+        if [ "$_CURRENT_SLUG" = "$_WS_SLUG" ]; then
+            _REPO_OK=true
+        elif [ -n "$_PROJECT_SLUG" ] && [ "$_CURRENT_SLUG" = "$_PROJECT_SLUG" ]; then
+            _REPO_OK=true
+        fi
+    else
+        _REPO_OK=true
+    fi
+
+    if [ "$_REPO_OK" = false ]; then
+        echo "❌ Error: gh would target '${_CURRENT_SLUG}', which is not the workspace or project repo." >&2
+        echo "   Workspace repo: ${_WS_SLUG:-<not detected>}" >&2
+        echo "   Project repo:   ${_PROJECT_SLUG:-<not configured>}" >&2
+        echo "" >&2
+        echo "   You are likely inside a scratchpad clone. Use -R to target the correct repo:" >&2
+        echo "   $0 -R ${_WS_SLUG:-owner/repo} [other args]" >&2
+        exit 2
+    fi
+fi
+
+# --- AI signature injection --------------------------------------------------
+# Append the canonical signature footer unless:
+#   - --no-signature was passed
+#   - body already contains **Authored-By**:
+# When signature is required but AGENT_NAME / AGENT_MODEL are unset,
+# hard-fail with instructions (workspace policy: PRs are signed).
+SIG_MARKER='**Authored-By**:'
+needs_signature() {
+    [ "$NO_SIGNATURE" = true ] && return 1
+    if [ -n "$BODY_TEXT" ]; then
+        printf '%s' "$BODY_TEXT" | grep -Fq "$SIG_MARKER" && return 1
+    elif [ -n "$BODY_FILE_PATH" ] && [ -f "$BODY_FILE_PATH" ]; then
+        grep -Fq "$SIG_MARKER" "$BODY_FILE_PATH" && return 1
+    fi
+    return 0
+}
+
+if needs_signature; then
+    if [ -z "${AGENT_NAME:-}" ] || [ -z "${AGENT_MODEL:-}" ]; then
+        echo "❌ Error: AGENT_NAME and/or AGENT_MODEL are unset; cannot sign PR." >&2
+        echo "" >&2
+        echo "   Set them via:" >&2
+        echo "     source .agent/scripts/set_git_identity_env.sh \"Name\" \"email\" \"<model>\"" >&2
+        echo "" >&2
+        echo "   Or pass --no-signature to skip signing (rare; revert PRs only)." >&2
+        exit 2
+    fi
+
+    SIG_BLOCK=$(printf '\n\n---\n**Authored-By**: `%s`\n**Model**: `%s`\n' \
+                       "$AGENT_NAME" "$AGENT_MODEL")
+
+    if [ -n "$BODY_TEXT" ]; then
+        ORIGINAL_ARGS[$BODY_ARG_INDEX]="${BODY_TEXT}${SIG_BLOCK}"
+    elif [ -n "$BODY_FILE_PATH" ] && [ -f "$BODY_FILE_PATH" ]; then
+        SIGNED_BODY_FILE=$(mktemp /tmp/gh_pr_body.XXXXXX.md)
+        trap 'rm -f "$SIGNED_BODY_FILE"' EXIT
+        cp "$BODY_FILE_PATH" "$SIGNED_BODY_FILE"
+        printf '%s' "$SIG_BLOCK" >> "$SIGNED_BODY_FILE"
+        ORIGINAL_ARGS[$BODY_FILE_ARG_INDEX]="$SIGNED_BODY_FILE"
+    elif [ "$BODY_STDIN" = true ]; then
+        # Drain stdin, append signature, then convert --body-stdin to --body-file
+        SIGNED_BODY_FILE=$(mktemp /tmp/gh_pr_body.XXXXXX.md)
+        trap 'rm -f "$SIGNED_BODY_FILE"' EXIT
+        cat > "$SIGNED_BODY_FILE"
+        printf '%s' "$SIG_BLOCK" >> "$SIGNED_BODY_FILE"
+        # Rewrite ORIGINAL_ARGS: --body-stdin → --body-file <path>
+        NEW_ARGS=()
+        for arg in "${ORIGINAL_ARGS[@]}"; do
+            if [ "$arg" = "--body-stdin" ]; then
+                NEW_ARGS+=(--body-file "$SIGNED_BODY_FILE")
+            else
+                NEW_ARGS+=("$arg")
+            fi
+        done
+        ORIGINAL_ARGS=("${NEW_ARGS[@]}")
+    fi
+    # If no body was provided at all, we leave args alone; gh pr create
+    # will open an editor and the user can add the signature there.
+fi
+
+# Strip the wrapper-only flag before invoking gh
+FINAL_ARGS=()
+for arg in "${ORIGINAL_ARGS[@]}"; do
+    [ "$arg" = "--no-signature" ] && continue
+    FINAL_ARGS+=("$arg")
+done
+
+# --- Label validation -------------------------------------------------------
+# Skip when no labels were passed or metadata file is absent.
+if [ ${#LABELS[@]} -eq 0 ]; then
+    echo "ℹ️  No labels specified, passing through to 'gh pr create'"
+    exec gh pr create "${FINAL_ARGS[@]}"
+fi
+
+if [ ! -f "$METADATA_FILE" ]; then
+    echo "⚠️  Warning: $METADATA_FILE not found"
+    echo "   Skipping label validation. Labels will be validated by GitHub."
+    exec gh pr create "${FINAL_ARGS[@]}"
+fi
+
+VALID_LABELS=$(jq -r '.labels[]' "$METADATA_FILE" 2>/dev/null) || {
+    echo "⚠️  Warning: Failed to parse $METADATA_FILE"
+    echo "   Skipping label validation."
+    exec gh pr create "${FINAL_ARGS[@]}"
+}
+
+INVALID_LABELS=()
+for label in "${LABELS[@]}"; do
+    if ! echo "$VALID_LABELS" | grep -Fxq "$label"; then
+        INVALID_LABELS+=("$label")
+    fi
+done
+
+if [ ${#INVALID_LABELS[@]} -gt 0 ]; then
+    echo "❌ Invalid label(s) detected: ${INVALID_LABELS[*]}"
+    echo ""
+    echo "Valid labels (from $METADATA_FILE):"
+    echo "$VALID_LABELS" | sed 's/^/  - /'
+    echo ""
+    echo "To add a new label to the repository:"
+    echo "  1. Create it: gh label create '<name>' --description '<desc>' --color '<hex>'"
+    echo "  2. Update $METADATA_FILE"
+    exit 1
+fi
+
+echo "✅ All labels valid, creating PR..."
+exec gh pr create "${FINAL_ARGS[@]}"

--- a/.agent/scripts/gh_create_pr.sh
+++ b/.agent/scripts/gh_create_pr.sh
@@ -98,6 +98,7 @@ NO_SIGNATURE=false
 BODY_TEXT=""
 BODY_FILE_PATH=""
 BODY_STDIN=false
+BODY_FLAG_PRESENT=false
 BODY_ARG_INDEX=-1
 BODY_FILE_ARG_INDEX=-1
 
@@ -123,7 +124,12 @@ while [ $i -lt ${#ORIGINAL_ARGS[@]} ]; do
             fi
             ;;
         --body)
-            if [ -n "${ORIGINAL_ARGS[$((i+1))]:-}" ]; then
+            # Track flag presence separately from content so `--body ""`
+            # is still recognized as non-interactive (would otherwise
+            # collapse into the "no body provided → editor mode" branch
+            # in needs_signature()).
+            BODY_FLAG_PRESENT=true
+            if [ $((i + 1)) -lt ${#ORIGINAL_ARGS[@]} ]; then
                 BODY_TEXT="${ORIGINAL_ARGS[$((i+1))]}"
                 BODY_ARG_INDEX=$((i + 1))
                 i=$((i + 2))
@@ -232,11 +238,13 @@ fi
 SIG_MARKER='**Authored-By**:'
 needs_signature() {
     [ "$NO_SIGNATURE" = true ] && return 1
-    # No body input at all → interactive editor mode → no injection
-    [ -z "$BODY_TEXT" ] && [ -z "$BODY_FILE_PATH" ] && return 1
+    # No body input flag at all → interactive editor mode → no injection.
+    # `--body ""` counts as flag-present (non-interactive) and will be signed,
+    # so it does NOT take this branch.
+    [ "$BODY_FLAG_PRESENT" = false ] && [ -z "$BODY_FILE_PATH" ] && return 1
     # Already signed (catches stdin-drained content too, since BODY_FILE_PATH
     # now points at the temp file)
-    if [ -n "$BODY_TEXT" ]; then
+    if [ "$BODY_FLAG_PRESENT" = true ] && [ -n "$BODY_TEXT" ]; then
         printf '%s' "$BODY_TEXT" | grep -Fq "$SIG_MARKER" && return 1
     elif [ -n "$BODY_FILE_PATH" ] && [ -f "$BODY_FILE_PATH" ]; then
         grep -Fq "$SIG_MARKER" "$BODY_FILE_PATH" && return 1
@@ -258,7 +266,7 @@ if needs_signature; then
     SIG_BLOCK=$(printf '\n\n---\n**Authored-By**: `%s`\n**Model**: `%s`\n' \
                        "$AGENT_NAME" "$AGENT_MODEL")
 
-    if [ -n "$BODY_TEXT" ]; then
+    if [ "$BODY_FLAG_PRESENT" = true ] && [ "$BODY_ARG_INDEX" -ge 0 ]; then
         ORIGINAL_ARGS[$BODY_ARG_INDEX]="${BODY_TEXT}${SIG_BLOCK}"
     elif [ -n "$BODY_FILE_PATH" ] && [ -f "$BODY_FILE_PATH" ]; then
         # Append directly to the existing temp file (for stdin) or copy+append
@@ -285,26 +293,35 @@ done
 
 # --- Label validation -------------------------------------------------------
 # Skip when no labels were passed or metadata file is absent.
+#
+# We invoke `gh pr create` without `exec` because `exec` replaces the shell
+# process and skips the EXIT trap, which would leak STDIN_BODY_FILE and
+# SIGNED_BODY_FILE in /tmp.
 if [ ${#LABELS[@]} -eq 0 ]; then
     echo "ℹ️  No labels specified, passing through to 'gh pr create'"
-    exec gh pr create "${FINAL_ARGS[@]}"
+    gh pr create "${FINAL_ARGS[@]}"
+    exit $?
 fi
 
 if [ ! -f "$METADATA_FILE" ]; then
     echo "⚠️  Warning: $METADATA_FILE not found"
     echo "   Skipping label validation. Labels will be validated by GitHub."
-    exec gh pr create "${FINAL_ARGS[@]}"
+    gh pr create "${FINAL_ARGS[@]}"
+    exit $?
 fi
 
 VALID_LABELS=$(jq -r '.labels[]' "$METADATA_FILE" 2>/dev/null) || {
     echo "⚠️  Warning: Failed to parse $METADATA_FILE"
     echo "   Skipping label validation."
-    exec gh pr create "${FINAL_ARGS[@]}"
+    gh pr create "${FINAL_ARGS[@]}"
+    exit $?
 }
 
 INVALID_LABELS=()
 for label in "${LABELS[@]}"; do
-    if ! echo "$VALID_LABELS" | grep -Fxq "$label"; then
+    # `--` terminates grep option parsing so labels starting with `-`
+    # are not misread as flags (matters under ugrep / stricter grep).
+    if ! echo "$VALID_LABELS" | grep -Fxq -- "$label"; then
         INVALID_LABELS+=("$label")
     fi
 done
@@ -322,4 +339,5 @@ if [ ${#INVALID_LABELS[@]} -gt 0 ]; then
 fi
 
 echo "✅ All labels valid, creating PR..."
-exec gh pr create "${FINAL_ARGS[@]}"
+gh pr create "${FINAL_ARGS[@]}"
+exit $?

--- a/.agent/scripts/tests/test_gh_create_pr.sh
+++ b/.agent/scripts/tests/test_gh_create_pr.sh
@@ -3,9 +3,10 @@
 #
 # Run: bash .agent/scripts/tests/test_gh_create_pr.sh
 #
-# Strategy: shim `gh` and `git` in a temporary PATH so the wrapper runs
-# end-to-end without network calls. The shimmed `gh pr create` writes its
-# argv to a known file; assertions inspect that file.
+# Strategy: shim `gh` in a temporary PATH so the wrapper runs end-to-end
+# without network calls. The shimmed `gh pr create` writes its argv to a
+# known file; assertions inspect that file. `git` (rev-parse, remotes) is
+# the real binary against the real worktree.
 
 set -uo pipefail
 
@@ -328,15 +329,33 @@ export AGENT_MODEL="test-model"
 
 echo
 echo "=== Missing value rejection ==="
-# --body / --body-file as the last arg with no value used to either
-# hard-fail on missing identity (misleading) or silently pass a value-less
-# flag through to gh. Now hard-fails with a clear error and exit 2.
+# --body / --body-file / --label as the last arg with no value used to
+# either hard-fail on missing identity (misleading) or silently pass a
+# value-less flag through to gh. Now hard-fails with a clear error and
+# exit 2 — consistent with --repo's existing behavior.
 export AGENT_NAME="Test Agent"
 export AGENT_MODEL="test-model"
 assert_exit_code "--body as last arg → exit 2" 2 \
     --title "T" --body
 assert_exit_code "--body-file as last arg → exit 2" 2 \
     --title "T" --body-file
+assert_exit_code "--label as last arg → exit 2" 2 \
+    --title "T" --body "B" --label
+
+echo
+echo "=== Mutually exclusive body sources ==="
+# Specifying more than one of --body / --body-file / --body-stdin would
+# let the wrapper sign one source while gh uses another (or errors),
+# leaving the PR unsigned. Reject with exit 2.
+TMPF_MX=$(mktemp /tmp/test_body.XXXXXX.md)
+echo "file body" > "$TMPF_MX"
+assert_exit_code "--body + --body-file → exit 2" 2 \
+    --title "T" --body "B" --body-file "$TMPF_MX"
+assert_exit_code "--body + --body-stdin → exit 2" 2 \
+    --title "T" --body "B" --body-stdin
+assert_exit_code "--body-file + --body-stdin → exit 2" 2 \
+    --title "T" --body-file "$TMPF_MX" --body-stdin
+rm -f "$TMPF_MX"
 
 echo
 echo "=== Empty body flag (--body \"\") is non-interactive ==="

--- a/.agent/scripts/tests/test_gh_create_pr.sh
+++ b/.agent/scripts/tests/test_gh_create_pr.sh
@@ -119,12 +119,14 @@ export AGENT_MODEL="test-model"
 
 assert_calls_gh "inline body, signature appended" \
     --title "T" --body "Body text"
-if argv_has "Body text
-
----
-**Authored-By**: \`Test Agent\`
-**Model**: \`test-model\`
-"; then
+# Use targeted `grep -Fq` rather than `argv_has` (`grep -Fxq`): the shim
+# writes each argv token via `printf '%s\n'`, so the signed `--body`
+# token's embedded newlines split it across multiple lines of argv.log.
+# `grep -Fxq` is line-oriented and would match too loosely against any
+# single line of the expected multi-line block.
+if grep -Fq 'Body text' "$ARGV_LOG" \
+   && grep -Fq '**Authored-By**: `Test Agent`' "$ARGV_LOG" \
+   && grep -Fq '**Model**: `test-model`' "$ARGV_LOG"; then
     echo "  PASS [body content]: inline body has signature footer"
     PASS=$((PASS + 1))
 else
@@ -321,6 +323,28 @@ assert_calls_gh "no body, env vars set" \
 unset AGENT_NAME AGENT_MODEL
 assert_calls_gh "no body, env vars unset (no hard-fail)" \
     --title "T"
+export AGENT_NAME="Test Agent"
+export AGENT_MODEL="test-model"
+
+echo
+echo "=== Empty body flag (--body \"\") is non-interactive ==="
+# `--body ""` is flag-present, so it must NOT collapse into interactive
+# mode: signature gets appended, and missing identity hard-fails.
+assert_calls_gh "--body \"\" still gets signature" \
+    --title "T" --body ""
+if grep -Fq '**Authored-By**: `Test Agent`' "$ARGV_LOG" \
+   && grep -Fq '**Model**: `test-model`' "$ARGV_LOG"; then
+    echo "  PASS [body content]: --body \"\" got signature appended"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [body content]: --body \"\" did not get signature appended"
+    echo "  Got argv:"
+    sed 's/^/    /' "$ARGV_LOG"
+    FAIL=$((FAIL + 1))
+fi
+unset AGENT_NAME AGENT_MODEL
+assert_exit_code "--body \"\" hard-fails with unset env vars" 2 \
+    --title "T" --body ""
 export AGENT_NAME="Test Agent"
 export AGENT_MODEL="test-model"
 

--- a/.agent/scripts/tests/test_gh_create_pr.sh
+++ b/.agent/scripts/tests/test_gh_create_pr.sh
@@ -214,6 +214,117 @@ assert_calls_gh "unset + already-signed body calls gh" \
 rm -f "$TMPF"
 
 echo
+echo "=== Joined-equals forms (--body=X, --body-file=X) ==="
+export AGENT_NAME="Test Agent"
+export AGENT_MODEL="test-model"
+
+assert_calls_gh "--body=VALUE shape" \
+    --title "T" --body=Inline-body-via-equals
+# After normalization + signature injection, gh should see `--body` followed
+# by the body+signature on the next argv line, not a single positional token.
+if argv_has "--body" \
+   && grep -q '^Inline-body-via-equals' "$ARGV_LOG" \
+   && grep -Fq '**Authored-By**: `Test Agent`' "$ARGV_LOG"; then
+    echo "  PASS [argv]:       --body=VALUE normalized and signed"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [argv]:       --body=VALUE handling broken"
+    echo "  argv was:"; sed 's/^/    /' "$ARGV_LOG"
+    FAIL=$((FAIL + 1))
+fi
+
+TMPF=$(mktemp /tmp/test_body.XXXXXX.md)
+echo "Eq form body" > "$TMPF"
+assert_calls_gh "--body-file=PATH shape" \
+    --title "T" "--body-file=$TMPF"
+if argv_has "--body-file" \
+   && [[ -f "$BODY_CAPTURE_DIR/body.md" ]] \
+   && grep -Fq "Eq form body" "$BODY_CAPTURE_DIR/body.md" \
+   && grep -Fq "**Authored-By**: \`Test Agent\`" "$BODY_CAPTURE_DIR/body.md"; then
+    echo "  PASS [body]:       --body-file=PATH normalized and signed"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [body]:       --body-file=PATH handling broken"
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$TMPF"
+
+echo
+echo "=== --body-stdin path ==="
+# Signed stdin (env vars set, content not pre-signed)
+reset_capture
+printf '%s\n' "Stdin body content" | "$SCRIPT" --title "T" --body-stdin >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 0 ]] && argv_has "--body-file" \
+   && [[ -f "$BODY_CAPTURE_DIR/body.md" ]] \
+   && grep -Fq "Stdin body content" "$BODY_CAPTURE_DIR/body.md" \
+   && grep -Fq "**Authored-By**: \`Test Agent\`" "$BODY_CAPTURE_DIR/body.md"; then
+    echo "  PASS [stdin]:      --body-stdin drained, rewritten to --body-file, signed"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [stdin]:      --body-stdin signed path broken (rc=$rc)"
+    FAIL=$((FAIL + 1))
+fi
+# --body-stdin should never reach gh
+if argv_has "--body-stdin"; then
+    echo "  FAIL [stdin]:      --body-stdin leaked through to gh"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS [stdin]:      --body-stdin stripped before gh"
+    PASS=$((PASS + 1))
+fi
+
+# Stdin + already-signed content → no duplicate
+reset_capture
+printf '%s' "Pre-signed stdin
+
+---
+**Authored-By**: \`Someone\`
+**Model**: \`x\`
+" | "$SCRIPT" --title "T" --body-stdin >/dev/null 2>&1
+SIG_COUNT_STDIN=$(grep -cF '**Authored-By**:' "$BODY_CAPTURE_DIR/body.md" 2>/dev/null || echo 0)
+if [[ "$SIG_COUNT_STDIN" -eq 1 ]]; then
+    echo "  PASS [stdin]:      already-signed stdin not duplicated (1 Authored-By)"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [stdin]:      already-signed stdin got $SIG_COUNT_STDIN Authored-By lines"
+    FAIL=$((FAIL + 1))
+fi
+
+# Stdin + --no-signature → still drained and rewritten, no signature added
+reset_capture
+printf '%s\n' "Stdin no-sig" | "$SCRIPT" --title "T" --body-stdin --no-signature >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 0 ]] && argv_has "--body-file" \
+   && [[ -f "$BODY_CAPTURE_DIR/body.md" ]] \
+   && grep -Fq "Stdin no-sig" "$BODY_CAPTURE_DIR/body.md"; then
+    if grep -Fq '**Authored-By**:' "$BODY_CAPTURE_DIR/body.md"; then
+        echo "  FAIL [stdin]:      --no-signature on stdin still added signature"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS [stdin]:      --body-stdin + --no-signature drains without signing"
+        PASS=$((PASS + 1))
+    fi
+else
+    echo "  FAIL [stdin]:      --body-stdin + --no-signature didn't reach gh (rc=$rc)"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "=== Interactive (no body provided) ==="
+# With env vars set: no body means editor mode; should not hard-fail or
+# require signature injection.
+assert_calls_gh "no body, env vars set" \
+    --title "T"
+# With env vars UNSET: no body should ALSO pass through (no signature needed
+# because there's nothing to sign yet — user will edit interactively).
+unset AGENT_NAME AGENT_MODEL
+assert_calls_gh "no body, env vars unset (no hard-fail)" \
+    --title "T"
+export AGENT_NAME="Test Agent"
+export AGENT_MODEL="test-model"
+
+echo
 echo "=== Pass-through flags ==="
 export AGENT_NAME="Test Agent"
 export AGENT_MODEL="test-model"

--- a/.agent/scripts/tests/test_gh_create_pr.sh
+++ b/.agent/scripts/tests/test_gh_create_pr.sh
@@ -327,6 +327,18 @@ export AGENT_NAME="Test Agent"
 export AGENT_MODEL="test-model"
 
 echo
+echo "=== Missing value rejection ==="
+# --body / --body-file as the last arg with no value used to either
+# hard-fail on missing identity (misleading) or silently pass a value-less
+# flag through to gh. Now hard-fails with a clear error and exit 2.
+export AGENT_NAME="Test Agent"
+export AGENT_MODEL="test-model"
+assert_exit_code "--body as last arg → exit 2" 2 \
+    --title "T" --body
+assert_exit_code "--body-file as last arg → exit 2" 2 \
+    --title "T" --body-file
+
+echo
 echo "=== Empty body flag (--body \"\") is non-interactive ==="
 # `--body ""` is flag-present, so it must NOT collapse into interactive
 # mode: signature gets appended, and missing identity hard-fails.

--- a/.agent/scripts/tests/test_gh_create_pr.sh
+++ b/.agent/scripts/tests/test_gh_create_pr.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Tests for .agent/scripts/gh_create_pr.sh
+#
+# Run: bash .agent/scripts/tests/test_gh_create_pr.sh
+#
+# Strategy: shim `gh` and `git` in a temporary PATH so the wrapper runs
+# end-to-end without network calls. The shimmed `gh pr create` writes its
+# argv to a known file; assertions inspect that file.
+
+set -uo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FATAL: jq is required to run these tests" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/../gh_create_pr.sh"
+
+if [[ ! -x "$SCRIPT" ]]; then
+    echo "FATAL: wrapper not found or not executable at $SCRIPT"
+    exit 1
+fi
+
+# --- shims ------------------------------------------------------------------
+SHIM_DIR=$(mktemp -d /tmp/gh_create_pr_shim-XXXXXX)
+ARGV_LOG="$SHIM_DIR/argv.log"
+BODY_CAPTURE_DIR="$SHIM_DIR/body-capture"
+mkdir -p "$BODY_CAPTURE_DIR"
+trap 'rm -rf "$SHIM_DIR"' EXIT
+
+# Real gh path for command discovery; we only shim `gh pr create`
+REAL_GH=$(command -v gh || true)
+cat > "$SHIM_DIR/gh" <<EOF
+#!/bin/bash
+# Capture argv to $ARGV_LOG when 'gh pr create' is called.
+# Capture any --body-file contents to $BODY_CAPTURE_DIR so the test can
+# inspect the post-injection body.
+if [[ "\$1" = "pr" && "\$2" = "create" ]]; then
+    : > "$ARGV_LOG"
+    shift 2
+    for arg in "\$@"; do
+        printf '%s\n' "\$arg" >> "$ARGV_LOG"
+    done
+    # Snapshot any --body-file content while the temp file still exists
+    prev=""
+    for arg in "\$@"; do
+        if [[ "\$prev" = "--body-file" && -f "\$arg" ]]; then
+            cp "\$arg" "$BODY_CAPTURE_DIR/body.md"
+        fi
+        prev="\$arg"
+    done
+    exit 0
+fi
+exec "$REAL_GH" "\$@"
+EOF
+chmod +x "$SHIM_DIR/gh"
+
+# The wrapper calls `command -v gh` and `command -v jq` early; shim PATH so
+# only `gh` is mocked while jq/git remain real.
+export PATH="$SHIM_DIR:$PATH"
+
+PASS=0
+FAIL=0
+
+run_wrapper() {
+    # Capture all argv from a single invocation. Echoes the script's
+    # stdout/stderr and returns its exit code.
+    "$SCRIPT" "$@"
+}
+
+read_argv() {
+    # Print the captured argv (one per line), or empty if no call was made.
+    [[ -f "$ARGV_LOG" ]] && cat "$ARGV_LOG"
+}
+
+argv_has() {
+    # $1 = expected argv token (exact match against any line in argv.log).
+    # `--` terminates grep option parsing so tokens like `--draft` don't
+    # get interpreted as flags (ugrep is stricter than GNU grep here).
+    grep -Fxq -- "$1" "$ARGV_LOG" 2>/dev/null
+}
+
+reset_capture() { rm -f "$ARGV_LOG"; rm -rf "$BODY_CAPTURE_DIR"; mkdir -p "$BODY_CAPTURE_DIR"; }
+
+assert_calls_gh() {
+    local label="$1"; shift
+    reset_capture
+    run_wrapper "$@" >/dev/null 2>&1
+    rc=$?
+    if [[ "$rc" -eq 0 && -f "$ARGV_LOG" ]]; then
+        echo "  PASS [calls gh]:   $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL [calls gh]:   $label  (rc=$rc, argv-log $([[ -f $ARGV_LOG ]] && echo present || echo missing))"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_code() {
+    local label="$1" expected="$2"; shift 2
+    reset_capture
+    run_wrapper "$@" >/dev/null 2>&1
+    rc=$?
+    if [[ "$rc" -eq "$expected" ]]; then
+        echo "  PASS [exit=$expected]: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL [exit=$expected]: $label  (got $rc)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- tests ------------------------------------------------------------------
+echo
+echo "=== Signature injection (env vars set) ==="
+export AGENT_NAME="Test Agent"
+export AGENT_MODEL="test-model"
+
+assert_calls_gh "inline body, signature appended" \
+    --title "T" --body "Body text"
+if argv_has "Body text
+
+---
+**Authored-By**: \`Test Agent\`
+**Model**: \`test-model\`
+"; then
+    echo "  PASS [body content]: inline body has signature footer"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [body content]: inline body did not get signature appended"
+    echo "  Got argv:"
+    sed 's/^/    /' "$ARGV_LOG"
+    FAIL=$((FAIL + 1))
+fi
+
+TMPF=$(mktemp /tmp/test_body.XXXXXX.md)
+echo "File body" > "$TMPF"
+assert_calls_gh "--body-file, signature appended" \
+    --title "T" --body-file "$TMPF"
+if [[ -f "$BODY_CAPTURE_DIR/body.md" ]] \
+   && grep -Fq "**Authored-By**: \`Test Agent\`" "$BODY_CAPTURE_DIR/body.md" \
+   && grep -Fq "File body" "$BODY_CAPTURE_DIR/body.md"; then
+    echo "  PASS [body content]: body-file gets signature appended"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [body content]: body-file signature missing or original lost"
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$TMPF"
+
+echo
+echo "=== Signature already present (no duplicate) ==="
+TMPF=$(mktemp /tmp/test_body.XXXXXX.md)
+cat > "$TMPF" <<'EOM'
+This PR already has a signature
+
+---
+**Authored-By**: `Existing`
+**Model**: `existing-model`
+EOM
+assert_calls_gh "body-file already signed, gh still called" \
+    --title "T" --body-file "$TMPF"
+# Verify only ONE Authored-By line in the captured body
+SIG_COUNT=$(grep -cF '**Authored-By**:' "$BODY_CAPTURE_DIR/body.md" 2>/dev/null || echo 0)
+if [[ "$SIG_COUNT" -eq 1 ]]; then
+    echo "  PASS [body content]: already-signed body not duplicated (1 Authored-By line)"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [body content]: expected 1 Authored-By, got $SIG_COUNT"
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$TMPF"
+
+echo
+echo "=== --no-signature flag ==="
+assert_calls_gh "--no-signature suppresses footer" \
+    --title "T" --body "B" --no-signature
+if argv_has "--no-signature"; then
+    echo "  FAIL [argv]: --no-signature should be stripped before gh"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS [argv]:       --no-signature stripped from gh argv"
+    PASS=$((PASS + 1))
+fi
+# Body should be exactly "B" (no signature)
+if argv_has "B"; then
+    echo "  PASS [body]:       --no-signature kept body unmodified"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL [body]:       body changed despite --no-signature"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "=== Hard fail when env vars unset (workspace policy) ==="
+unset AGENT_NAME AGENT_MODEL
+assert_exit_code "unset AGENT_NAME hard-fails" 2 \
+    --title "T" --body "B"
+# But --no-signature should still allow pass-through
+assert_calls_gh "unset + --no-signature still calls gh" \
+    --title "T" --body "B" --no-signature
+# Already-signed body also bypasses the env-var check
+TMPF=$(mktemp /tmp/test_body.XXXXXX.md)
+cat > "$TMPF" <<'EOM'
+Already signed body
+
+---
+**Authored-By**: `Someone`
+**Model**: `x`
+EOM
+assert_calls_gh "unset + already-signed body calls gh" \
+    --title "T" --body-file "$TMPF"
+rm -f "$TMPF"
+
+echo
+echo "=== Pass-through flags ==="
+export AGENT_NAME="Test Agent"
+export AGENT_MODEL="test-model"
+assert_calls_gh "--draft passes through" \
+    --title "T" --body "B" --draft
+argv_has "--draft" && echo "  PASS [argv]:       --draft preserved" && PASS=$((PASS + 1)) \
+    || { echo "  FAIL [argv]:       --draft missing"; FAIL=$((FAIL + 1)); }
+
+assert_calls_gh "--base and --head pass through" \
+    --title "T" --body "B" --base develop --head feature/x
+argv_has "--base" && argv_has "develop" && argv_has "--head" && argv_has "feature/x" \
+    && echo "  PASS [argv]:       --base/--head preserved" && PASS=$((PASS + 1)) \
+    || { echo "  FAIL [argv]:       --base/--head missing"; FAIL=$((FAIL + 1)); }
+
+echo
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+
+[[ "$FAIL" -gt 0 ]] && exit 1
+exit 0

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -215,4 +215,27 @@ fails because `--draft` is interpreted as a flag. Fix: `grep -Fxq -- "$pattern"`
 Applied to argv_has() in the new test; worth remembering across other tests.
 
 ### Actions
-- [ ] Open PR closing #197 umbrella item 2 (last remaining sub-task)
+- [x] Open PR closing #197 umbrella item 2 — PR #203 opened
+
+## External Review (PR #203, round 1)
+**Status**: complete
+**When**: 2026-05-12 12:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #203 at `dd7ee00` — 1 Copilot review (6 comments, all valid, 0 false positives)
+**CI**: all-pass (8/8)
+
+### Actions
+- [x] Normalize joined-equals flag forms (`--body=X` → `--body X`) in a pre-parse pass — fixed in `31a13d8`. Closes the two argv-rewrite bugs (#1, #2) on `--body=` and `--body-file=`.
+- [x] Hoist `--body-stdin` drain-and-rewrite out of the signature branch — fixed in `31a13d8`. `--body-stdin` no longer leaks to `gh` when `--no-signature` or pre-signed content (#6).
+- [x] Run signature dedupe against stdin-drained content — fixed in `31a13d8` (falls out naturally once the drain happens before `needs_signature` runs) (#4).
+- [x] `needs_signature` returns false when no body provided — fixed in `31a13d8`. Interactive `gh pr create` works without `AGENT_NAME` (#3).
+- [x] Test coverage for all 4 body shapes × signed/unsigned/already-signed/interactive — added in `31a13d8`. 10 new tests; suite 26/26.
+
+### Lesson
+Pre-review checklist should explicitly enumerate argv shape variants
+(`--flag X` vs `--flag=X` vs stdin) for any wrapper that rewrites
+argv. Five of the six Copilot catches cluster around this single
+gap — and they all would have been caught by adding one row to the
+test ledger upfront. Feeding into the `feedback_adversarial_pre_review`
+memory.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -276,9 +276,11 @@ memory.
 **CI**: all-pass (8/8)
 
 ### Actions
-- [ ] Reject mutually exclusive body sources: count `{BODY_FLAG_PRESENT, BODY_FILE_PATH non-empty, BODY_STDIN}` after parsing; if > 1, exit 2 with "❌ Error: --body, --body-file, and --body-stdin are mutually exclusive". Otherwise signature can land on a source `gh pr create` doesn't use, leaving the PR unsigned. Add regression tests for each pair.
-- [ ] Hard-fail on missing `--label` / `-l` value (mirror the round-3 fix for `--body` / `--body-file`): exit 2 with clear error. Add regression test for `--label` as last arg.
-- [ ] Fix misleading test header comment at `tests/test_gh_create_pr.sh:6-8`: only `gh` is shimmed, not `git`. One-line edit.
+- [x] Rejected mutually exclusive body sources with `exit 2` — fixed in `694ef25`. Count of `{BODY_FLAG_PRESENT, BODY_FILE_PATH non-empty, BODY_STDIN}` > 1 → error. Three regression tests cover all pairs.
+- [x] Hard-fail on missing `--label` / `-l` value with `exit 2` — fixed in `694ef25`. Mirrors `--repo` / `--body` / `--body-file`. Regression test added.
+- [x] Fixed misleading test header comment at `tests/test_gh_create_pr.sh:6-8` — only `gh` is shimmed — fixed in `694ef25`.
+
+Suite: 35/35 (was 31/31, +4 new tests).
 
 ### Trend
 Round comment counts: 6 → 5 → 2 → 3. Zero false positives across all 4 rounds. Each round is finding genuine smaller refinements rather than re-flagging earlier concerns or churning over style.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -291,7 +291,7 @@ Suite: 35/35 (was 31/31, +4 new tests).
 **CI**: all-pass (8/8)
 
 ### Actions
-- [ ] Rewrite the "Exit codes" header comment in `gh_create_pr.sh` (lines 41-46) to match actual behavior: `1` = invalid label (not "bad label" — that's a missing value); `2` = argument/usage errors (missing values for `-R` / `--label` / `--body` / `--body-file`, repo mismatch, mutually exclusive body sources, identity unset when signing); `3` = missing dependencies (gh, jq).
+- [x] Rewrote the "Exit codes" header in `gh_create_pr.sh` to match actual behavior (1 = invalid label value, 2 = argument/usage errors enumerated, 3 = missing deps) — fixed in `cccf264`.
 
 ### Trend
 Round comment counts: 6 → 5 → 2 → 3 → 1. Zero false positives across all 5 rounds. Each round is closing remaining edges rather than reopening earlier ground.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -263,6 +263,6 @@ memory.
 **CI**: all-pass (8/8)
 
 ### Actions
-- [ ] Reject missing `--body` / `--body-file` values with `exit 2` and a clear error message in `gh_create_pr.sh` (lines 125-148). Mirror the `-R/--repo` pattern: when `i+1 >= len`, emit `❌ Error: --body requires a value` (or `--body-file …`) and exit 2. Currently a trailing `--body` with no value sets `BODY_FLAG_PRESENT=true` / `BODY_ARG_INDEX=-1`, then either hard-fails on missing identity (misleading) or silently drops signature injection and passes a value-less `--body` to gh.
-- [ ] Add regression tests for `--body` as last arg and `--body-file` as last arg — both expect `exit 2`.
-- [ ] Document the identity-unset hard-fail in AGENTS.md "Creating pull requests" section (after line 230): one sentence noting that providing a body without `AGENT_NAME` / `AGENT_MODEL` exits with code 2 and points to `set_git_identity_env.sh`.
+- [x] Reject missing `--body` / `--body-file` values up-front with `exit 2` and a clear error message in `gh_create_pr.sh` — fixed in `f21f4fc`. Mirrors the `-R/--repo` pattern.
+- [x] Added regression tests for both `--body` and `--body-file` as last-arg cases (assert exit code 2) — fixed in `f21f4fc`. Suite 31/31.
+- [x] Documented the identity-unset hard-fail in AGENTS.md "Creating pull requests" section — fixed in `f21f4fc`.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -239,3 +239,17 @@ argv. Five of the six Copilot catches cluster around this single
 gap — and they all would have been caught by adding one row to the
 test ledger upfront. Feeding into the `feedback_adversarial_pre_review`
 memory.
+
+## External Review (PR #203, round 2)
+**Status**: complete
+**When**: 2026-05-13 14:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #203 at `0f26739` — 1 new Copilot review (5 comments, 4 valid, 0 false positives; the stale 6-comment review against `dd7ee00` is already addressed by `31a13d8`)
+**CI**: all-pass (8/8)
+
+### Actions
+- [ ] Fix exec/trap temp-file leak: replace all four `exec gh pr create "${FINAL_ARGS[@]}"` (lines 290, 296, 302, 325) with `gh pr create "${FINAL_ARGS[@]}"; rc=$?; exit $rc` so the EXIT traps at lines 204 and 271 actually run and `/tmp/gh_pr_body.XXXXXX.md` files don't accumulate.
+- [ ] Harden label validation against `ugrep`: change `grep -Fxq "$label"` → `grep -Fxq -- "$label"` at `gh_create_pr.sh:307` and the mirror at `gh_create_issue.sh:279`.
+- [ ] Replace unreliable multi-line `argv_has` assertion at `tests/test_gh_create_pr.sh:120-135` with targeted `grep -Fq '**Authored-By**: \`Test Agent\`' "$ARGV_LOG"` + `grep -Fq 'Body text' "$ARGV_LOG"` (matches the working pattern already used at lines 225-227 for `--body=VALUE`).
+- [ ] Track `--body` flag presence separately from content so `--body ""` still triggers signature path / identity check; add a regression test.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -266,3 +266,19 @@ memory.
 - [x] Reject missing `--body` / `--body-file` values up-front with `exit 2` and a clear error message in `gh_create_pr.sh` — fixed in `f21f4fc`. Mirrors the `-R/--repo` pattern.
 - [x] Added regression tests for both `--body` and `--body-file` as last-arg cases (assert exit code 2) — fixed in `f21f4fc`. Suite 31/31.
 - [x] Documented the identity-unset hard-fail in AGENTS.md "Creating pull requests" section — fixed in `f21f4fc`.
+
+## External Review (PR #203, round 4)
+**Status**: complete
+**When**: 2026-05-13 14:55
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #203 at `5bc83b1` — 1 new Copilot review (3 comments, 3 valid, 0 false positives)
+**CI**: all-pass (8/8)
+
+### Actions
+- [ ] Reject mutually exclusive body sources: count `{BODY_FLAG_PRESENT, BODY_FILE_PATH non-empty, BODY_STDIN}` after parsing; if > 1, exit 2 with "❌ Error: --body, --body-file, and --body-stdin are mutually exclusive". Otherwise signature can land on a source `gh pr create` doesn't use, leaving the PR unsigned. Add regression tests for each pair.
+- [ ] Hard-fail on missing `--label` / `-l` value (mirror the round-3 fix for `--body` / `--body-file`): exit 2 with clear error. Add regression test for `--label` as last arg.
+- [ ] Fix misleading test header comment at `tests/test_gh_create_pr.sh:6-8`: only `gh` is shimmed, not `git`. One-line edit.
+
+### Trend
+Round comment counts: 6 → 5 → 2 → 3. Zero false positives across all 4 rounds. Each round is finding genuine smaller refinements rather than re-flagging earlier concerns or churning over style.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -181,3 +181,38 @@ Not dispatched this pass — Claude adversarial findings substantive enough to f
 ### Actions
 - [x] Catch GNU sed `--quiet`/`--silent` long forms (equivalent to `-n`) — fixed in `594870c`. Added `has_sed_quiet` helper; `-f` exemption preserved. 5 regression tests added; 113/113 pass.
 - [x] Drop "nudge" wording in wrapper-flags comment (Copilot has flagged this framing repeatedly) — fixed in `594870c`. Replaced with plain trade-off description.
+
+## Implement: gh_create_pr.sh (item 2 of #197 umbrella)
+**Status**: complete
+**When**: 2026-05-12 11:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**Branch**: `feature/issue-197-gh-create-pr` (off main; sibling to merged #200/#199)
+
+### Scope
+Collapses the heredoc + mktemp + `gh pr create --body-file` + rm sequence
+(2–3 permission prompts each PR) into a single allowlistable wrapper.
+
+### Design decisions
+- **Hard-fail on missing identity** — when signature would be added but
+  `AGENT_NAME`/`AGENT_MODEL` are unset, exit 2 with set_git_identity_env.sh
+  instructions. `--no-signature` and already-signed bodies bypass this
+  check. Stance is workspace-policy strict per Roland's pick.
+- **`--body-stdin` as canonical form in AGENTS.md** — single allowlisted
+  call, no mktemp dance. `--body-file` and `--body` still supported as
+  alternatives. Wrapper internally drains stdin to a temp file and uses
+  trap-based cleanup.
+- **Mirror gh_create_issue.sh structure** — repo-safety check, label
+  validation, json metadata path, error code conventions. Dropped the
+  git-bug path (PRs aren't git-bug tracked per ADR-0010).
+- **Test approach: shimmed `gh` via PATH** — `.agent/scripts/tests/test_gh_create_pr.sh`
+  injects a `gh` shim that captures argv into a logfile; assertions inspect
+  the logfile. No network calls, mirrors test_block_bash_tool_mapping.sh style.
+
+### Test gotcha (logged for future)
+The system's `grep` is `ugrep` (stricter option parser). `grep -Fxq "--draft"`
+fails because `--draft` is interpreted as a flag. Fix: `grep -Fxq -- "$pattern"`.
+Applied to argv_has() in the new test; worth remembering across other tests.
+
+### Actions
+- [ ] Open PR closing #197 umbrella item 2 (last remaining sub-task)

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -253,3 +253,16 @@ memory.
 - [x] Harden label validation against `ugrep`: added `--` to `grep -Fxq` in both `gh_create_pr.sh:307` and the mirror at `gh_create_issue.sh:279` — fixed in `6d59a0d`.
 - [x] Replaced unreliable multi-line `argv_has` assertion with targeted `grep -Fq` checks for body text + `**Authored-By**:` / `**Model**:` markers — fixed in `6d59a0d`.
 - [x] Track `--body` flag presence separately via `BODY_FLAG_PRESENT` so `--body ""` is recognized as non-interactive (signed when env vars set, hard-fails when unset) — fixed in `6d59a0d`. Added 3 regression tests; suite 29/29.
+
+## External Review (PR #203, round 3)
+**Status**: complete
+**When**: 2026-05-13 14:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #203 at `2f4bb88` — 1 new Copilot review (2 comments, 2 valid, 0 false positives; plus 1 low-confidence suppressed comment on `--body-file` parsing, same root cause as #1 below)
+**CI**: all-pass (8/8)
+
+### Actions
+- [ ] Reject missing `--body` / `--body-file` values with `exit 2` and a clear error message in `gh_create_pr.sh` (lines 125-148). Mirror the `-R/--repo` pattern: when `i+1 >= len`, emit `❌ Error: --body requires a value` (or `--body-file …`) and exit 2. Currently a trailing `--body` with no value sets `BODY_FLAG_PRESENT=true` / `BODY_ARG_INDEX=-1`, then either hard-fails on missing identity (misleading) or silently drops signature injection and passes a value-less `--body` to gh.
+- [ ] Add regression tests for `--body` as last arg and `--body-file` as last arg — both expect `exit 2`.
+- [ ] Document the identity-unset hard-fail in AGENTS.md "Creating pull requests" section (after line 230): one sentence noting that providing a body without `AGENT_NAME` / `AGENT_MODEL` exits with code 2 and points to `set_git_identity_env.sh`.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -249,7 +249,7 @@ memory.
 **CI**: all-pass (8/8)
 
 ### Actions
-- [ ] Fix exec/trap temp-file leak: replace all four `exec gh pr create "${FINAL_ARGS[@]}"` (lines 290, 296, 302, 325) with `gh pr create "${FINAL_ARGS[@]}"; rc=$?; exit $rc` so the EXIT traps at lines 204 and 271 actually run and `/tmp/gh_pr_body.XXXXXX.md` files don't accumulate.
-- [ ] Harden label validation against `ugrep`: change `grep -Fxq "$label"` → `grep -Fxq -- "$label"` at `gh_create_pr.sh:307` and the mirror at `gh_create_issue.sh:279`.
-- [ ] Replace unreliable multi-line `argv_has` assertion at `tests/test_gh_create_pr.sh:120-135` with targeted `grep -Fq '**Authored-By**: \`Test Agent\`' "$ARGV_LOG"` + `grep -Fq 'Body text' "$ARGV_LOG"` (matches the working pattern already used at lines 225-227 for `--body=VALUE`).
-- [ ] Track `--body` flag presence separately from content so `--body ""` still triggers signature path / identity check; add a regression test.
+- [x] Fix exec/trap temp-file leak: replaced all four `exec gh pr create "${FINAL_ARGS[@]}"` with non-exec + `exit $?` so the EXIT traps actually fire — fixed in `6d59a0d`. Verified via `/tmp/gh_pr_body.*.md` count before/after test run (0 → 0).
+- [x] Harden label validation against `ugrep`: added `--` to `grep -Fxq` in both `gh_create_pr.sh:307` and the mirror at `gh_create_issue.sh:279` — fixed in `6d59a0d`.
+- [x] Replaced unreliable multi-line `argv_has` assertion with targeted `grep -Fq` checks for body text + `**Authored-By**:` / `**Model**:` markers — fixed in `6d59a0d`.
+- [x] Track `--body` flag presence separately via `BODY_FLAG_PRESENT` so `--body ""` is recognized as non-interactive (signed when env vars set, hard-fails when unset) — fixed in `6d59a0d`. Added 3 regression tests; suite 29/29.

--- a/.agent/work-plans/issue-197/progress.md
+++ b/.agent/work-plans/issue-197/progress.md
@@ -282,5 +282,19 @@ memory.
 
 Suite: 35/35 (was 31/31, +4 new tests).
 
+## External Review (PR #203, round 5)
+**Status**: complete
+**When**: 2026-05-13 15:15
+**By**: Claude Code Agent (claude-opus-4-7)
+
+**PR**: #203 at `163aab3` — 1 new Copilot review (1 comment, 1 valid, 0 false positives)
+**CI**: all-pass (8/8)
+
+### Actions
+- [ ] Rewrite the "Exit codes" header comment in `gh_create_pr.sh` (lines 41-46) to match actual behavior: `1` = invalid label (not "bad label" — that's a missing value); `2` = argument/usage errors (missing values for `-R` / `--label` / `--body` / `--body-file`, repo mismatch, mutually exclusive body sources, identity unset when signing); `3` = missing dependencies (gh, jq).
+
+### Trend
+Round comment counts: 6 → 5 → 2 → 3 → 1. Zero false positives across all 5 rounds. Each round is closing remaining edges rather than reopening earlier ground.
+
 ### Trend
 Round comment counts: 6 → 5 → 2 → 3. Zero false positives across all 4 rounds. Each round is finding genuine smaller refinements rather than re-flagging earlier concerns or churning over style.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -99,6 +99,7 @@
       "Bash(.agent/scripts/cross_model_review.sh *)",
       "Bash(*/.agent/scripts/cross_model_review.sh *)",
       "Bash(.agent/scripts/gh_create_issue.sh *)",
+      "Bash(.agent/scripts/gh_create_pr.sh *)",
       "Bash(.agent/scripts/update_roadmap.sh *)",
       "Bash(bash .agent/scripts/tests/*)",
       "Bash(bash -n *)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,14 +207,40 @@ Use your actual runtime identity — never copy example model names from docs.
 
 ## GitHub CLI Patterns
 
-### Use `--body-file`, Not `--body`
+### Creating pull requests
+
+Use `.agent/scripts/gh_create_pr.sh` for PRs — it injects the AI signature,
+validates labels, and prevents wrong-repo targeting. Heredoc body via stdin
+keeps the whole flow in one allowlisted call:
+
+```bash
+.agent/scripts/gh_create_pr.sh --title "Title" --body-stdin <<'EOF'
+Your markdown content here.
+EOF
+```
+
+For a body already in a file:
+
+```bash
+.agent/scripts/gh_create_pr.sh --title "Title" --body-file path/to/body.md
+```
+
+The signature footer is appended automatically when `AGENT_NAME` and
+`AGENT_MODEL` are set (via `set_git_identity_env.sh`). Pass
+`--no-signature` to suppress — rare; revert PRs or human-authored only.
+
+### Use `--body-file`, Not `--body` (for direct `gh` calls)
+
+When invoking `gh issue create` / `gh issue comment` directly (the wrapper
+above covers PRs), prefer `--body-file` so multiline content isn't mangled
+by shell quoting:
 
 ```bash
 BODY_FILE=$(mktemp /tmp/gh_body.XXXXXX.md)
 cat << 'EOF' > "$BODY_FILE"
 Your markdown content here.
 EOF
-gh pr create --title "Title" --body-file "$BODY_FILE"
+gh issue create --title "Title" --body-file "$BODY_FILE"
 rm "$BODY_FILE"
 ```
 
@@ -340,6 +366,7 @@ Scripts marked **(source)** must be sourced; all others should be executed.
 | `.agent/scripts/setup_project.sh` | Configure project/ directory |
 | `.agent/scripts/check_branch_updates.sh` | Check if branch is behind default |
 | `.agent/scripts/gh_create_issue.sh` | Create issue with label validation (`GITBUG_CREATE=1` for offline) |
+| `.agent/scripts/gh_create_pr.sh` | Create PR with AI signature injection + label validation; reads body via `--body-stdin`, `--body-file`, or `--body` |
 | `.agent/scripts/revert_feature.sh` | Revert all commits for an issue |
 | `.agent/scripts/merge_pr.sh` | Merge PR (auto-updates roadmap, waits for CI on the latest HEAD before merging), remove worktree, delete branch, sync main; `--no-wait` to skip the CI wait |
 | `.agent/scripts/update_roadmap.sh` | Auto-update roadmap status for completed issues |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,10 @@ The signature footer is appended automatically when `AGENT_NAME` and
 `AGENT_MODEL` are set (via `set_git_identity_env.sh`). Pass
 `--no-signature` to suppress — rare; revert PRs or human-authored only.
 
+If a body is provided and identity env vars are unset, the wrapper hard-fails
+with exit code 2 and points to `set_git_identity_env.sh`. This is intentional
+workspace policy: PRs must be signed unless explicitly opted out.
+
 ### Use `--body-file`, Not `--body` (for direct `gh` calls)
 
 When invoking `gh issue create` / `gh issue comment` directly (the wrapper


### PR DESCRIPTION
## Summary

Closes the last sub-task of the #197 umbrella. The new wrapper
collapses the heredoc + mktemp + `gh pr create --body-file` + rm
sequence (2–3 permission prompts per PR) into a single allowlistable
call.

**Behavior**
- AI signature footer auto-injected when `AGENT_NAME` + `AGENT_MODEL`
  are set and the body doesn't already contain `**Authored-By**:`.
- Missing identity hard-fails (exit 2) with `set_git_identity_env.sh`
  instructions. `--no-signature` and already-signed bodies bypass.
- Accepts `--body`, `--body-file`, and `--body-stdin` (drained to a
  temp file internally, trap-cleaned).
- Mirrors `gh_create_issue.sh`: same repo-safety check, same label
  validation against `.agent/github_metadata.json`. Dropped git-bug
  path — PRs aren't git-bug tracked per ADR-0010.
- Pass-through for `--draft`, `--base`, `--head`, `--reviewer`,
  `--assignee`, etc.

**AGENTS.md** — "Creating pull requests" now leads with the
`--body-stdin <<EOF` pattern (one allowlisted call, no mktemp dance).
The legacy `--body-file` heredoc snippet remains in a separate
subsection for direct `gh issue create` / `gh issue comment` calls
where the wrapper doesn't apply.

**Allowlist** — `Bash(.agent/scripts/gh_create_pr.sh *)` added to
`.claude/settings.json`.

## Test plan

- [x] `bash .agent/scripts/tests/test_gh_create_pr.sh` — 16/16 pass
  (shims `gh` via PATH, inspects captured argv; no network calls)
- [x] Signature injection — inline body, body-file, and stdin paths
- [x] Already-signed body not duplicated
- [x] `--no-signature` strips footer and stripped from gh argv
- [x] Unset `AGENT_NAME` hard-fails (exit 2); `--no-signature` and
  pre-signed body still pass through
- [x] Pass-through flags (`--draft`, `--base`, `--head`)
- [x] JSON validation on `.claude/settings.json`
- [x] Hook from PR #200 successfully dogfooded the new tool-mapping
  rules during development (`tail` was blocked, used Read instead)

Closes #197

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
