### PR TITLE
docs(#217): make workspace digests and guides project-agnostic

### DIFF
--- a/.agent/WORKTREE_GUIDE.md
+++ b/.agent/WORKTREE_GUIDE.md
@@ -55,8 +55,8 @@ agent_workspace/
 │   │   └── issue-workspace-42/
 │   │       └── ... (workspace files)
 │   └── project/                   # Project repo worktrees (per-repo)
-│       └── daddy_camp/
-│           └── issue-daddy_camp-42/
+│       └── <repo_name>/
+│           └── issue-<repo_name>-42/
 │               └── ... (project files)
 ```
 
@@ -107,8 +107,8 @@ Since `--type` is mandatory, workspace vs. project is never ambiguous.
 For multiple project repos, use `--repo`:
 
 ```bash
-source .agent/scripts/worktree_enter.sh --issue 42 --type project --repo daddy_camp
-.agent/scripts/worktree_remove.sh --issue 42 --type project --repo daddy_camp
+source .agent/scripts/worktree_enter.sh --issue 42 --type project --repo <repo_name>
+.agent/scripts/worktree_remove.sh --issue 42 --type project --repo <repo_name>
 ```
 
 For multiple worktrees of the same type with different repo slugs, use `--repo-slug`:

--- a/.agent/knowledge/inspiration_agent-orchestrator_digest.md
+++ b/.agent/knowledge/inspiration_agent-orchestrator_digest.md
@@ -206,7 +206,7 @@ into issue-or-PR or agent-session actions. Key decisions:
 
 5. **Hash-based project namespacing** — `sha256(configDir).slice(0,12)`
    prevents collisions when the same config manages multiple projects.
-   We only have one active project (daddy_camp); overkill now, worth
+   A workspace instance manages one project at a time; overkill now, worth
    remembering if we scale
 6. **Exclusive routing mode (local OR scm)** — their explicit decision
    that routing can't split both ways. Clarity-over-flexibility
@@ -229,7 +229,7 @@ into issue-or-PR or agent-session actions. Key decisions:
 
 - **Tier 3 orchestration** (Deferred, Row 6 of #157) — AO IS Tier 3.
   This survey confirms the category is well-formed, pattern-convergent,
-  and mature. Still deferred for daddy_camp per our "most of our
+  and mature. Still deferred per our "most of our
   backlog isn't mechanical" reasoning. Revisit trigger unchanged
 - **Agent Teams declined** (Row 7) — AO's reaction system is the
   non-Agent-Teams equivalent of the coordination they offer; our

--- a/.agent/knowledge/inspiration_engram_digest.md
+++ b/.agent/knowledge/inspiration_engram_digest.md
@@ -23,7 +23,7 @@ the harness's authoritative instruction channel** at inject time, instead
 of trusting a side-channel memory block to compete with CLAUDE.md-tier
 text.
 
-- **Daddy_camp relevance**: High as a lesson about our own memory system.
+- **Workspace relevance**: High as a lesson about our own memory system.
   Recalled memories arrive in `<system-reminder>` blocks — a weaker
   channel than CLAUDE.md/AGENTS.md. Load-bearing feedback-type memories
   (standing corrections, hard rules) may deserve promotion into the
@@ -37,7 +37,7 @@ text.
   line + orientation header leading with the running version).
 - Version-drift check rides along in inject.
 
-- **Daddy_camp relevance**: Medium. Convergent with our roadmapped
+- **Workspace relevance**: Medium. Convergent with our roadmapped
   `per-session-context-card` concept (rapid re-grounding when switching
   agent tabs) — engram's orientation header is a working example of the
   same idea. Cross-link when that item is picked up.
@@ -49,7 +49,7 @@ staged, then graduate to `$HOME/.engram/agenttools`. Notably the
 **project-level** tool subsystem was later removed — global-only
 survived. (Author's own scope-discipline worth noting.)
 
-- **Daddy_camp relevance**: Low-medium. Parallels our
+- **Workspace relevance**: Low-medium. Parallels our
   analyze-permissions / skill-authoring flows ("mine sessions for
   recurring patterns, then promote"). Pattern noted; no port target.
 
@@ -60,7 +60,7 @@ save-archive + staged restore across machines. Fix discipline visible:
 "never silently drop projects from the archive", "report file writes
 truthfully".
 
-- **Daddy_camp relevance**: Low. Git already gives our markdown memory
+- **Workspace relevance**: Low. Git already gives our markdown memory
   portability. Unchanged from prior skip decision.
 
 ### MCP surface removed
@@ -70,7 +70,7 @@ The experimental MCP server we deferred on (2026-05-07,
 CLI-viability check"). Codex/Gemini integration went hook-parity + AGENTS
 fallback instead.
 
-- **Daddy_camp action**: Close the deferral as obsolete.
+- **Workspace action**: Close the deferral as obsolete.
 
 ### Misc
 
@@ -119,7 +119,7 @@ the workflow conventions through prose instructions written into a global
 | `long`       | project  | Settled project decisions and facts.             |
 | `short`      | project  | In-flight context, conversation stack, backlog.  |
 
-Note: this is a *durability* axis. Daddy_camp's existing memory uses a
+Note: this is a *durability* axis. This workspace's existing memory uses a
 *source/topic* axis (user / feedback / project / reference). The two are
 orthogonal — could be combined.
 
@@ -155,7 +155,7 @@ status line stops showing your agent's name, context coherence is breaking.
 ### Isolation strategy
 
 - Per-project DB in `<project-root>/.claude/engram.db` keeps project memory
-  scoped (similar to daddy_camp's per-project memory dir under
+  scoped (similar to our per-project memory dir under
   `~/.claude/projects/<encoded-path>/memory/`).
 - Global DB in `~/.claude/engram.db` for cross-project invariants and
   preferences.
@@ -199,7 +199,7 @@ a known footgun.
 
 ## Mapping to interest_areas
 
-| Interest area | What engram does | Daddy_camp delta |
+| Interest area | What engram does | Workspace delta |
 |---|---|---|
 | Stack-based short-term memory | `short` tier holds "in-flight context, conversation stack, backlog." Workflow says push current context before digression, pop on resume. The *tool* doesn't enforce stack semantics — it's prose-encoded in the global `engram-workflow` invariant. | We'd add this as a workflow convention in CLAUDE.md/AGENTS.md without needing tooling. |
 | Personality as context-decay canary | `codename` invariant + status-line render. When status line drops the codename, context is breaking down. | Adoptable as a memory entry + lightweight status-line addition. |
@@ -232,7 +232,7 @@ issues or PRs — author works on `main` directly.
   injection. Bootstrap also extended for `go install`-based distribution.
 - **CLAUDE.md @file inclusion** (commit a3b9d9d) — bootstrap now writes
   `@<path>` reference into CLAUDE.md instead of inlining `agentinfo` text.
-  Daddy_camp already uses this pattern for `@AGENTS.md`.
+  This workspace already uses this pattern for `@AGENTS.md`.
 - **`promote` → `move`** (commit b33fc9a) — internal CLI rename.
 - **Refined global vs project instructions** (commit 125f1d4).
 
@@ -257,11 +257,12 @@ issues or PRs — author works on `main` directly.
 ## Issued
 
 - `personality-canary-light` — agent_workspace #168 (2026-04-26).
-  Adopted at light layer: codename **Grover** + 5-trait tone (lean,
-  precise, skeptical, quietly dry, calm under load). Memory file written
-  to auto-memory at `~/.claude/projects/-home-roland-daddy-camp/memory/user_agent_personality.md`;
-  index updated. 30-day revisit (~2026-05-26) to evaluate whether the
-  light layer earns its keep or escalation/deletion is warranted.
+  Adopted at light layer: an agent codename + 5-trait tone, written as a
+  `user_agent_personality` entry in the then-active project's auto-memory
+  (project-scoped; the specific codename and file path live with that
+  project, not the workspace — see issue #217). 30-day revisit
+  (~2026-05-26) to evaluate whether the light layer earns its keep or
+  escalation/deletion is warranted.
 
 ## Skipped
 
@@ -281,7 +282,7 @@ issues or PRs — author works on `main` directly.
 ### 2026-05-07 decisions
 
 - `agentinfo-command-pattern` — Engram's "tool prints its own usage"
-  pattern. Daddy_camp already gets the portable insight via CLAUDE.md →
+  pattern. This workspace already gets the portable insight via CLAUDE.md →
   `@AGENTS.md` referencing; no new helper needed.
 - `db-migration-system` — Engram's schema-evolution support for SQLite
   DBs. Markdown-based memory has no schema to migrate; pattern is N/A.

--- a/.agent/knowledge/inspiration_gstack_digest.md
+++ b/.agent/knowledge/inspiration_gstack_digest.md
@@ -24,7 +24,7 @@ since (cso, document-release, design-consultation). Open issues extend it:
 ~120 lines of boilerplate duplicated across 51/56 skills, over-prescriptive
 STRICT recipes).
 
-- **Daddy_camp relevance**: High. Our skill bodies keep growing (this
+- **Workspace relevance**: High. Our skill bodies keep growing (this
   skill's own SKILL.md included), and ros2's open #564 (slim AGENTS.md via
   an enforcement-backed criterion) is the same concern arriving from the
   fork side — convergent evidence that always-loaded instruction mass is
@@ -42,7 +42,7 @@ host variants (Conductor) breaking native AUQ. Net lesson: gates must
 fail loud, fallbacks get abused unless scoped to verified tool failure,
 and self-decide needs an explicit contract.
 
-- **Daddy_camp relevance**: Medium. Complements the already-roadmapped
+- **Workspace relevance**: Medium. Complements the already-roadmapped
   AUQ cadence/Pros-Cons item and the plan-* STOP-gate item (both
   2026-05-07): this adds the fallback-abuse failure mode and the
   AUTO_DECIDE contract idea.
@@ -53,7 +53,7 @@ Skills record decisions durably across sessions; 5 planning skills now
 read structured memory context *before* asking the user anything ("don't
 ask what the brain already knows").
 
-- **Daddy_camp relevance**: Medium. The ask-side rule is portable to our
+- **Workspace relevance**: Medium. The ask-side rule is portable to our
   skills: consult memory/progress.md/ROADMAP before AskUserQuestion.
   Storage side is gbrain-domain.
 
@@ -68,7 +68,7 @@ ask what the brain already knows").
   second-model review" pricing landed on opposite defaults.
 - v1.39.1 — EXIT PLAN MODE GATE for plan-mode review skills.
 
-- **Daddy_camp relevance**: Medium for unresolved-decisions declaration
+- **Workspace relevance**: Medium for unresolved-decisions declaration
   (cheap addition to review-code/triage-reviews report formats);
   informational for the Codex-default contrast (feeds our own
   cross-model cost tuning).
@@ -79,7 +79,7 @@ A community bug wave found **4 security guards failing open** (guard
 hooks that silently passed when their precondition machinery broke).
 Fix wave + tests.
 
-- **Daddy_camp relevance**: Medium as a lesson: we have enforcement hooks
+- **Workspace relevance**: Medium as a lesson: we have enforcement hooks
   (block-bash-tool-mapping, pre-commit) — worth an explicit fail-closed
   audit/test pass. Cheap, concrete.
 
@@ -274,7 +274,7 @@ release engineer). 25+ skills, TypeScript/Bun-based, MIT license.
 - `gstack-design-html` — /design-html from any starting point (#734). Gstack domain (2026-04-19)
 - `gstack-aquavoice-triggers` — Voice-friendly skill triggers for AquaVoice (v0.14.6.0). Gstack domain (2026-04-19)
 - `gstack-cookie-picker` — Cookie picker auth token leak fix (#904). Gstack domain (2026-04-19)
-- `gstack-plan-devex-review` — New /plan-devex-review persona (#784). Pattern interesting but not a current need; no analogue motivated in daddy_camp (2026-04-19)
+- `gstack-plan-devex-review` — New /plan-devex-review persona (#784). Pattern interesting but not a current need; no analogue motivated in this workspace (2026-04-19)
 - `gstack-relationship-closing` (2026-05-07) — Office-hours adapts to repeat
   users (#937). Auto-memory `user_workflow_patterns` + `user_agent_personality`
   already cover this at the memory layer; no skill-level adaptation needed.
@@ -375,7 +375,7 @@ versioned releases in 19 days. Continued rapid iteration.
 
 ### Major themes
 
-**Plan-* skill reliability (high relevance for daddy_camp's /plan-task and /review-plan):**
+**Plan-* skill reliability (high relevance for our /plan-task and /review-plan):**
 
 - v1.21.1.0 #1255 — tighten plan-ceo-review smoke (Step 0 must fire)
 - v1.25.1.0 #1296 — office-hours Phase 4 STOP gate + AskUserQuestion

--- a/.agent/knowledge/inspiration_registry.yml
+++ b/.agent/knowledge/inspiration_registry.yml
@@ -36,7 +36,7 @@ projects:
     # interest_areas tightened 2026-04-19: dropped browser-based QA
     # (gstack domain), de-emphasized release engineering (scale mismatch);
     # added session/context management + agent-user UX patterns to match
-    # daddy_camp's current concerns
+    # the workspace's current concerns
     interest_areas:
       - review and QA workflow (multi-role review, adversarial, anti-skip)
       - planning methodology (CEO/eng/design review roles, scope modes)
@@ -60,7 +60,7 @@ projects:
     repo: shiblon/engram
     description: Memory and personality aid for Claude Code — stack-based short-term memory and dump/load portability
     # Added 2026-04-26. Author's own framing emphasizes personality
-    # as a context-decay canary. Daddy_camp already has a working
+    # as a context-decay canary. The workspace already has a working
     # auto-memory setup (CLAUDE.md + per-project memory files);
     # interest is in the patterns, not adopting the Go binary.
     # Personality angle is exploratory — user is curious but no

--- a/.agent/knowledge/inspiration_ros2_agent_workspace_digest.md
+++ b/.agent/knowledge/inspiration_ros2_agent_workspace_digest.md
@@ -23,7 +23,7 @@ rules, adds only repo-specific content plus a standalone context block for
 Copilot which can't see the workspace), and wiring into `onboard-project`
 (offers the file) and `audit-project` (checks presence/currency).
 
-- **Daddy_camp relevance**: High. The project repo gets Copilot PR
+- **Workspace relevance**: High. The project repo gets Copilot PR
   reviews with zero instructions today. Template + ADR + skill wiring are
   all domain-neutral. Direct port candidate.
 
@@ -33,7 +33,7 @@ Copilot which can't see the workspace), and wiring into `onboard-project`
 via pytest) in a dedicated CI job. Tests are hermetic (temp git sandboxes,
 stubbed `gh`, no network), so the job needs only git + pytest.
 
-- **Daddy_camp relevance**: High, cheap. We have 4 hermetic test scripts
+- **Workspace relevance**: High, cheap. We have 4 hermetic test scripts
   in `.agent/scripts/tests/` that run manual-only; our `validate.yml` has
   lint + docs jobs but no script-tests job. Direct port.
 
@@ -62,7 +62,7 @@ The largest theme (~15 PRs). Three layers:
    PR created at the end. `/address-findings` is a deliberately thin
    "work the agreed fix plan" phase.
 
-- **Daddy_camp relevance**: Split. ADR-0013 vocabulary + progress_read
+- **Workspace relevance**: Split. ADR-0013 vocabulary + progress_read
   pattern is Medium — we already write progress.md entries in
   triage-reviews and the drift risk is real. The dispatch/run-issue
   machinery is the "orchestrator" category we deferred (Tier 3, D5
@@ -82,7 +82,7 @@ load-bearing: rejects PRs where an agent-convention branch has commits
 whose primary author matches a human pattern; Co-Authored-By trailers
 deliberately not evaluated).
 
-- **Daddy_camp relevance**: Medium. Same failure mode exists here when
+- **Workspace relevance**: Medium. Same failure mode exists here when
   sub-agents commit. The CI-side check is the portable part (no env
   dependency); patterns would need adapting to rolker.net emails.
 
@@ -99,7 +99,7 @@ deliberately not evaluated).
   Includes a lighter severity bar for agent-guidance docs (SKILL.md).
 - `--skip-static` / `--no-progress` / `--issue` overrides.
 
-- **Daddy_camp relevance**: Medium. The convergence/ship-signal pattern
+- **Workspace relevance**: Medium. The convergence/ship-signal pattern
   is portable to our review-code/cross_model_review loop and addresses a
   real cost (each re-review round is expensive). Copilot-opt-in decision
   is an interesting data point for our own external-review cost tuning.
@@ -114,7 +114,7 @@ Behavioral operating mode for live field deployments: urgency contract
 (fix: forbid typed timestamps, use a helper); log-append via `printf >>`
 hits a permission prompt per entry (fix: dlog helper).
 
-- **Daddy_camp relevance**: Low (field-ops domain). The two lessons
+- **Workspace relevance**: Low (field-ops domain). The two lessons
   (fabricated timestamps; prompt-free append helper) are worth remembering
   if we ever build session-logging tooling. Skip.
 
@@ -201,7 +201,7 @@ detector), `.agent/scripts/tests/test_field_mode.sh`, and a hotfix
 walkthrough at `.agent/knowledge/field_mode_hotfix.md`. AGENTS.md grew a
 "Field Mode" section.
 
-- **Daddy_camp relevance**: Low. The project repo's origin is GitHub.
+- **Workspace relevance**: Low. The project repo's origin is GitHub.
   No second remote planned. Skip unless we add a non-GitHub deploy target.
 
 ### ADR-0012 — Permit Cross-Reference Addendums in ADRs
@@ -211,7 +211,7 @@ addendums: a Status-line note pointing at a later superseding/scoped
 ADR, or a References section listing related ADRs. Substantive edits
 still require superseding.
 
-- **Daddy_camp relevance**: Medium. We inherited `docs/decisions/` from
+- **Workspace relevance**: Medium. We inherited `docs/decisions/` from
   ros2; the discoverability gap (older ADRs don't link forward to newer
   ones that scope them) applies to us too. Cheap port.
 
@@ -221,7 +221,7 @@ Batch-imports remote-ahead commits from a secondary remote (gitcloud) back
 to GitHub: per-repo issue creation, draft PR, and pre-review against the
 Quality Standard. Depends on `pull_remote.py --json`.
 
-- **Daddy_camp relevance**: Low. Pairs with field-mode; same scope. Skip
+- **Workspace relevance**: Low. Pairs with field-mode; same scope. Skip
   unless field deploys are added.
 
 ### AGENTS.md "Quality Standard" section (#437 → PR #438)
@@ -232,8 +232,8 @@ failures or stale data as "nits", don't offer to "table this for later"
 when the permanent solve is minutes away. Originally framed for "robot
 boats on open water" but the substance is domain-neutral.
 
-- **Daddy_camp relevance**: High. Principles transfer to a public-release
-  game project. Direct port with framing adjusted.
+- **Workspace relevance**: High. Principles transfer to any public-release
+  project. Direct port with framing adjusted.
 
 ### plan-task — "During implementation" guidance + `--no-pr` (#449 → PR #450)
 
@@ -243,7 +243,7 @@ when implementation diverges; an `## Implementation Notes` section at the
 bottom is allowed only for rationale-bearing design pivots whose *why*
 isn't obvious from the diff. Also adds `--no-pr` flag for offline planning.
 
-- **Daddy_camp relevance**: High. Our `plan-task` skill is in active use;
+- **Workspace relevance**: High. Our `plan-task` skill is in active use;
   drift between plan and landed code is a recurring concern. Cheap port.
 
 ### triage-reviews — "Require justification for false positives" (#439 → PR #441)
@@ -253,7 +253,7 @@ tightens example wording from "Why it's not applicable" to "Specific
 reason the failure mode cannot occur". Forces dismissals to articulate
 the absent failure mode, not vibes.
 
-- **Daddy_camp relevance**: Medium. Our local `triage-reviews` already
+- **Workspace relevance**: Medium. Our local `triage-reviews` already
   has additional logic upstream lacks (Update progress.md step). Small
   additive port.
 
@@ -263,7 +263,7 @@ the absent failure mode, not vibes.
 self-report their model via the 3rd argument; the table now functions
 as documented fallbacks only.
 
-- **Daddy_camp status**: Already in place. Local versions diverged to use
+- **Workspace status**: Already in place. Local versions diverged to use
   rolker.net emails, list Codex CLI, and document the "FALLBACKS ONLY"
   stance per `feedback_model_detection.md`. No port.
 
@@ -301,7 +301,7 @@ No carry-over.
 ~3498 LOC Python web dashboard (ThreadingHTTPServer + SSE, Playwright tests,
 CSRF hardening, static-file containment). ~20 commits over review iterations.
 
-- **Already decided on daddy_camp side**: roadmap #64 "Web dashboard" is
+- **Already decided on workspace side**: roadmap #64 "Web dashboard" is
   `done`. No re-port planned (see "CLI-first architecture note" below).
 
 ### Git-bug v0.10.1 syntax fix (PR #419 closes #418)
@@ -311,7 +311,7 @@ v0.10.1 nested them under `git bug bug`. Every call silently fell back to `gh`
 for ~2 weeks before the regression was caught. Key lesson: **silent fallbacks
 hide breakage.**
 
-- **daddy_camp status**: we got the syntax right first try (our AGENTS.md +
+- **Workspace status**: we got the syntax right first try (our AGENTS.md +
   `_issue_helpers.sh` use `git bug bug ...`). Verified live 2026-04-19 —
   96 local issues cached, bridge configured.
 - **Gap**: we don't warn on fallback. Captured in PR #157 roadmap as
@@ -323,7 +323,7 @@ Four new scripts (677 LOC): `add_remote.py`, `push_remote.py`, `pull_remote.py`,
 `lib/remote_utils.py`. Forgejo-aware; supports pushing to gitcloud or similar
 from field machines.
 
-- **daddy_camp status**: **Skip.** Backup for us = `git push origin <branch>`;
+- **Workspace status**: **Skip.** Backup for us = `git push origin <branch>`;
   Forgejo declined (D6); no multi-repo manifest need. Ros2's scripts solve a
   problem we don't have.
 
@@ -352,7 +352,7 @@ They imported the skill **from us**. No action.
 - **#423 — Git-bug and offline agent workflow for field deployments** —
   read 2026-04-19. Still design-stage (Forgejo bridge planned, not built).
 - **#432 — Merging field changes from gitcloud back to GitHub** — related
-  to #422 push/pull scripts. Daddy_camp doesn't have this workflow need.
+  to #422 push/pull scripts. This workspace doesn't have that workflow need.
 - **#435 — Deployment debrief skill** — field-ops specific (bag analysis
   with noise filtering). Skip.
 - **#427, #429, #430, #431, #434** — ROS-domain or field-specific. Skip.
@@ -363,14 +363,14 @@ They imported the skill **from us**. No action.
 |---|---|---|
 | `dashboard-sh-enhancements` | deferred | **Skip** — ros2 moved to Python web dashboard; our CLI-first preference makes re-port a bad fit |
 | `tests/` directory for scripts | deferred | **Ported/Adapted** — we started this session (test_cross_model_review, test_resolve_work_plans_dir, test_merge_pr_root_resolution) |
-| `ci_workflow.yml` template | deferred | **Skip** — template targets ROS repos; daddy_camp isn't ROS |
+| `ci_workflow.yml` template | deferred | **Skip** — template targets ROS repos; the managed project isn't ROS |
 | `pre-commit-config.yaml` template | deferred | **Skip** — same reason |
 | `.github/copilot-instructions.md` adapter | deferred | **Skip** — we have Copilot review working via default behavior |
 
 ## CLI-first architecture note (2026-04-19 session)
 
 A common thread through recent decisions: the ros2 workspace has chosen
-a web dashboard + intermediated review UI direction. Daddy_camp's
+a web dashboard + intermediated review UI direction. This workspace's
 single-user, single-machine, CLI-intensive workflow goes the opposite way.
 The user:
 
@@ -443,7 +443,7 @@ concurrent ideas:
 - `identity-script-revisions-#407` — already in place locally with
   rolker.net emails, Codex CLI listed, FALLBACKS-ONLY stance documented
   (per `feedback_model_detection.md`).
-- `git-bug-in-devcontainer` — ros2-specific devcontainer; daddy_camp
+- `git-bug-in-devcontainer` — ros2-specific devcontainer; this workspace
   uses host install per ADR-0010.
 - `--symlink-install-doc` — ROS colcon-specific; not applicable.
 - `adr-0001/0002-status-line-addendums` — depends on ADR-0012 landing
@@ -455,7 +455,7 @@ concurrent ideas:
 
 - `secondary-remote-sync` — ros2 #422 `push_remote.py`/`pull_remote.py`.
   Backup via `git push origin <branch>`; Forgejo declined; no multi-repo
-  manifest. Daddy_camp doesn't need it.
+  manifest. This workspace doesn't need it.
 - `dashboard-phase1-re-port` — web-UI model doesn't fit CLI-centric
   workflow. Valid need (attention handoff) tracked as context-card concept.
 - `root-dir-symlink-fix` — solved differently in our #146/#155.

--- a/.agent/knowledge/inspiration_superpowers_digest.md
+++ b/.agent/knowledge/inspiration_superpowers_digest.md
@@ -46,7 +46,7 @@ the portable part:
   to files with red/green test evidence, and a progress ledger lets a
   context-lost controller resume rather than redo.
 
-- **Daddy_camp relevance**: High. We dispatch review subagents
+- **Workspace relevance**: High. We dispatch review subagents
   (review-code specialists, cross_model_review) and the anti-coaching,
   files-not-paste, mandatory-model, and read-only-reviewer rules are all
   cheap to adopt piecemeal.
@@ -62,7 +62,7 @@ the portable part:
   review pass; fold setup/config/docs into the task that needs them. Their
   A/B: one fix round vs two-to-four for control (which also shipped a bug).
 
-- **Daddy_camp relevance**: Medium-high. Direct enhancement candidates for
+- **Workspace relevance**: Medium-high. Direct enhancement candidates for
   our plan-task skill's plan format.
 
 ### Writing-skills guidance (v6.0.0 + #1741)
@@ -73,7 +73,7 @@ the portable part:
 - **Micro-Test Wording** — sample a phrasing a handful of times against a
   no-guidance control before committing; run-to-run variance is a warning.
 
-- **Daddy_camp relevance**: Medium. We author skills continuously; this is
+- **Workspace relevance**: Medium. We author skills continuously; this is
   distilled craft knowledge. Resolves the prior
   `writing-skills-script-vs-prose` deferral (that guidance landed as part
   of this).
@@ -87,7 +87,7 @@ tools (Claude Code, Codex, Copilot, Gemini, Pi, Antigravity).
 `finishing-a-development-branch` went forge-neutral (no hardcoded
 `gh pr create`).
 
-- **Daddy_camp relevance**: Medium. Our AGENTS.md + adapter-file structure
+- **Workspace relevance**: Medium. Our AGENTS.md + adapter-file structure
   already does the workspace-level version; the *skill-body* neutrality
   pattern applies if our skills ever run under Codex/Gemini (which the
   workspace nominally supports). Resolves the prior
@@ -101,7 +101,7 @@ into points of use. Same quarter: gstack carved skills (56% catalog token
 cut), ros2 opened #564 to slim AGENTS.md. Three tracked sources
 independently attacking always-loaded instruction mass.
 
-- **Daddy_camp relevance**: Feeds the just-roadmapped
+- **Workspace relevance**: Feeds the just-roadmapped
   `skill-carving-token-reduction` item; no separate entry needed. The
   convergence itself is the signal.
 
@@ -320,7 +320,7 @@ process as mandatory workflow rather than optional suggestions.
   evals/ on dev (PR #1488).
 - `plan-review-cycle-skill` — added to ROADMAP.md "To Consider" 2026-05-07.
   Adversarial plan review between writing-plans and executing-plans
-  (PR #1473 merged). Compare with daddy_camp's existing /review-plan skill.
+  (PR #1473 merged). Compare with our existing /review-plan skill.
 
 ## Issued (historical, 2026-03-22)
 
@@ -333,7 +333,7 @@ process as mandatory workflow rather than optional suggestions.
 
 ## Skipped
 
-- `using-superpowers-opt-in-bootstrap` (2026-05-07) — Daddy_camp has no analogous
+- `using-superpowers-opt-in-bootstrap` (2026-05-07) — This workspace has no analogous
   always-on session-start prompt injection. CLAUDE.md/AGENTS.md load once per
   session; settings.json hooks fire on specific events without injecting prompt
   text. Pattern noted for the workspace-context system but no direct adoption.
@@ -360,13 +360,13 @@ process as mandatory workflow rather than optional suggestions.
   skill-to-skill reactivity beyond settings.json hooks.
 - `lift-agent-into-skill` (2026-05-07) — v5.1.0 pattern. Note for next
   reorganization of `.claude/agents/`; some 1:1 agent→skill pairs in
-  daddy_camp may be inlining candidates.
+  this workspace may be inlining candidates.
 - `harness-neutral-skill-prose` (2026-07-14) — v6.0.0 action-vocabulary
   rewrite + per-harness tool references. Supersedes the 2026-05-07
   `cross-platform-skill-compatibility` deferral (PR #1486 merged). Our
   skills only run under Claude Code today; revisit if Codex/Gemini skill
   use becomes real.
-- `worktree-consent-gate` (2026-05-07) — v5.1.0 pattern. Daddy_camp's
+- `worktree-consent-gate` (2026-05-07) — v5.1.0 pattern. This workspace's
   workflow is friction-averse with 4-5 concurrent agents; auto-creation
   is currently preferred. Native-tool preference also conflicts with our
   cross-runtime stance. Keep on radar if worktree volume becomes a problem.

--- a/.agent/knowledge/research_digest.md
+++ b/.agent/knowledge/research_digest.md
@@ -174,7 +174,7 @@ Key takeaways:
 
 ## ROS 2 Agent Frameworks
 
-**Added**: 2026-02-27 | **Last verified**: 2026-04-19 (reference only — daddy_camp is non-ROS) | **Sources**: [ROSA (NASA JPL)](https://github.com/nasa-jpl/rosa), [RAI (RobotecAI)](https://github.com/RobotecAI/rai), [ROS-LLM (Auromix)](https://github.com/Auromix/ROS-LLM), [EmbodiedAgents (Automatika)](https://automatika-robotics.github.io/embodied-agents/)
+**Added**: 2026-02-27 | **Last verified**: 2026-04-19 (reference only — no ROS project currently managed) | **Sources**: [ROSA (NASA JPL)](https://github.com/nasa-jpl/rosa), [RAI (RobotecAI)](https://github.com/RobotecAI/rai), [ROS-LLM (Auromix)](https://github.com/Auromix/ROS-LLM), [EmbodiedAgents (Automatika)](https://automatika-robotics.github.io/embodied-agents/)
 
 Key takeaways:
 - **ROSA** (NASA JPL): natural language interaction with ROS 1/2 systems — inspect nodes, query topics, diagnose issues; published at IROS 2024
@@ -230,7 +230,7 @@ Key takeaways:
 - **Bidirectional bridges**: GitHub, GitLab, Jira, Launchpad.
 - Multiple interfaces: CLI, TUI, web UI.
 - **Latest release still v0.10.1** (May 2025). Last repo activity noted Apr 9, 2026; master branch removed Jan 31, 2026 (structural change). No v0.11/v0.12 cut yet.
-- **v0.10.1 syntax migration** (lesson from ros2 #418): commands moved from top-level (`git bug select/show`) to nested under `git bug bug` in v0.10.1. Scripts written for earlier versions silently fall back to whatever wraps them (`2>/dev/null`) without complaint — the ros2 workspace's scripts fell back to `gh` for ~2 weeks before someone noticed. daddy_camp verified 2026-04-19 that our scripts use the correct `git bug bug ...` form.
+- **v0.10.1 syntax migration** (lesson from ros2 #418): commands moved from top-level (`git bug select/show`) to nested under `git bug bug` in v0.10.1. Scripts written for earlier versions silently fall back to whatever wraps them (`2>/dev/null`) without complaint — the ros2 workspace's scripts fell back to `gh` for ~2 weeks before someone noticed. verified 2026-04-19 that this workspace's scripts use the correct `git bug bug ...` form.
 - **git-issue** (Spinellis) is a simpler alternative storing issues as files in a dedicated branch.
 
 **Relevance**: Our workspace has adopted git-bug as the first read path (ADR-0010). 96 issues cached locally as of 2026-04-19. Two gaps remain vs. an ideal offline-first story: (1) visible fallback warnings when git-bug is unavailable (roadmap item in PR #157); (2) writes still go through `gh issue create` — offline issue creation exists via `GITBUG_CREATE=1` but hasn't been exercised end-to-end. Forgejo as an alternative remote has been explicitly declined this session (D6).
@@ -254,7 +254,7 @@ Key takeaways:
 
 ## ROS 2 Offline Development Patterns
 
-**Added**: 2026-03-04 | **Last verified**: 2026-04-19 (reference only — daddy_camp is non-ROS) | **Sources**: [rosdep offline mirror PR](https://github.com/ros-infrastructure/rosdep/pull/839), [ROS Answers: rosdep offline](https://answers.ros.org/question/276942/can-sudo-rosdep-init-and-rosdep-update-be-done-offline/), [rosdep mirror guide](https://answers.ros.org/question/338122/how-do-i-deploy-a-rosdep-mirror/)
+**Added**: 2026-03-04 | **Last verified**: 2026-04-19 (reference only — no ROS project currently managed) | **Sources**: [rosdep offline mirror PR](https://github.com/ros-infrastructure/rosdep/pull/839), [ROS Answers: rosdep offline](https://answers.ros.org/question/276942/can-sudo-rosdep-init-and-rosdep-update-be-done-offline/), [rosdep mirror guide](https://answers.ros.org/question/338122/how-do-i-deploy-a-rosdep-mirror/)
 
 Key takeaways:
 - `rosdep` can work offline by setting `ROSDISTRO_INDEX_URL=file:///path/to/local/index-v4.yaml` — clone the `rosdistro` repo locally and point to it

--- a/.claude/skills/analyze-permissions/SKILL.md
+++ b/.claude/skills/analyze-permissions/SKILL.md
@@ -80,7 +80,7 @@ Examples:
 - `gh api repos/owner/repo/issues -f title="..."` -> `Bash(gh api *)` (Tier 3, write detected)
 
 **Path-based commands** (scripts):
-- `/home/user/daddy_camp/.agent/scripts/dashboard.sh --quick` -> `Bash(.agent/scripts/dashboard.sh *)`
+- `/home/user/workspace/.agent/scripts/dashboard.sh --quick` -> `Bash(.agent/scripts/dashboard.sh *)`
 - `.agent/scripts/worktree_create.sh --issue 42` -> `Bash(.agent/scripts/worktree_create.sh *)`
 - Normalize absolute paths: strip any prefix up to and including the workspace
   root or worktree root, keeping the relative path from `.agent/` onward.

--- a/.claude/skills/inspiration-tracker/SKILL.md
+++ b/.claude/skills/inspiration-tracker/SKILL.md
@@ -337,6 +337,15 @@ When invoked with `add` or `add <url>`:
 
 - **Interactive, not autonomous** — always present findings and let the user
   decide. Never add to roadmap without confirmation.
+- **Workspace digests are project-agnostic** (issue #217) — digests in
+  `.agent/knowledge/`, registry comments, and ROADMAP.md entries assess
+  **workspace relevance** (agent infrastructure: skills, scripts,
+  governance, worktrees) and never name or depend on a specific managed
+  project. Use "the project repo" / "this workspace" phrasing. A finding
+  that only matters to a specific project belongs in that project's own
+  inspiration digest in the project repo (mirroring the research skill's
+  workspace/project digest split), recorded there via a project-type
+  worktree — not in the workspace digest.
 - **Discovery, not implementation** — this skill identifies and triages
   enhancements. Findings go to the roadmap's "To Consider" section. GitHub
   issues are created later (during `/brainstorm`) when work is ready to begin.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ code being changed:
 | Scope | Repo | What lives there |
 |-------|------|-----------------|
 | Workspace | `agent_workspace` | `AGENTS.md`, `.agent/`, skills, scripts, docs |
-| Project | project repo (e.g. `daddy_camp`) | The product being built (`project/`) |
+| Project | project repo (e.g. `my_project`) | The product being built (`project/`) |
 
 ## Boundaries
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -222,7 +222,7 @@ Items considered and rejected, with reasons.
 |------|-----------|--------|
 | Forgejo / local self-hosted git forge | 2026-04-19 session (prompted by ros2 #423/#355) | Ros2 needs it because field machines can't reach GitHub. We have no comparable constraint — always-online single-machine setup. Hosting cost + new dependency without addressing real pain here. Revisit only if GitHub-dependency friction grows materially |
 | Coordinator-intermediated mode | 2026-04-19 session | Would require the coordinator to sit between Roland and sub-agents. Incompatible with direct terminal visibility that Roland uses for debugging (watch agents in action, scroll back to see process). Any coordinator must be additive-only |
-| Ros2 tmux ATC protocol (verbatim port) | 2026-04-19 session | Solves multi-machine/remote-agent visibility problem. daddy_camp is single-machine local — agents don't drive each other's tmux panes. Protocol would add overhead without fitting the actual failure mode |
+| Ros2 tmux ATC protocol (verbatim port) | 2026-04-19 session | Solves multi-machine/remote-agent visibility problem. this workspace is single-machine local — agents don't drive each other's tmux panes. Protocol would add overhead without fitting the actual failure mode |
 | Mandatory commit squashing before push | 2026-04-19 session | We merge with `--merge` (not `--squash`), so branch history = PR history. Squashing would hide useful intermediate state. Commits are cheap; keep them honest. `fixup!` autosquash remains optional per-developer |
 
 ## To Consider
@@ -251,7 +251,7 @@ Cherry-picked from a recon scan of tracked inspirations since last refresh (2026
 
 ### From superpowers (2026-05-07)
 
-- **drill / evals harness** — Python-based skill compliance benchmark with multi-backend support (Claude / Codex / Gemini variants), 30+ scenario YAMLs, LLM verifier + deterministic assertions, 122-test pytest suite. Daddy_camp has ~25 skills with no behavioral tests; explore a scaled-down version for our context. Source: obra/superpowers — `evals/` on dev branch (PR #1488)
+- **drill / evals harness** — Python-based skill compliance benchmark with multi-backend support (Claude / Codex / Gemini variants), 30+ scenario YAMLs, LLM verifier + deterministic assertions, 122-test pytest suite. The workspace has ~25 skills with no behavioral tests; explore a scaled-down version for our context. Source: obra/superpowers — `evals/` on dev branch (PR #1488)
 - **plan-review-cycle skill** — Adversarial plan review skill that sits between writing-plans and executing-plans. Compare against our existing `/review-plan` skill body; absorb stronger patterns. Source: obra/superpowers — PR #1473 (merged)
 
 ### From gstack (2026-05-07)
@@ -262,7 +262,7 @@ Cherry-picked from a recon scan of tracked inspirations since last refresh (2026
 
 ### From ros2_agent_workspace (2026-07-14)
 
-- **Per-repo root AGENTS.md for the project repo** — Copilot code review reads a repo's root `AGENTS.md` (since 2026-06-18); daddy_camp gets Copilot PR reviews with zero instructions today. Port the thin "reference, never fork" template (~40–60 lines with a standalone context block for Copilot) + ADR + onboard-project/audit-project wiring. Source: rolker/ros2_agent_workspace — ADR-0017, `.agent/templates/project_agents_md.md`, PR #567
+- **Per-repo root AGENTS.md for the project repo** — Copilot code review reads a repo's root `AGENTS.md` (since 2026-06-18); project repos get Copilot PR reviews with zero instructions today. Port the thin "reference, never fork" template (~40–60 lines with a standalone context block for Copilot) + ADR + onboard-project/audit-project wiring. Source: rolker/ros2_agent_workspace — ADR-0017, `.agent/templates/project_agents_md.md`, PR #567
 - **Run .agent/scripts/tests/ in CI** — Add a `make test-scripts` target + CI job running our 4 hermetic script tests (currently manual-only; `validate.yml` has lint + docs jobs but no test job). Source: rolker/ros2_agent_workspace — #509/PR #510, `.agent/scripts/tests/run_script_tests.sh`
 - **Agent-identity CI check** — Env-independent CI check rejecting PRs where an agent-convention branch has commits whose primary author email matches a human pattern (Co-Authored-By trailers deliberately exempt). Complements the fragile env-var-based local enforcement; adapt patterns to rolker.net emails. Source: rolker/ros2_agent_workspace — #468, `.agent/hooks/check_pr_authors.py` + `identity_patterns.py`
 - **Review convergence/ship signal** — Pre-push review rounds get a ship-vs-continue verdict (round = prior review entries + 1; ship when no must-fixes, or round ≥ 2 with ≤2 mechanical, non-rising must-fixes) so review loops don't run indefinitely. Related data point: they made Copilot Adversarial opt-in after measuring context cost, defaulting to a dual-lens Claude pass. Source: rolker/ros2_agent_workspace — #537/PR #543, #467/PR #517


### PR DESCRIPTION
## Summary

Closes #217.

Makes all workspace-tracked inspiration/research artifacts project-agnostic (~57 references reworded across 12 files):

- **Digests** (ros2_agent_workspace, gstack, superpowers, engram, agent-orchestrator): "Daddy_camp relevance/status" → "Workspace relevance/status"; prose references → "this workspace" / "the project repo". The engram personality-canary record was genericized (project-scoped codename + path noted as living with the project, not the workspace).
- **Registry + research digest + ROADMAP**: same rule applied to comments and entries.
- **WORKTREE_GUIDE.md**: example repo name → `<repo_name>`.
- **AGENTS.md** (approved): example → `my_project`.
- **analyze-permissions SKILL.md**: example path genericized.
- **inspiration-tracker SKILL.md**: new guideline codifying the workspace/project digest split — workspace digests assess workspace relevance only; project-scoped findings route to a project digest in the project repo via a project-type worktree.

**Left intact** (per issue non-goals): historical work-plan records under `.agent/work-plans/issue-*/` that accurately describe past project-scoped work.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-fable-5`
