### PR TITLE
Use cd uniformly in /start-task instead of EnterWorktree

### DIFF
--- a/.agent/work-plans/issue-204/plan.md
+++ b/.agent/work-plans/issue-204/plan.md
@@ -1,0 +1,116 @@
+# Plan: /start-task — use Bash `cd` uniformly instead of EnterWorktree
+
+## Issue
+
+https://github.com/rolker/agent_workspace/issues/204
+
+## Context
+
+`/start-task` step 4 calls `EnterWorktree(path="$WT")`. EnterWorktree only
+accepts paths registered in `git worktree list` for the **current** repo,
+so it rejects project worktrees (which belong to the project repo, not the
+workspace). Today this causes `/start-task --type project` to half-complete:
+the worktree exists on disk but the session stays in the workspace cwd.
+
+The issue (after review) settles on uniform Bash `cd` — drop EnterWorktree
+from `/start-task` entirely. One mechanism across `--type workspace`,
+`--type project`, and `--skill`. The session-end cleanup prompt is given up
+in exchange for `worktree_remove.sh --skill <name>` as the explicit
+deletion path (which is already the documented cleanup for skill
+worktrees). Cache-coherence and original-dir-return claims tied to
+EnterWorktree did not survive two days of side-by-side use.
+
+## Approach
+
+1. **`.claude/skills/start-task/SKILL.md` — step 4**: replace
+   `EnterWorktree(path="$WT")` with `cd "$WT"`. Keep step 3 (worktree path
+   resolution) and step 1 ("refuse if already in a worktree") unchanged —
+   the nested-worktree guard is still useful, the rationale just shifts
+   from "EnterWorktree refuses" to "don't nest".
+2. **`.claude/skills/start-task/SKILL.md` — step 5 ("Confirm to the user")**:
+   drop the "via EnterWorktree" framing; the confirmation message is the
+   same content.
+3. **`.claude/skills/start-task/SKILL.md` — "Exit semantics" section**:
+   rewrite. Today it says "the worktree was created outside of EnterWorktree
+   so ExitWorktree will refuse to remove it" and prescribes
+   `ExitWorktree(action="keep")`. After this change, exit is just `cd -`
+   (or any `cd` away); delete is `worktree_remove.sh --issue <N> --type
+   <type>` or `make merge-pr PR=<N>`.
+4. **`.claude/skills/start-task/SKILL.md` — "Why not just call EnterWorktree
+   directly?" section**: keep the policy-enforcement justification (issue
+   lookup, branch naming, allowlist, workflow scaffolding, plan-file PR,
+   cross-repo PR targeting). Remove the closing sentence about
+   "EnterWorktree only for the session-level switch — which gives smoother
+   CWD handling and proper cache coherence on exit" — it's the claim
+   discarded by this issue.
+5. **`.claude/skills/start-task/SKILL.md` — "When not to use" first
+   bullet**: today says "The session is already inside a worktree.
+   EnterWorktree refuses in that case." Reword: "/start-task refuses in
+   that case (step 1 detects it)" — the behaviour is the same, the cause
+   is the skill, not the native tool.
+6. **`.claude/skills/start-task/SKILL.md` — "Manual verification" cases
+   1–3**: each ends with "EnterWorktree succeeds; session lands in the new
+   worktree." Replace with "the `cd` command succeeds; session lands in
+   the new worktree." Case 4 (glob safety) is unrelated and unchanged.
+7. **`CLAUDE.md` — lines 50–56 ("Worktree entry" bullet under Claude-Specific
+   Notes)**: rewrite to describe the uniform `cd` flow. Drop the "enters
+   via the native EnterWorktree tool ... with proper cache coherence in
+   one tool call" framing. Keep the project-vs-workspace coverage point
+   (still true: all policy applies, all types covered) and the
+   Codex/Gemini caveat (still true).
+8. **`AGENTS.md` — add "Worktree Entry" subsection**: insert under
+   `## Worktree Workflow` (after the existing `### Skill Worktree
+   Exception` subsection, before `## Issue-First Policy`). Content per
+   the issue body's "Convention to document" block: skills auto-entering
+   a worktree use `cd <path>`, not EnterWorktree, with one-line rationale
+   and the exit/delete pointers.
+9. **Manual verification** in a fresh session after the changes land:
+   re-run the three SKILL.md cases (`--issue --type workspace`,
+   `--skill research --type workspace`, re-entry) plus the case the
+   issue exists for: `--issue --type project` against the project repo
+   (must end in the project worktree, not the workspace cwd).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.claude/skills/start-task/SKILL.md` | Step 4 (cd, not EnterWorktree); step 5 (drop EnterWorktree framing); "Exit semantics" section (rewrite for cd flow); "Why not just call EnterWorktree directly?" (drop cache-coherence claim); "When not to use" first bullet (reword); "Manual verification" cases 1–3 (cd, not EnterWorktree) |
+| `CLAUDE.md` | Lines 50–56 worktree-entry bullet: rewrite for uniform `cd` flow |
+| `AGENTS.md` | Add `### Worktree Entry` subsection under `## Worktree Workflow` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Plan removes a conditional, not adds one. The change is net-negative on complexity in `/start-task`. |
+| A change includes its consequences | Three-file edit set covers the doc surface that mentions EnterWorktree in this flow. WORKTREE_GUIDE.md, Copilot/Gemini adapters, and AGENT_ONBOARDING.md were grepped — none reference the EnterWorktree-via-/start-task pattern, so no further fan-out. Memory file follow-up is captured as a post-merge note (out of scope here). |
+| Capture decisions, not just implementations | The convention lands in AGENTS.md ("Worktree Entry"); rationale lives there and in the issue body (which records the split-vs-uniform decision). |
+| Workspace vs. project separation | Preserved — project worktrees still belong to the project repo; this just changes how the session navigates. |
+| Primary framework first | Trades a Claude-native tool call for a portable `cd`. Justified by the "imperceptible benefit" data in the issue; documented in the issue body so the choice isn't lost. |
+| Enforcement over documentation | Convention is doc-only. Acceptable because `/start-task` is the single entry point; the only way a future skill could regress is by writing its own auto-enter logic, which is rare and reviewable. Not introducing a hook for this. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | No (substantively) | Isolation preserved; only the session-entry mechanism changes |
+| 0003 — Project-agnostic workspace | No | Changes are generic; no project-specific content added |
+| 0004 — Enforcement hierarchy | Light touch | New convention is documentation-only at the AGENTS.md layer. The `/start-task` skill is the single entry point that enforces the convention automatically. No hook needed. |
+| 0006 — Shared AGENTS.md | **Yes** | New convention added to `AGENTS.md` (shared layer). `CLAUDE.md` adapter updated in the same PR to match — its current text describes the EnterWorktree-native flow and becomes false otherwise. Copilot/Gemini adapters and `AGENT_ONBOARDING.md` were checked — none reference EnterWorktree, no edits needed. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `AGENTS.md` | Framework adapters if affected | Yes — CLAUDE.md (lines 50–56). Copilot/Gemini adapters grepped, no mentions. |
+| A framework skill (`.claude/skills/start-task/SKILL.md`) | That framework's adapter file | Yes — CLAUDE.md is the Claude adapter and is part of the edit set |
+| Worktree scripts | `.agent/WORKTREE_GUIDE.md`; AGENTS.md worktree section | N/A — no script changes; AGENTS.md edit is a new subsection. WORKTREE_GUIDE.md grepped (no EnterWorktree mentions, no edit needed) |
+
+## Open Questions
+
+- **Issue title**: still reads "/start-task --type project: use Bash cd instead of EnterWorktree". After the proposal generalized to uniform `cd`, the `--type project` framing in the title is narrower than the change. Consider updating to "/start-task — use Bash cd uniformly instead of EnterWorktree" before merging. Low priority; not blocking.
+- **Memory file**: `feedback-enterworktree-cross-repo.md` describes the workaround this issue makes standard. The issue body lists this as a "follow-up after merge". Confirm at review time that we want it post-merge rather than in-PR — keeping it post-merge means the PR is purely workspace-repo changes, no memory-system churn.
+
+## Estimated Scope
+
+Single PR. Three files, all docs/instructions (no executable code, no tests). Manual verification only — no CI test exists for `/start-task` flow (acknowledged in SKILL.md "Manual verification" preamble and issue #188).

--- a/.agent/work-plans/issue-204/plan.md
+++ b/.agent/work-plans/issue-204/plan.md
@@ -22,59 +22,33 @@ EnterWorktree did not survive two days of side-by-side use.
 
 ## Approach
 
-1. **`.claude/skills/start-task/SKILL.md` — step 4**: replace
-   `EnterWorktree(path="$WT")` with `cd "$WT"`. Keep step 3 (worktree path
-   resolution) and step 1 ("refuse if already in a worktree") unchanged —
-   the nested-worktree guard is still useful, the rationale just shifts
-   from "EnterWorktree refuses" to "don't nest".
-2. **`.claude/skills/start-task/SKILL.md` — step 5 ("Confirm to the user")**:
-   drop the "via EnterWorktree" framing; the confirmation message is the
-   same content.
-3. **`.claude/skills/start-task/SKILL.md` — "Exit semantics" section**:
-   rewrite. Today it says "the worktree was created outside of EnterWorktree
-   so ExitWorktree will refuse to remove it" and prescribes
-   `ExitWorktree(action="keep")`. After this change, exit is just `cd -`
-   (or any `cd` away); delete is `worktree_remove.sh --issue <N> --type
-   <type>` or `make merge-pr PR=<N>`.
-4. **`.claude/skills/start-task/SKILL.md` — "Why not just call EnterWorktree
-   directly?" section**: keep the policy-enforcement justification (issue
-   lookup, branch naming, allowlist, workflow scaffolding, plan-file PR,
-   cross-repo PR targeting). Remove the closing sentence about
-   "EnterWorktree only for the session-level switch — which gives smoother
-   CWD handling and proper cache coherence on exit" — it's the claim
-   discarded by this issue.
-5. **`.claude/skills/start-task/SKILL.md` — "When not to use" first
-   bullet**: today says "The session is already inside a worktree.
-   EnterWorktree refuses in that case." Reword: "/start-task refuses in
-   that case (step 1 detects it)" — the behaviour is the same, the cause
-   is the skill, not the native tool.
-6. **`.claude/skills/start-task/SKILL.md` — "Manual verification" cases
-   1–3**: each ends with "EnterWorktree succeeds; session lands in the new
-   worktree." Replace with "the `cd` command succeeds; session lands in
-   the new worktree." Case 4 (glob safety) is unrelated and unchanged.
-7. **`CLAUDE.md` — lines 50–56 ("Worktree entry" bullet under Claude-Specific
-   Notes)**: rewrite to describe the uniform `cd` flow. Drop the "enters
-   via the native EnterWorktree tool ... with proper cache coherence in
-   one tool call" framing. Keep the project-vs-workspace coverage point
-   (still true: all policy applies, all types covered) and the
-   Codex/Gemini caveat (still true).
-8. **`AGENTS.md` — add "Worktree Entry" subsection**: insert under
-   `## Worktree Workflow` (after the existing `### Skill Worktree
-   Exception` subsection, before `## Issue-First Policy`). Content per
-   the issue body's "Convention to document" block: skills auto-entering
-   a worktree use `cd <path>`, not EnterWorktree, with one-line rationale
-   and the exit/delete pointers.
-9. **Manual verification** in a fresh session after the changes land:
-   re-run the three SKILL.md cases (`--issue --type workspace`,
-   `--skill research --type workspace`, re-entry) plus the case the
-   issue exists for: `--issue --type project` against the project repo
-   (must end in the project worktree, not the workspace cwd).
+1. **`.claude/skills/start-task/SKILL.md`** — edit every EnterWorktree/ExitWorktree mention. Touchpoints (re-grepped after review-plan flagged the original list was incomplete):
+   - Frontmatter `description:` (line 3): drop "via the native EnterWorktree tool" framing
+   - "When not to use" 1st bullet (line 19): replace "EnterWorktree refuses" rationale with "avoid nested worktrees"
+   - "When not to use" 3rd bullet (line 21): rejustify the Claude-only restriction in terms of the persistent-shell mechanism (Codex/Gemini use per-command shells)
+   - Step 3 inline comment (line 90): "Do not call EnterWorktree" → "Do not proceed to step 4"
+   - Step 4 (lines 108–118): rename heading from "Enter the worktree via the native tool" to "Enter the worktree"; replace `EnterWorktree(path="$WT")` with `cd "$WT"`; replace the EnterWorktree-specific rationale paragraph with a `cd`-rationale paragraph; rewrite (not name-swap) the failure-mode paragraph for the `cd` failure mode
+   - Step 5 (line 122): "After EnterWorktree returns successfully" → "After `cd` returns successfully"
+   - Manual verification cases 1, 3 (lines 132, 136): swap EnterWorktree/ExitWorktree mentions for `cd` / `cd -`; **add a new case 3 for `--type project`** (the failure case the issue exists for) and renumber re-entry to case 4, glob safety to case 5
+   - "Exit semantics" section (lines 140–144): rewrite for the `cd -` flow; drop ExitWorktree references entirely
+   - "Why not just call EnterWorktree directly?" section (lines 146–159): retitle to "Why a wrapper around `cd <path>`?"; reframe content as "what does the wrapper add over plain `cd`" (worktree_create.sh policy + path resolution); drop the cache-coherence claim
+   - "Implementation note" (line 163): "invokes EnterWorktree in section 4" → "runs `cd` in section 4"
+2. **`CLAUDE.md` — lines 50–56**: rewrite the "Worktree entry" bullet under Claude-Specific Notes for the uniform `cd` flow. Drop the "EnterWorktree native tool ... cache coherence ... in one tool call" framing. Keep the project-vs-workspace coverage point (still true: all policy applies, all types covered) and the Codex/Gemini caveat (rejustified in terms of per-command shells).
+3. **`AGENTS.md` — add `### Worktree Entry` subsection** inside `## Worktree Workflow`, placed after the existing `**Multi-project**` paragraph and before the `See WORKTREE_GUIDE.md` line was the original target; revised target is the same position (just before `## Issue-First Policy`). Content: skills auto-entering a worktree use `cd <path>`, with one-paragraph rationale (native tools key off `git worktree list` of the current repo, which rules them out for project worktrees) and the exit/delete pointers.
+4. **Manual verification** in a fresh session after the PR merges: run the five SKILL.md cases (`--issue --type workspace`, `--skill research --type workspace`, `--issue --type project`, re-entry, glob safety). The `--type project` case is the new addition and is the case the issue exists for.
+
+## Decisions on review-plan findings (resolved during implementation)
+
+- **Section retitle** (finding 2): renamed to "Why a wrapper around `cd <path>`?" (matches new step-4 mechanic).
+- **Step-4 failure paragraph** (finding 3): rewritten for the `cd` failure mode (filesystem race, permissions, externally-removed dir) rather than name-swapped.
+- **"When not to use" 3rd bullet** (finding 4): bullet **stays**, rejustified in terms of the persistent-shell mechanism (Claude Code keeps shell state across tool calls; Codex/Gemini use per-command shells, so they need `worktree_enter.sh --print-path` / `--shell-snippet` to communicate the cwd back).
+- **Memory file timing** (finding 5): post-merge follow-up confirmed. The memory file (`feedback-enterworktree-cross-repo.md`) lives outside the workspace repo (in `~/.claude/projects/.../memory/`), so it isn't bundleable into this PR even if we wanted to. Will note in the PR description that the memory update is deferred and tracked separately.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `.claude/skills/start-task/SKILL.md` | Step 4 (cd, not EnterWorktree); step 5 (drop EnterWorktree framing); "Exit semantics" section (rewrite for cd flow); "Why not just call EnterWorktree directly?" (drop cache-coherence claim); "When not to use" first bullet (reword); "Manual verification" cases 1–3 (cd, not EnterWorktree) |
+| `.claude/skills/start-task/SKILL.md` | Frontmatter description; "When not to use" bullets 1 and 3; step 3 inline comment; step 4 (heading rename + body rewrite + failure-mode paragraph rewrite); step 5 (cd, not EnterWorktree); Manual verification (rewrite cases 1, 3; add new project case; renumber); Exit semantics (rewrite for cd flow); "Why a wrapper..." section (retitle + reframe); Implementation note |
 | `CLAUDE.md` | Lines 50–56 worktree-entry bullet: rewrite for uniform `cd` flow |
 | `AGENTS.md` | Add `### Worktree Entry` subsection under `## Worktree Workflow` |
 

