### PR TITLE
Update inspiration digest: overstory (2026-07-14 check + archive)

### DIFF
--- a/.agent/knowledge/inspiration_overstory_digest.md
+++ b/.agent/knowledge/inspiration_overstory_digest.md
@@ -1,5 +1,10 @@
 # Inspiration Digest: overstory
 
+> **ARCHIVED 2026-07-14** — upstream repository was itself archived
+> read-only on 2026-05-28 (successor: Warren, not tracked — cloud
+> control-plane focus doesn't match our interest areas). All deferrals
+> resolved below; portable patterns preserved in this digest's survey.
+
 Type: inspiration
 Last checked: 2026-07-14
 Repo: jayminwest/overstory @ ff38f3f76f084abcc34f519bcaa69580f6e53cf1
@@ -227,9 +232,26 @@ own maintainers advise against deploying casually.
 - **Mode-posture preservation (Row 4 prompt audit)** — their Base+Overlay
   split is a clean pattern for the audit to aim at
 
-## Roadmapped
+## Roadmapped (2026-07-14 decisions)
 
-(none this run)
+Added to ROADMAP.md "To Consider" under "From overstory (2026-07-14,
+archival round)":
+
+- `overstory-steelman-pattern` (2026-07-14)
+- `overstory-base-overlay-prompts` (2026-07-14)
+- `overstory-agent-role-vocabulary` (2026-07-14)
+
+## Skipped (2026-07-14 decisions)
+
+- `overstory-hook-orchestrator-pattern` — closed with upstream archival.
+  The "session IS the orchestrator" ethos already shaped the additive-only
+  coordinator constraint; the concrete hook mechanics are preserved in
+  this digest's survey section and recoverable if the coordinator design
+  is ever un-parked.
+- `warren-successor-tracking` — Warren (cloud control plane + web UI) not
+  added to the registry; interest areas don't transfer. Re-evaluate if a
+  local-orchestration need makes its self-manage/self-repair loop
+  relevant.
 
 ## Skipped (this run)
 
@@ -241,13 +263,5 @@ own maintainers advise against deploying casually.
 
 ## Deferred
 
-- `overstory-steelman-pattern` — Write our own STEELMAN docs for big
-  decisions. Candidate for Row 6 Tier-3 defer + Row 7 coordinator
-  simmering. Revisit at next brainstorm.
-- `overstory-base-overlay-prompts` — Split skill HOW from task WHAT.
-  Could emerge from Row 4 Opus 4.7 prompt audit. Revisit during sweep.
-- `overstory-hook-orchestrator-pattern` — Use hooks to prime + inject
-  context rather than external daemon. Candidate for coordinator design
-  when we un-park Row 7.
-- `overstory-agent-role-vocabulary` — Borrow role names (builder,
-  reviewer, scout, etc.) when formalizing swarm-of-personas from Row 3.
+(none — all deferrals resolved 2026-07-14 on upstream archival: three
+roadmapped, one skipped; see sections above)

--- a/.agent/knowledge/inspiration_overstory_digest.md
+++ b/.agent/knowledge/inspiration_overstory_digest.md
@@ -1,8 +1,53 @@
 # Inspiration Digest: overstory
 
 Type: inspiration
-Last checked: 2026-04-19
-Repo: jayminwest/overstory @ 590e729b332fecc449aa0abdb4ea608e43329fb0
+Last checked: 2026-07-14
+Repo: jayminwest/overstory @ ff38f3f76f084abcc34f519bcaa69580f6e53cf1
+Previously checked: 2026-04-19 @ 590e729
+
+## Changelog (2026-04-19 → 2026-07-14): project archived upstream
+
+434 commits, then the end:
+
+- Late April–early May: an intense burst of the tool **driving its own
+  development** — the commit log is swarm merges (`Merge branch
+  'overstory/builder-*/overstory-XXXX'`), `mulch: update expertise`, and
+  `seeds: sync` state commits. Notable late additions: headless-first
+  spawning with a web UI (`ov serve`) demoting tmux to an escape hatch,
+  spawn-per-turn mail/nudge consumers, worker_done terminal contract.
+- **2026-05-15**: README notes maintenance mode, "points to Warren as
+  successor."
+- **2026-05-28**: repository marked **no longer maintained / archived
+  (read-only)**. No merged PRs and no new issues since our last check —
+  community activity had already stopped.
+
+**Successor**: [Warren](https://github.com/jayminwest/warren) — "control
+plane and UI for cloud-based custom agents that operate in isolation,
+self-manage, self-repair, and self-improve." Active (pushed 2026-07-14,
+119 stars), but it is a cloud-agent control plane with a web UI —
+farther from the local, terminal-first patterns (SQLite mailbox, watchdog
+daemon, tiered conflict resolution) that motivated tracking overstory.
+Those patterns are frozen in overstory's MIT-licensed archive and
+captured in this digest's survey; nothing further will evolve here.
+
+**Registry action**: archive overstory. Warren not added — interest
+areas don't transfer; re-evaluate if a local-orchestration need makes
+its self-repair/self-manage loop relevant.
+
+## Deferral triage forced by upstream archival (2026-07-14)
+
+The four deferrals below were "revisit when upstream evolves" items; with
+upstream dead, each must resolve to roadmap or close:
+
+1. `overstory-steelman-pattern` — write the strongest case AGAINST a
+   major approach before adopting it (their STEELMAN.md remains the model
+   artifact, archived but readable)
+2. `overstory-base-overlay-prompts` — role HOW as reusable base + task
+   WHAT as per-invocation overlay
+3. `overstory-hook-orchestrator-pattern` — "your session IS the
+   orchestrator": hooks prime and inject, no external daemon
+4. `overstory-agent-role-vocabulary` — named role catalog (builder,
+   reviewer, scout, merger, …) for multi-persona review
 
 ## Survey Summary
 

