### PR TITLE
fix(#223): migrate gemini agent invocation to agy binary and print-mode flags

### DIFF
--- a/.agent/scripts/cross_model_review.sh
+++ b/.agent/scripts/cross_model_review.sh
@@ -10,6 +10,7 @@
 # recursive-bloat failure mode that motivated this.
 #
 # Supported agents: gemini, codex, claude, copilot
+# (the gemini agent runs via the `agy` binary — see AGENT_BINS)
 #
 # Two execution modes:
 #   tmux (default) — runs the agent in a background tmux session
@@ -46,28 +47,39 @@ set -euo pipefail
 
 # --- Agent configuration ---
 # Binary name to search for in PATH and fallback locations.
+# The Gemini CLI migrated to the `agy` binary (issue #223); the agent key
+# stays "gemini" so existing callers (--agent gemini, review-code skill
+# mapping, artifact filenames) keep working.
 declare -A AGENT_BINS=(
-    ["gemini"]="gemini"
+    ["gemini"]="agy"
     ["codex"]="codex"
     ["claude"]="claude"
     ["copilot"]="copilot"
 )
 
+# Timeout for agy print mode. The agy default (5m) is too tight for
+# adversarial reviews of large diffs; Go duration format.
+AGY_PRINT_TIMEOUT="30m"
+
 # Build the shell command string to invoke an agent.
 # Args: agent_key, bin_path, prompt_file, findings_file
 # Stdout: a shell command string safe for tmux new-session.
-# All agents use stdin-based invocation to avoid argv limits on large diffs.
+# Agents use stdin-based invocation where the CLI supports it, to avoid
+# argv limits on large diffs. agy is the exception — see below.
 build_invoke_cmd() {
     local agent="$1" bin="$2" prompt="$3" findings="$4"
 
     case "$agent" in
         gemini)
-            # gemini's -p (--prompt) requires a value, even when stdin
-            # supplies the real prompt. Empty string activates headless
-            # mode; the help text confirms gemini "appends" stdin to it.
-            # Without the "", argparse reports "Not enough arguments" and
-            # dumps the help screen into the findings file. Issue #181.
-            echo "\"${bin}\" -p \"\" < \"${prompt}\" > \"${findings}\" 2>&1"
+            # agy print mode takes the prompt as the argument value of
+            # -p/--print — it does not read the prompt from stdin (the
+            # old `gemini -p "" < prompt` stdin-append convention from
+            # #181 no longer applies). Issue #223. The $(cat ...) is
+            # escaped so it expands inside the tmux session's shell.
+            # Caveat: argv passing is subject to the kernel's per-argument
+            # size limit (~128KiB on Linux); verified working for typical
+            # review prompts during the PR #211 review.
+            echo "\"${bin}\" --print-timeout ${AGY_PRINT_TIMEOUT} -p \"\$(cat \"${prompt}\")\" > \"${findings}\" 2>&1"
             ;;
         codex)
             # Codex exec reads prompt via stdin
@@ -93,9 +105,9 @@ run_agent_sync() {
     local agent="$1" bin="$2" prompt="$3" findings="$4"
 
     case "$agent" in
-        # gemini's -p needs an explicit value — empty string activates
-        # headless mode while leaving the real prompt on stdin (#181).
-        gemini)  "$bin" -p "" < "$prompt" > "$findings" 2>&1 ;;
+        # agy print mode takes the prompt as the -p argument value; it
+        # does not read the prompt from stdin (#223).
+        gemini)  "$bin" --print-timeout "$AGY_PRINT_TIMEOUT" -p "$(cat "$prompt")" > "$findings" 2>&1 ;;
         codex)   "$bin" exec < "$prompt" > "$findings" 2>&1 ;;
         claude)  "$bin" -p < "$prompt" > "$findings" 2>&1 ;;
         copilot) "$bin" -p < "$prompt" > "$findings" 2>&1 ;;

--- a/.agent/scripts/tests/test_cross_model_review.sh
+++ b/.agent/scripts/tests/test_cross_model_review.sh
@@ -28,13 +28,27 @@ setup() {
     MOCK_BIN="${TMPDIR_BASE}/bin"
     mkdir -p "${MOCK_BIN}"
 
-    # Mock gemini CLI that just writes "mock review" to the findings file
-    cat > "${MOCK_BIN}/gemini" << 'MOCK_EOF'
+    # Mock agy CLI (the gemini agent's binary post-#223). Records argv to
+    # MOCK_AGY_LOG when set, and prints the -p/--print/--prompt argument
+    # value to stdout (the script redirects stdout to the findings file).
+    # Deliberately never reads stdin — real agy print mode takes the
+    # prompt as an argument value, not on stdin.
+    cat > "${MOCK_BIN}/agy" << 'MOCK_EOF'
 #!/usr/bin/env bash
-# Mock gemini: copy stdin to stdout (findings file via redirect)
-cat
+if [[ -n "${MOCK_AGY_LOG:-}" ]]; then
+    printf '%s\n' "$@" >> "${MOCK_AGY_LOG}"
+fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--print|--prompt)
+            printf '%s\n' "${2:-}"
+            shift 2 2>/dev/null || shift
+            ;;
+        *) shift ;;
+    esac
+done
 MOCK_EOF
-    chmod +x "${MOCK_BIN}/gemini"
+    chmod +x "${MOCK_BIN}/agy"
 }
 
 teardown() {
@@ -761,6 +775,80 @@ GH_EOF
     teardown
 }
 
