### PR TITLE
fix(#222): single_project setup/sync robustness — abort failed rebases; symlink-aware project/ cleanup

### DIFF
--- a/.agent/project_types/single_project/setup.sh
+++ b/.agent/project_types/single_project/setup.sh
@@ -33,6 +33,19 @@ get_remote_url() {
     git -C "$dir" remote get-url origin 2>/dev/null || echo ""
 }
 
+# --- Helper: clear a stale placeholder at project/ ---
+# Removes a symlink (broken, or pointing at a non-repo — a valid repo symlink
+# never reaches this path because Case 1 handles it) or an empty placeholder
+# directory. A non-empty real directory is deliberately left in place so the
+# subsequent ln -s / git clone fails loudly instead of clobbering data.
+remove_placeholder() {
+    if [ -L "$PROJECT_DIR" ]; then
+        rm "$PROJECT_DIR"
+    elif [ -d "$PROJECT_DIR" ] && [ -z "$(ls -A "$PROJECT_DIR" 2>/dev/null)" ]; then
+        rmdir "$PROJECT_DIR"
+    fi
+}
+
 # --- Case 1: project/ already exists and is a valid git repo ---
 if is_git_repo "$PROJECT_DIR"; then
     REMOTE_URL="$(get_remote_url "$PROJECT_DIR")"
@@ -50,7 +63,15 @@ if is_git_repo "$PROJECT_DIR"; then
         if [ -z "$DIRTY" ]; then
             echo ""
             echo "Pulling latest changes on branch '$BRANCH'..."
-            git -C "$PROJECT_DIR" pull --rebase 2>/dev/null && echo "   ✅ Up to date." || echo "   ⚠️  Pull failed (continuing anyway)"
+            if git -C "$PROJECT_DIR" pull --rebase 2>/dev/null; then
+                echo "   ✅ Up to date."
+            else
+                # A failed rebase pull (conflict, network error) can leave the
+                # repo mid-rebase, wedging later git operations. Abort any
+                # in-progress rebase; ignore failure when none is in progress.
+                git -C "$PROJECT_DIR" rebase --abort &>/dev/null || true
+                echo "   ⚠️  Pull failed (continuing anyway)"
+            fi
         fi
     fi
 
@@ -89,10 +110,8 @@ if [ -d "$PROJECT_INPUT" ]; then
         exit 1
     fi
 
-    # Remove project/ if it's an empty placeholder directory
-    if [ -d "$PROJECT_DIR" ] && [ -z "$(ls -A "$PROJECT_DIR" 2>/dev/null)" ]; then
-        rmdir "$PROJECT_DIR"
-    fi
+    # Remove project/ if it's a stale symlink or empty placeholder directory
+    remove_placeholder
 
     # Create symlink to avoid duplicating the repo on disk
     RESOLVED_PATH="$(cd "$PROJECT_INPUT" && pwd -P)"
@@ -101,10 +120,8 @@ if [ -d "$PROJECT_INPUT" ]; then
     echo "✅ Symlinked: project → $RESOLVED_PATH"
 else
     # Treat as a git URL — clone it
-    # Remove project/ if it's an empty placeholder directory
-    if [ -d "$PROJECT_DIR" ] && [ -z "$(ls -A "$PROJECT_DIR" 2>/dev/null)" ]; then
-        rmdir "$PROJECT_DIR"
-    fi
+    # Remove project/ if it's a stale symlink or empty placeholder directory
+    remove_placeholder
 
     echo ""
     echo "Cloning '$PROJECT_INPUT'..."

--- a/.agent/project_types/single_project/sync.py
+++ b/.agent/project_types/single_project/sync.py
@@ -83,6 +83,11 @@ def sync_repo(repo_path, repo_name, dry_run=False):
             else:
                 print(f"     ✅ Updated:\n{output}")
         else:
+            # A failed rebase pull (conflict, network error) can leave the
+            # repo mid-rebase, wedging later git operations. Abort any
+            # in-progress rebase; the abort itself failing (no rebase in
+            # progress) is fine and ignored.
+            run_git_cmd(repo_path, ["rebase", "--abort"])
             print(f"     ❌ Update failed: {output}")
     else:
         print(f"  On feature branch '{branch}'. Fetching only...")

--- a/.agent/scripts/tests/test_adapter.sh
+++ b/.agent/scripts/tests/test_adapter.sh
@@ -461,6 +461,114 @@ test_scope_for_pr_requires_path() {
     assert_contains "explains the requirement" "requires a path argument" "$out"
 }
 
+# ---- setup.sh / sync.py robustness tests (issue #222) ----
+
+# Build an origin repo and a clone at $2 primed for a rebase conflict:
+# origin's default branch gains a commit the clone doesn't have, and the
+# clone gains a local commit touching the same line. The clone ends up on
+# 'main', clean, so setup/sync will attempt `git pull --rebase` and fail
+# mid-rebase.
+make_conflicted_clone() {
+    local sb="$1" clone="$2"
+    local origin="$sb/origin_repo"
+    mkdir -p "$origin"
+    git -C "$origin" init --quiet -b main
+    echo "base" > "$origin/f.txt"
+    git -C "$origin" add f.txt
+    git -C "$origin" -c user.name=t -c user.email=t@t commit -m base --quiet
+    git clone --quiet "$origin" "$clone" 2>/dev/null
+    git -C "$clone" config user.name t
+    git -C "$clone" config user.email t@t
+    echo "upstream" > "$origin/f.txt"
+    git -C "$origin" -c user.name=t -c user.email=t@t commit -am upstream --quiet
+    echo "local" > "$clone/f.txt"
+    git -C "$clone" commit -am local --quiet
+}
+
+# Echo "clean" if no rebase is in progress in repo $1, else "mid-rebase".
+rebase_state() {
+    local repo="$1"
+    if [ -d "$repo/.git/rebase-merge" ] || [ -d "$repo/.git/rebase-apply" ]; then
+        echo "mid-rebase"
+    else
+        echo "clean"
+    fi
+}
+
+test_setup_aborts_failed_rebase() {
+    echo "TEST: setup aborts an in-progress rebase after a failed pull"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    make_conflicted_clone "$sb" "$sb/project"
+    out="$("$sb/.agent/scripts/adapter" setup 2>&1)" || rc=$?
+    assert_eq "setup still exits 0" "0" "$rc"
+    assert_contains "reports the pull failure" "Pull failed" "$out"
+    assert_eq "repo left clean, not mid-rebase" "clean" "$(rebase_state "$sb/project")"
+}
+
+test_setup_replaces_broken_symlink() {
+    echo "TEST: setup removes a broken symlink at project/ before symlinking"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    make_git_repo "$sb/real_checkout" "git@github.com:owner/repo.git"
+    ln -s "$sb/nonexistent_target" "$sb/project"
+    out="$(echo "$sb/real_checkout" | "$sb/.agent/scripts/adapter" setup 2>&1)" || rc=$?
+    assert_eq "exit 0" "0" "$rc"
+    assert_contains "symlink created" "Symlinked: project" "$out"
+    assert_eq "project/ now points at the checkout" \
+        "$(cd "$sb/real_checkout" && pwd -P)" "$(readlink "$sb/project")"
+}
+
+test_setup_replaces_valid_symlink_to_nonrepo() {
+    echo "TEST: setup removes a valid symlink to a non-repo dir before symlinking"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    mkdir "$sb/not_a_repo"
+    ln -s "$sb/not_a_repo" "$sb/project"
+    make_git_repo "$sb/real_checkout" "git@github.com:owner/repo.git"
+    out="$(echo "$sb/real_checkout" | "$sb/.agent/scripts/adapter" setup 2>&1)" || rc=$?
+    assert_eq "exit 0" "0" "$rc"
+    assert_eq "project/ now points at the checkout" \
+        "$(cd "$sb/real_checkout" && pwd -P)" "$(readlink "$sb/project")"
+}
+
+test_setup_removes_empty_placeholder_dir() {
+    echo "TEST: setup still removes an empty placeholder directory (regression)"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    mkdir "$sb/project"
+    make_git_repo "$sb/real_checkout" "git@github.com:owner/repo.git"
+    out="$(echo "$sb/real_checkout" | "$sb/.agent/scripts/adapter" setup 2>&1)" || rc=$?
+    assert_eq "exit 0" "0" "$rc"
+    assert_eq "project/ now points at the checkout" \
+        "$(cd "$sb/real_checkout" && pwd -P)" "$(readlink "$sb/project")"
+}
+
+test_setup_preserves_nonempty_dir() {
+    echo "TEST: setup does NOT delete a non-empty project/ directory"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    mkdir "$sb/project"
+    echo "precious" > "$sb/project/data.txt"
+    make_git_repo "$sb/real_checkout" "git@github.com:owner/repo.git"
+    out="$(echo "$sb/real_checkout" | "$sb/.agent/scripts/adapter" setup 2>&1)" || rc=$?
+    assert_eq "setup fails" "1" "$rc"
+    assert_eq "existing file untouched" "precious" "$(< "$sb/project/data.txt")"
+}
+
+test_sync_aborts_failed_rebase() {
+    echo "TEST: sync.py aborts an in-progress rebase after a failed pull"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    mkdir -p "$sb/.agent/scripts/lib"
+    cp "$REAL_ROOT/.agent/scripts/lib/"*.py "$sb/.agent/scripts/lib/"
+    make_conflicted_clone "$sb" "$sb/project"
+    out="$(python3 "$sb/.agent/project_types/single_project/sync.py" 2>&1)" || rc=$?
+    assert_eq "sync exits 0" "0" "$rc"
+    assert_contains "reports the pull failure" "Update failed" "$out"
+    assert_eq "repo left clean, not mid-rebase" "clean" "$(rebase_state "$sb/project")"
+}
+
 # ---- Delegation / shim-chain tests ----
 
 test_setup_delegates() {
@@ -551,6 +659,12 @@ test_scope_for_pr_https
 test_scope_for_pr_ssh_url_with_port
 test_scope_for_pr_walks_up
 test_scope_for_pr_requires_path
+test_setup_aborts_failed_rebase
+test_setup_replaces_broken_symlink
+test_setup_replaces_valid_symlink_to_nonrepo
+test_setup_removes_empty_placeholder_dir
+test_setup_preserves_nonempty_dir
+test_sync_aborts_failed_rebase
 test_setup_delegates
 test_sync_shim_chain
 test_sync_real_implementation_runs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-# Project directory (managed externally — cloned or symlinked)
+# Project directory (managed externally — cloned or symlinked).
+# Both forms are needed: `project/` matches a real directory but NOT a
+# symlink; bare `project` covers the symlinked-checkout case.
 project/
+project
 
 # Worktrees (workspace and project, see issue #25)
 worktrees/


### PR DESCRIPTION
## Summary

Closes #222

Two robustness gaps in the `single_project` adapter (surfaced by the Deep review of PR #211), plus a related `.gitignore` gap discovered while working in this territory.

### 1. Abort failed rebases (`setup.sh` and `sync.py`)

A failed `git pull --rebase` (conflict, network error) previously left the repository mid-rebase, wedging subsequent git operations. Both paths now run `git rebase --abort` on pull failure, ignoring the abort's own failure when no rebase is in progress:

- `.agent/project_types/single_project/setup.sh` — default-branch pull in Case 1
- `.agent/project_types/single_project/sync.py` — `sync_repo()`

### 2. Symlink-aware placeholder cleanup (`setup.sh`)

Setup's cleanup only removed an *empty directory* placeholder (`[ -d ] && rmdir`). A broken symlink fails the `-d` test and a valid symlink can't be `rmdir`'d, so the subsequent `ln -s` / `git clone` died with `File exists`. Both cleanup sites (symlink branch and clone branch) now use a shared `remove_placeholder` helper that removes a symlink at `project/` first, then falls back to the empty-dir case. Non-empty real directories are still deliberately preserved so setup fails loudly instead of clobbering data.

### 3. `.gitignore`: ignore a `project` symlink

The repo root `project` entry is now a symlink to the hosted project checkout, but `.gitignore`'s `project/` pattern (trailing slash) only matches a real directory — so the symlink showed as untracked in `git status`. Added a bare `project` pattern (with a comment) covering the symlinked form. Verified with `git check-ignore`: the symlink is ignored on this branch and untracked on `main`.

## Tests

Six new sandbox tests in `.agent/scripts/tests/test_adapter.sh`, following the suite's existing sandbox/stub patterns:

- `test_setup_aborts_failed_rebase` — real conflicted clone; asserts no `rebase-merge`/`rebase-apply` left behind
- `test_setup_replaces_broken_symlink`
- `test_setup_replaces_valid_symlink_to_nonrepo`
- `test_setup_removes_empty_placeholder_dir` (regression guard for the refactor)
- `test_setup_preserves_nonempty_dir` (data-preservation guard)
- `test_sync_aborts_failed_rebase`

Results:

- Baseline (pre-change): 62 passed, 0 failed
- With new tests against pre-fix code: 70 passed, **7 failed** (all new assertions — the tests catch the bugs)
- After fix: **77 passed, 0 failed**
- All other suites in `.agent/scripts/tests/` pass (`test_block_bash_tool_mapping`, `test_cross_model_review`, `test_merge_pr_root_resolution`, `test_resolve_work_plans_dir`)
- Pre-commit hooks (shellcheck, black, flake8, pylint, adapter-contract validator) pass on both commits

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-fable-5`
