### PR TITLE
Add four emerging sources to inspiration registry (2026-07-14 sweep)

### DIFF
--- a/.agent/knowledge/inspiration_registry.yml
+++ b/.agent/knowledge/inspiration_registry.yml
@@ -73,6 +73,72 @@ projects:
       - memory dump/load for cross-machine portability
       - bootstrap UX (single command sets up CLAUDE.md, hooks, gitignore)
 
+  cc-harness-skills:
+    type: inspiration
+    repo: LearnPrompt/cc-harness-skills
+    description: Portable Claude-Code-inspired skills for memory, verification, coordination, and context compression
+    # Added 2026-07-14 (emerging-source sweep). Created 2026-04, very
+    # active. Strongest interest-area overlap of the sweep; context
+    # compression angle feeds the skill-carving/token-reduction roadmap
+    # thread (convergent across gstack/superpowers/ros2).
+    interest_areas:
+      - context compression and token-reduction techniques
+      - verification skill patterns (evidence-before-claims)
+      - memory management patterns
+      - multi-agent coordination skills
+      - cross-harness skill portability
+
+  project-codeguard:
+    type: inspiration
+    repo: cosai-oasis/project-codeguard
+    description: Model-agnostic secure-by-default rules framework for AI coding agent workflows (OASIS/CoSAI)
+    # Added 2026-07-14 (emerging-source sweep). Standards-body backed;
+    # complements the security-review skill and the fail-closed-hook
+    # audit roadmap item.
+    interest_areas:
+      - secure-by-default rule design for agent workflows
+      - rule packaging and distribution format
+      - integration with review pipelines
+      - model-agnostic enforcement mechanisms
+
+  diffx:
+    type: inspiration
+    repo: wong2/diffx
+    description: Local code review tool designed for the coding-agent workflow
+    # Added 2026-07-14 (emerging-source sweep). Review-before-push UX
+    # for humans supervising agents — adjacent to our review-code /
+    # triage-reviews loop and the CLI-first constraint.
+    interest_areas:
+      - review-before-push workflow integration
+      - diff presentation for human supervision of agent output
+      - inline commenting and finding-tracking UX
+      - staying local-first / terminal-adjacent
+
+  harness-starter-kit:
+    type: inspiration
+    repo: harnessworks/harness-starter-kit
+    description: Prompt-first harness engineering for safer AI coding agent workflows
+    # Added 2026-07-14 (emerging-source sweep). Newest of the batch
+    # (created 2026-05); watch whether "harness engineering" as a
+    # discipline develops enforcement-backed patterns beyond ours.
+    interest_areas:
+      - enforcement-backed instruction design
+      - safety guardrails for agent workflows
+      - harness bootstrap / starter-kit UX
+      - prompt-engineering-as-configuration patterns
+
+  # --- Watched, not tracked (2026-07-14 sweep) ---
+  #
+  # hqhq1025/skill-optimizer (132★) — skill lifecycle mining/audit/
+  # generalization; strong concept but quiet since 2026-05-14. Revisit
+  # next quarter if activity resumes.
+  # ForgeAILab/forge (42★) — structured task-lifecycle workflow engine;
+  # composable-timeline adjacent, still small.
+  # ma08/botfiles (28★) — portable agent-ecosystem hooks/config.
+  # Just-Agent/make-agents-cheaper (22★) — prompt-cache economics; tiny.
+  # smtg-ai/claude-squad, ruvnet/ruflo — established orchestration
+  # platforms; excluded per Tier-3 defer + STEELMAN reasoning.
+
   # --- Archived sources (2026-04-19) ---
   #
   # The following entries were removed from active tracking after a signal-


### PR DESCRIPTION
## Inspiration Tracker: emerging-source sweep (2026-07-14)

GitHub + web search for emerging (created 2026, active) sources aligned with registry interest areas. Four added, all inspiration-type:

- **LearnPrompt/cc-harness-skills** (224★, pushed 4d ago) — memory/verification/coordination/context-compression skills; strongest overlap, feeds the token-reduction convergence
- **cosai-oasis/project-codeguard** (246★, OASIS/CoSAI, pushed today) — secure-by-default rules for agent workflows
- **wong2/diffx** (171★) — local review-before-push tool for agent workflows
- **harnessworks/harness-starter-kit** (103★, newest) — prompt-first harness engineering

**Watched, not tracked** (registry comment): skill-optimizer (quiet 2mo), forge, botfiles, make-agents-cheaper. **Excluded**: claude-squad, ruflo (established orchestration; Tier-3 defer + STEELMAN reasoning).

Initial surveys will run as future `/inspiration-tracker <name>` checks (one source per run).

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-fable-5`