--- a/.agent/work-plans/issue-204/progress.md
+++ b/.agent/work-plans/issue-204/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 204
+---
+
+# Issue #204 — /start-task --type project: use Bash cd instead of EnterWorktree (cross-repo limitation)
+
+## Plan
+**Status**: complete
+**When**: 2026-05-13 16:30
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Plan file: `.agent/work-plans/issue-204/plan.md`.
+
+Replace `EnterWorktree(path="$WT")` in `/start-task` step 4 with `cd "$WT"`,
+uniformly across all modes. Update `.claude/skills/start-task/SKILL.md`
+(step 4 + exit semantics + verification cases), `CLAUDE.md` lines 50–56
+(adapter description), and add a `### Worktree Entry` subsection to
+`AGENTS.md`. No script changes, no hook changes — `/start-task` is the
+single entry point that enforces the new convention.

--- a/.agent/work-plans/issue-204/progress.md
+++ b/.agent/work-plans/issue-204/progress.md
@@ -17,3 +17,50 @@ uniformly across all modes. Update `.claude/skills/start-task/SKILL.md`
 (adapter description), and add a `### Worktree Entry` subsection to
 `AGENTS.md`. No script changes, no hook changes — `/start-task` is the
 single entry point that enforces the new convention.
+
+## Review (plan)
+**Status**: complete
+**When**: 2026-05-13 17:00
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Self-review on PR #205: structurally sound, but file-targeting needs work.
+Plan undercounted the SKILL.md touchpoint list — re-grep found five
+additional EnterWorktree/ExitWorktree references (frontmatter description,
+"When not to use" 3rd bullet, step 3 inline comment, step 4 failure-mode
+paragraph, Implementation note). Also flagged: section retitle for "Why
+not just call EnterWorktree directly?", failure-mode paragraph needs
+rewrite not name-swap, "When not to use" 3rd bullet rationale needs
+rejustification, and memory file timing.
+
+Plan updated inline (`plan.md`) before implementation began to reflect
+the expanded touchpoint list and decisions on findings 2–5.
+
+## Implement
+**Status**: complete
+**When**: 2026-05-13 17:15
+**By**: Claude Code Agent (claude-opus-4-7)
+
+Three files edited per the (updated) plan:
+- `.claude/skills/start-task/SKILL.md` — ten distinct touchpoints (frontmatter,
+  two "When not to use" bullets, step 3 inline comment, step 4 heading + body
+  + failure paragraph, step 5, manual verification (rewrite 1, 3; add project
+  case; renumber), exit semantics, "Why a wrapper..." section (retitled +
+  reframed), implementation note). Post-edit grep shows the only remaining
+  EnterWorktree mentions are explanatory: line 116 explains *why* `cd` works
+  uniformly (EnterWorktree wouldn't), line 136 explains what the new project
+  verification case validates. Both intentional.
+- `CLAUDE.md` lines 50–58 — worktree-entry bullet rewritten for uniform `cd`
+  flow; Codex/Gemini caveat rejustified in terms of per-command shells.
+- `AGENTS.md` — new `### Worktree Entry` subsection inside `## Worktree
+  Workflow`, placed before `## Issue-First Policy`. Covers the convention,
+  the rationale (native tools key off `git worktree list` of the current
+  repo), and the exit/delete pointers.
+
+No script changes. No hook changes. Manual verification (the five SKILL.md
+cases) is post-merge work since `/start-task` cannot be invoked from inside
+an existing worktree (it refuses; this is step 1 of the skill).
+
+Follow-up after merge (out of scope here): update
+`feedback-enterworktree-cross-repo.md` in `~/.claude/projects/.../memory/`
+— the workaround it describes is now the standard, so the memory should be
+retired or rewritten as a historical note.

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-task
-description: "Claude Code only — create or enter the worktree for an issue/skill and switch the session into it via the native EnterWorktree tool. Wraps worktree_create.sh / worktree_enter.sh so all project policy (issue checks, branch naming, skill allowlist, --plan-file draft PR, --workflow scaffolding) still applies."
+description: "Claude Code only — create or enter the worktree for an issue/skill and cd the session into it. Wraps worktree_create.sh / worktree_enter.sh so all project policy (issue checks, branch naming, skill allowlist, --plan-file draft PR, --workflow scaffolding) still applies."
 argument-hint: "--issue <N> --type <workspace|project> | --skill <name> --type workspace [--branch <name>] [--parent-issue <N>] [--plan-file <path>] [--workflow <name>]"
 ---
 
@@ -16,9 +16,9 @@ Replace the two-step `worktree_create.sh && source worktree_enter.sh` ceremony w
 
 ## When not to use
 
-- The session is **already inside a worktree.** EnterWorktree refuses in that case. Step 1 below detects this and stops; tell the user to exit the current worktree first.
+- The session is **already inside a worktree.** /start-task refuses in that case to avoid nested worktrees. Step 1 below detects this and stops; tell the user to exit the current worktree first.
 - You want a worktree without entering it (e.g., creating one for another agent). Call `worktree_create.sh` directly.
-- The framework is **not Claude Code.** Codex / Gemini agents stay on the existing `worktree_create.sh` + `worktree_enter.sh --print-path` / `--shell-snippet` flow. This command depends on the native `EnterWorktree` tool.
+- The framework is **not Claude Code.** This command depends on the Claude Code slash-command mechanism (a persistent shell where `cd` carries forward across tool calls). Codex / Gemini agents use per-command shells and stay on the existing `worktree_create.sh` + `worktree_enter.sh --print-path` / `--shell-snippet` flow.
 - **Values containing embedded whitespace** (e.g. `--branch "feature/foo bar"`). Slash-command argument forwarding flattens user-supplied quotes; the inner whitespace will not be preserved across the boundary. Call `worktree_create.sh` directly for those cases.
 
 ## Argument handling
@@ -87,7 +87,7 @@ elif WT=$(.agent/scripts/worktree_create.sh $ARGUMENTS --print-path-only); then
 else
     set +f
     # Creation failed. The script already wrote its error to stderr.
-    # Surface the error to the user verbatim and STOP. Do not call EnterWorktree.
+    # Surface the error to the user verbatim and STOP. Do not proceed to step 4.
     #
     # Recovery: a partial creation may have left a worktree on disk even on
     # non-zero exit (e.g., set -e fires after `git worktree add` succeeds but
@@ -105,21 +105,21 @@ fi
 
 > Argument compatibility: `worktree_enter.sh` accepts `--issue`/`--skill`/`--type`/`--repo`/`--repo-slug`. `worktree_create.sh` accepts those plus `--branch`/`--parent-issue`/`--plan-file`/`--workflow`, but does **not** accept `--repo` (only `--repo-slug`). For multi-project disambiguation, use `--repo-slug`. Creation-only flags (`--branch`, `--parent-issue`, `--plan-file`, `--workflow`) cause `worktree_enter.sh` to reject the call as "Unknown option", which makes the `if` branch fail and the `elif` (creation) branch run. That's the correct behavior: those flags only make sense at creation time.
 
-### 4. Enter the worktree via the native tool
+### 4. Enter the worktree
 
-Call **EnterWorktree** with the captured path:
+`cd` into the worktree path captured in step 3:
 
 ```
-EnterWorktree(path="$WT")
+cd "$WT"
 ```
 
-The `path` parameter (rather than `name`) tells EnterWorktree to switch into a pre-existing worktree of this repo. EnterWorktree validates the path against `git worktree list` and rejects anything not registered.
+`cd` is used uniformly across `--type workspace`, `--type project`, and `--skill` modes. Project worktrees live in a separate git repo from the workspace; the native `EnterWorktree` tool would reject them because `git worktree list` from the workspace tree doesn't include them. `cd` doesn't care which repo owns the directory, so one mechanism covers every mode.
 
-**If EnterWorktree fails:** the worktree exists on disk but the session can't enter it. Tell the user the worktree path, and offer two recovery options: (a) manually `cd <path>` and continue without the harness-level worktree session, or (b) run `.agent/scripts/worktree_remove.sh --issue <N> --type <type>` (or `--skill <name>`) to clean up. Do not retry EnterWorktree silently.
+**If `cd` fails:** the worktree path was just printed by a successful `worktree_create.sh` (or returned by `worktree_enter.sh` for an existing one), so failure here is anomalous — a filesystem race, a permissions problem, or the directory was removed externally between steps 3 and 4. Report the error and run `.agent/scripts/worktree_remove.sh --issue <N> --type <type>` (or `--skill <name>`) to clean up before retrying.
 
 ### 5. Confirm to the user
 
-After EnterWorktree returns successfully, briefly tell the user:
+After `cd` returns successfully, briefly tell the user:
 
 - Which worktree they're now in (issue/skill, branch)
 - Whether it was newly created or pre-existing (you know from step 3 — the `if` branch hit means existing, `elif` means new)
@@ -129,23 +129,24 @@ After EnterWorktree returns successfully, briefly tell the user:
 
 After changes to this skill, run these checks from a fresh main-tree session to confirm behaviour. End-to-end automation would require a Claude Code SDK test harness; declined as out-of-scope (issue #188).
 
-1. **Typical case** — `/start-task --issue <test-N> --type workspace`. Expected: step 3's `elif` fires; new worktree created at `worktrees/workspace/issue-workspace-<test-N>/`; `EnterWorktree` succeeds; session lands in the new worktree.
+1. **Typical case** — `/start-task --issue <test-N> --type workspace`. Expected: step 3's `elif` fires; new worktree created at `worktrees/workspace/issue-workspace-<test-N>/`; `cd` succeeds; session lands in the new worktree.
 
 2. **Skill case** — `/start-task --skill research --type workspace`. Same flow with a skill-worktree path (`worktrees/workspace/skill-research-<TS>/`).
 
-3. **Re-entry case** — exit the worktree from check 1 (`ExitWorktree(action="keep")`), then re-run the same `/start-task --issue <test-N> --type workspace`. Expected: step 3's `if` branch fires (existing worktree found); no new creation; `EnterWorktree` returns to it.
+3. **Project case** — `/start-task --issue <test-N> --type project` against a configured project repo. Expected: step 3's `elif` fires; new worktree created at `worktrees/project/<repo>/issue-<repo>-<test-N>/`; `cd` succeeds. This is the case the previous `EnterWorktree`-based flow failed (the project worktree belongs to a separate git repo from the workspace, which `git worktree list` doesn't see); confirms uniform `cd` covers it.
 
-4. **Glob safety (structural check)** — inspect step 3 of this skill body and confirm `set -f` precedes the `if` block and `set +f` is restored in each of the three branches. Without these, an invocation containing values like `--branch main*` or `--plan-file *.md` would glob-expand against the cwd before reaching the script. The bracket makes the failure mode structurally impossible.
+4. **Re-entry case** — exit the worktree from check 1 (`cd -` back to the workspace root), then re-run the same `/start-task --issue <test-N> --type workspace`. Expected: step 3's `if` branch fires (existing worktree found); no new creation; `cd` puts the session back in the existing worktree.
+
+5. **Glob safety (structural check)** — inspect step 3 of this skill body and confirm `set -f` precedes the `if` block and `set +f` is restored in each of the three branches. Without these, an invocation containing values like `--branch main*` or `--plan-file *.md` would glob-expand against the cwd before reaching the script. The bracket makes the failure mode structurally impossible.
 
 ## Exit semantics
 
-- The worktree was created **outside** of EnterWorktree (our scripts called `git worktree add`), so `ExitWorktree` will refuse to remove it. If the user asks to exit:
-  - `ExitWorktree(action="keep")` returns the session to the original directory but leaves the worktree on disk. This is the only valid exit action for worktrees entered this way.
-  - To actually delete the worktree, use `.agent/scripts/worktree_remove.sh --issue <N> --type <type>` or `make merge-pr PR=<N>` (which removes the worktree as part of the merge flow).
+- To return the session to the previous directory: `cd -` (Bash returns to whatever directory `cd` was invoked from). Any other `cd` works too. The worktree stays on disk.
+- To delete the worktree: `.agent/scripts/worktree_remove.sh --issue <N> --type <type>` (or `--skill <name>`). `make merge-pr PR=<N>` also removes the worktree as part of the merge flow.
 
-## Why not just call EnterWorktree directly?
+## Why a wrapper around `cd <path>`?
 
-EnterWorktree alone would work, but it doesn't know about:
+Plain `cd <some-path>` would work — but only after `worktree_create.sh` has run, since the path is what the script computes (issue → branch name → worktree directory). And `worktree_create.sh` is where all the policy lives:
 
 - Issue-first policy (lookup, closed-issue warning, PR-vs-issue check)
 - The workspace/project repo distinction (two repos managed in one tree)
@@ -156,8 +157,8 @@ EnterWorktree alone would work, but it doesn't know about:
 - `--plan-file` draft-PR creation with AI signature
 - Cross-repo PR targeting for project-type worktrees
 
-`worktree_create.sh` enforces all of that. This skill keeps the script as the source of truth for policy and uses EnterWorktree only for the session-level switch — which gives smoother CWD handling and proper cache coherence on exit.
+This skill keeps `worktree_create.sh` as the source of truth for that policy, resolves the worktree path (existing → create-new fallback) consistently across workspace/project/skill modes, and `cd`s into the result — all in one slash-command invocation.
 
 ## Implementation note
 
-Slash commands in Claude Code are markdown instructions — there is no executable file behind `/start-task`. The agent reads this body, runs the Bash calls in sections 1–3, and invokes EnterWorktree in section 4. The flow is intentionally short and prescriptive so it's reliable across model versions.
+Slash commands in Claude Code are markdown instructions — there is no executable file behind `/start-task`. The agent reads this body and runs the Bash calls in sections 1–4 (path resolution in 3, `cd` in 4). The flow is intentionally short and prescriptive so it's reliable across model versions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,23 @@ source .agent/scripts/worktree_enter.sh --skill research --type workspace
 
 See [`.agent/WORKTREE_GUIDE.md`](.agent/WORKTREE_GUIDE.md) for disambiguation and troubleshooting.
 
+### Worktree Entry
+
+Skills that auto-enter a worktree (currently `/start-task`; potentially others
+in the future) use `Bash cd <path>`, not framework-native worktree-entry tools.
+Native tools that key off `git worktree list` (e.g. Claude Code's
+`EnterWorktree`) only accept worktrees of the *current* repo, so they reject
+project worktrees from a workspace session — the workspace and project are
+separate git repos. Using `cd` uniformly avoids a mode-dependent branch in
+entry skills and keeps behaviour consistent regardless of which repo owns the
+worktree.
+
+- **Exit a worktree**: `cd -` returns the session to the previous directory.
+  Any `cd` works; the worktree stays on disk.
+- **Delete a worktree**: `.agent/scripts/worktree_remove.sh --issue <N> --type
+  <type>` (or `--skill <name> --type workspace`). `make merge-pr PR=<N>` also
+  removes the worktree as part of the merge flow.
+
 ## Issue-First Policy
 
 No code without a ticket. Check for an existing GitHub issue first; if none exists,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,13 @@ often the hook fires.
 - **Worktree entry**: prefer `/start-task --issue <N> --type <workspace|project>` (or
   `--skill <name> --type workspace`) over the two-step `worktree_create.sh` +
   `source worktree_enter.sh` flow. The slash command wraps the policy scripts and
-  enters via the native `EnterWorktree` tool, so the session lands in the worktree
-  with proper cache coherence in one tool call. All policy still applies (issue
-  checks, branch naming, `--plan-file`, `--workflow`, skill allowlist). Codex /
-  Gemini agents stay on the script flow — `/start-task` is Claude Code only.
+  `cd`s the session into the worktree in one invocation. `cd` is used uniformly
+  across `--type workspace`, `--type project`, and `--skill` modes — the native
+  `EnterWorktree` tool would reject project worktrees (those live in a separate
+  git repo from the workspace), so `cd` is the one mechanism that covers every
+  mode. All policy still applies (issue checks, branch naming, `--plan-file`,
+  `--workflow`, skill allowlist). Codex / Gemini agents use per-command shells
+  and stay on the script flow — `/start-task` is Claude Code only.
 
 ## References
 


### PR DESCRIPTION
Closes #204

## Summary

Replace `EnterWorktree(path="$WT")` in `/start-task` step 4 with `cd "$WT"`, uniformly across `--type workspace`, `--type project`, and `--skill` modes. The native `EnterWorktree` tool only operates on worktrees of the current git repo, so it rejects project worktrees (workspace and project are separate repos) — `/start-task --type project` half-completed today. `cd` works uniformly.

Three files changed (all docs/instructions):
- `.claude/skills/start-task/SKILL.md` — ten touchpoints updated (frontmatter description, "When not to use" bullets 1 and 3, step 3 inline comment, step 4 heading + body + failure paragraph, step 5, manual verification (added new project case + renumbered re-entry and glob safety), exit semantics, "Why a wrapper..." section retitled and reframed, implementation note).
- `CLAUDE.md` — worktree-entry bullet rewritten for the uniform `cd` flow; Codex/Gemini caveat rejustified (per-command shells need `--print-path` / `--shell-snippet`, persistent Claude Code shell doesn't).
- `AGENTS.md` — new `### Worktree Entry` subsection inside `## Worktree Workflow` documenting the convention and exit/delete pointers.

No script changes. No hook changes. `/start-task` is the single entry point that enforces the convention.

## Memory file (post-merge follow-up)

The memory `feedback-enterworktree-cross-repo.md` lives outside this repo (in `~/.claude/projects/.../memory/`), so it can't be bundled into this PR. After merge, the workaround it describes is the standard — the file should be retired or rewritten as a historical note. Not blocking.

## Verification

Manual verification of the five SKILL.md cases (typical, skill, **project (new)**, re-entry, glob safety) is post-merge work — `/start-task` refuses to run from inside an existing worktree (step 1 detects nesting), so the cases need a fresh main-tree session.

## Plan and progress

- Plan: `.agent/work-plans/issue-204/plan.md` (kept current with implementation)
- Progress log: `.agent/work-plans/issue-204/progress.md` (plan, review, implement steps)

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-7`