+# ---- Test: gemini agent invokes agy with prompt as -p argument (#223) ----
+#
+# The Gemini CLI migrated to the `agy` binary. Print mode takes the prompt
+# as the argument value of -p/--print — the old `gemini -p "" < prompt`
+# stdin-append convention (#181) no longer applies. This test asserts:
+#   1. the script resolves and invokes the `agy` binary,
+#   2. agy receives --print-timeout and -p,
+#   3. the prompt content arrives as an argument value (not stdin), and
+#   4. the findings-file flow completes end-to-end.
+# The script is run with stdin from /dev/null so a regression back to
+# stdin-based invocation fails fast instead of hanging the suite.
+test_agy_invocation() {
+    echo "TEST: gemini agent invokes agy with prompt as -p argument (#223)"
+    setup
+
+    # Mock gh with a valid PR body and non-empty diff.
+    cat > "${MOCK_BIN}/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    shift 2; PR="$1"; shift
+    [[ "${1:-}" == "-R" ]] && shift 2
+    if [[ "$1" == "--json" && "$2" == "body" ]]; then
+        echo "Closes #42"
+    elif [[ "$1" == "--json" && "$2" == "title" ]]; then
+        echo "Test PR"
+    elif [[ "$1" == "--json" && "$2" == "url" ]]; then
+        echo "https://github.com/test/repo/pull/99"
+    fi
+elif [[ "$1" == "pr" && "$2" == "diff" ]]; then
+    echo "diff --git a/file.txt b/file.txt"
+    echo "--- a/file.txt"
+    echo "+++ b/file.txt"
+    echo "@@ -1 +1 @@"
+    echo "-old"
+    echo "+new"
+fi
+exit 0
+GH_EOF
+    chmod +x "${MOCK_BIN}/gh"
+
+    export MOCK_AGY_LOG="${TMPDIR_BASE}/agy_calls.log"
+    true > "$MOCK_AGY_LOG"
+
+    cd "${MOCK_REPO}"
+    local exit_code=0
+    PATH="${MOCK_BIN}:${PATH}" WORKTREE_ISSUE=42 bash "${SCRIPT_UNDER_TEST}" \
+        --pr 99 --sync < /dev/null >/dev/null 2>&1 || exit_code=$?
+    unset MOCK_AGY_LOG
+
+    assert_exit_code "review completes (exit 0)" "0" "$exit_code"
+
+    local agy_log
+    agy_log=$(cat "${TMPDIR_BASE}/agy_calls.log")
+    assert_contains "agy received --print-timeout" "^--print-timeout$" "$agy_log"
+    assert_contains "agy received -p" "^-p$" "$agy_log"
+    assert_contains "prompt content passed as argument value" \
+        "Adversarial Code Review" "$agy_log"
+
+    local findings_file="${MOCK_REPO}/.agent/work-plans/issue-42/review-gemini-findings.md"
+    if [[ -f "$findings_file" ]]; then
+        local content
+        content=$(cat "$findings_file")
+        assert_contains "findings file received agy output" \
+            "Adversarial Code Review" "$content"
+        assert_contains "findings file has completion marker" \
+            "Review complete" "$content"
+    else
+        echo "  FAIL: findings file not created"
+        FAIL=$((FAIL + 1))
+    fi
+
+    teardown
+}
+
 # ---- Run all tests ----
 echo "=== cross_model_review.sh tests ==="
 echo ""
@@ -780,6 +868,7 @@ test_issue_flag_overrides_extraction
 test_missing_keyword_aborts
 test_issue_flag_validates_integer
 test_gh_pr_view_failure_distinct_error
+test_agy_invocation
 
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="


### PR DESCRIPTION
## Summary

The Gemini CLI on this machine migrated to the `agy` binary (v1.1.2), and print mode changed: `agy -p/--print "<prompt text>"` takes the prompt as an argument value, while the old `gemini -p "" < prompt` stdin-append convention (#181) no longer exists. `cross_model_review.sh` still mapped `["gemini"]="gemini"` and used the stdin invocation, so gemini adversarial reviews failed.

Closes #223

## Changes

- **`.agent/scripts/cross_model_review.sh`**
  - `AGENT_BINS`: `gemini` agent key now maps to the `agy` binary. The key is kept as `gemini` so existing callers (`--agent gemini`, the review-code skill mapping, `review-gemini-*.md` artifact filenames) keep working.
  - `build_invoke_cmd` (tmux mode) and `run_agent_sync` (sync mode) now pass the prompt as the `-p` argument value via `$(cat "$prompt")` — verified against `agy --help` (v1.1.2) and the working PR #211 workaround.
  - Added `--print-timeout 30m` (via `AGY_PRINT_TIMEOUT`) — agy's 5m default is too tight for long adversarial reviews.
  - Comments updated: the "all agents use stdin" claim now notes the agy exception and the ~128KiB per-argument kernel limit caveat.
- **`.agent/scripts/tests/test_cross_model_review.sh`**
  - Mock agent binary renamed `gemini` → `agy`; it now records argv and echoes the `-p` value to stdout instead of copying stdin (real agy never reads the prompt from stdin).
  - New `test_agy_invocation` test: end-to-end sync run asserting agy receives `--print-timeout` and `-p`, the prompt content arrives as an argument value (not stdin — the run uses `< /dev/null` so a stdin regression fails fast instead of hanging), and the findings file receives output plus the completion marker.
  - Tmux-mode command string was additionally verified manually: prompt content with quotes and `$` passes through as a single argument, unexpanded.

## Out of Scope

- #212 — Copilot invocation bug in the same script
- #206 — tmux/sync execution concerns

## Test Results

`bash .agent/scripts/tests/test_cross_model_review.sh`: **52 passed, 0 failed** (46 pre-existing + 6 new agy-invocation assertions). Pre-commit hooks (incl. shellcheck) pass.

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-fable-5`