--- a/.agent/knowledge/inspiration_registry.yml
+++ b/.agent/knowledge/inspiration_registry.yml
@@ -55,22 +55,6 @@ projects:
       - subagent patterns and orchestration
       - development methodology and workflows
 
-  overstory:
-    type: inspiration
-    repo: jayminwest/overstory
-    description: Multi-agent orchestrator with SQLite-backed messaging and watchdog daemon
-    # Added 2026-04-19. Paired with agent-orchestrator to cover the
-    # category from two angles — agent-orchestrator is the big/reference
-    # implementation, Overstory explores different messaging tech
-    # (SQLite-backed mailbox) and conflict-resolution patterns. Of
-    # particular interest: watchdog daemon, which we're building
-    # separately as a small bash helper per Row 7 decision.
-    interest_areas:
-      - inter-agent messaging (SQLite-backed mailbox)
-      - conflict resolution (4-tier)
-      - watchdog daemon patterns
-      - multi-runtime agent support (Claude Code, Pi, Gemini CLI)
-
   engram:
     type: inspiration
     repo: shiblon/engram
@@ -113,3 +97,10 @@ projects:
   # is covered by the ros2 dispatch/run-issue design (roadmapped
   # 2026-07-14). Was tracked for: reaction system, task decomposition,
   # adapter architecture, worktree-per-agent discipline, dashboard model.
+  #
+  # overstory (jayminwest/overstory) — upstream repository archived
+  # read-only 2026-05-28; successor Warren (cloud control plane + web UI)
+  # not tracked, interest areas don't transfer. Portable patterns
+  # (STEELMAN doc, base+overlay prompts, role vocabulary) roadmapped
+  # 2026-07-14; SQLite mailbox / watchdog / conflict-tier survey preserved
+  # in the digest.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -292,6 +292,12 @@ Cherry-picked from a recon scan of tracked inspirations since last refresh (2026
 - **Duplicate-spawn prevention** — Before starting work on an issue, check whether a worktree/agent already exists for it and fail loud (worktree_create.sh partially covers this; the gap is cross-session awareness). Source: ComposioHQ/agent-orchestrator #1337
 - **Code-review-as-slot** — Treat reviewer personas as pluggable implementations behind one review interface, so alternate reviewers (different models, different lenses) can be swapped without editing the review-code skill body. Source: ComposioHQ/agent-orchestrator #1339/#2572
 
+### From overstory (2026-07-14, archival round)
+
+- **STEELMAN document pattern** — Before adopting any workspace-wide approach (orchestration, new skill class, major tooling), write the strongest case *against* it — as a STEELMAN section in the ADR or a standalone doc. Overstory's own STEELMAN.md (compounding error rates, cost amplification, debugging-as-forensics) remains the model artifact and validated our own Tier-3 defer reasoning. Source: jayminwest/overstory STEELMAN.md (archived, readable)
+- **Base+overlay prompt split** — Separate role HOW (reusable base: workflow, constraints, capabilities) from task WHAT (per-invocation overlay: task ID, scope, branch). Candidate outcome of the existing prompt-audit sweep row rather than a separate effort. Source: jayminwest/overstory agents/*.md + ov sling overlay architecture
+- **Agent role vocabulary** — Named role catalog (builder, coordinator, lead, merger, monitor, reviewer, scout, supervisor) as the working vocabulary when formalizing multi-persona review (swarm-of-personas row). Source: jayminwest/overstory agents/ catalog
+
 ### Research topics to add (not tracker items)
 
 Candidates for `.agent/knowledge/research_digest.md`, separate from roadmap items.


### PR DESCRIPTION
## Inspiration Tracker: overstory

Checked upstream 2026-04-19 → 2026-07-14: **upstream repository archived read-only 2026-05-28** after a final swarm-driven burst; successor is Warren (cloud control plane + web UI).

### Decisions

**Roadmapped** (deferrals resolved on archival):
- STEELMAN document pattern (strongest case against, before adopting)
- Base+overlay prompt split (role HOW vs task WHAT)
- Agent role vocabulary (builder/reviewer/scout/… catalog)

**Skipped**: hook-orchestrator pattern (ethos already absorbed into the additive-only coordinator constraint; mechanics preserved in digest).

**Archived**: overstory removed from active registry tracking. **Warren not added** — cloud control-plane focus doesn't match our interest areas.

Note: digest written with workspace-agnostic wording per #217.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-fable-5`
