### PR TITLE
fix(#224): derive issue from worktree path/branch when WORKTREE_ISSUE unset

### DIFF
--- a/.agent/scripts/_resolve_work_plans_dir.sh
+++ b/.agent/scripts/_resolve_work_plans_dir.sh
@@ -17,6 +17,13 @@
 #      --work-plans-dir), return it verbatim (no normalization).
 #   2. Else if $WORKTREE_ISSUE equals the requested issue number, return
 #      "$(git rev-parse --show-toplevel)/.agent/work-plans/issue-<N>".
+#   2b. Else if $WORKTREE_ISSUE is UNSET (not merely different) and the
+#       current git toplevel's basename matches "issue-*-<N>" or the current
+#       branch matches "feature/issue-<N>" (optionally "-<description>",
+#       case-insensitive), return the same toplevel-anchored path. This
+#       covers EnterWorktree-based sessions (issue #224) where the cwd is
+#       inside the correct worktree but worktree_enter.sh was never sourced.
+#       A set-but-mismatched $WORKTREE_ISSUE never takes this fallback.
 #   3. Else abort with remediation guidance pointing at worktree_enter.sh.
 #
 # Caller-gotcha: prefer a bare assignment (`WORK_PLANS_DIR=$(resolve ... )
@@ -57,6 +64,39 @@ resolve_work_plans_dir() {
         return 0
     fi
 
+    # Rule 2b: WORKTREE_ISSUE unset — derive the issue from the worktree
+    # path or branch name (issue #224). Sessions entered via the native
+    # EnterWorktree tool switch cwd without sourcing worktree_enter.sh, so
+    # the env var is never exported even though the session is inside the
+    # correct worktree. The worktree basename (issue-<slug>-<N>) and branch
+    # (feature/issue-<N>[-<description>]) already encode the fact the env
+    # var asserts, so trusting them keeps the #147 guard's purpose intact:
+    # the main tree (basename != issue-*-<N>, branch = main) still refuses,
+    # and a set-but-mismatched WORKTREE_ISSUE never reaches this fallback.
+    if [ -z "${WORKTREE_ISSUE:-}" ] && [[ "$issue" =~ ^[0-9]+$ ]]; then
+        local toplevel base branch
+        toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || toplevel=""
+        if [ -n "$toplevel" ]; then
+            base=$(basename "$toplevel")
+            branch=$(git -C "$toplevel" branch --show-current 2>/dev/null) || branch=""
+            # Worktree directory naming: issue-<slug>-<N> (worktree_create.sh).
+            # The trailing -<N> match is exact, so issue-x-2244 can't satisfy
+            # a request for 224.
+            case "$base" in
+                issue-*-"$issue")
+                    echo "${toplevel}/.agent/work-plans/issue-${issue}"
+                    return 0
+                    ;;
+            esac
+            # Branch naming: feature/issue-<N> or feature/ISSUE-<N>-<desc>.
+            # (-|$) anchors the number so feature/issue-2244 can't satisfy 224.
+            if [[ "${branch,,}" =~ ^feature/issue-${issue}(-|$) ]]; then
+                echo "${toplevel}/.agent/work-plans/issue-${issue}"
+                return 0
+            fi
+        fi
+    fi
+
     # Rule 3: abort.
     {
         echo "ERROR: refusing to resolve work-plans dir for issue #${issue} outside its worktree."
@@ -64,8 +104,9 @@ resolve_work_plans_dir() {
         if [ -n "${WORKTREE_ISSUE:-}" ]; then
             echo "  Current \$WORKTREE_ISSUE is '${WORKTREE_ISSUE}', not '${issue}'."
         else
-            echo "  \$WORKTREE_ISSUE is not set — you're likely in the main tree or a shell"
-            echo "  that didn't source worktree_enter.sh."
+            echo "  \$WORKTREE_ISSUE is not set, and neither the current worktree path nor"
+            echo "  the branch name encodes issue ${issue} — you're likely in the main tree"
+            echo "  or a shell that didn't source worktree_enter.sh."
         fi
         echo ""
         echo "  Enter the matching worktree first (pick workspace or project by issue):"

--- a/.agent/scripts/tests/test_resolve_work_plans_dir.sh
+++ b/.agent/scripts/tests/test_resolve_work_plans_dir.sh
@@ -166,6 +166,129 @@ test_rule3_mismatch_message() {
     assert_contains "mentions current WORKTREE_ISSUE" "'100', not '42'" "$out"
 }
 
+# ---- Rule 2b helpers: temp git repos with controlled dir/branch names ----
+#
+# make_temp_repo <basename> <branch> — creates an empty git repo whose
+# toplevel basename and initial branch are controlled, echoes its path.
+# No commits needed: `git branch --show-current` reports unborn branches.
+# TMP_ROOT is created eagerly in the parent shell: make_temp_repo runs
+# inside $(...) subshells, so any assignment there would not persist and
+# the EXIT trap would miss it.
+TMP_ROOT=$(mktemp -d)
+make_temp_repo() {
+    local base="$1" branch="$2"
+    local repo="${TMP_ROOT}/$base"
+    git init -q -b "$branch" "$repo"
+    echo "$repo"
+}
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# ---- Test: rule-2b resolves from worktree dir name when env unset (issue #224) ----
+test_rule2b_dir_name_match() {
+    echo "TEST: unset WORKTREE_ISSUE resolves via issue-<slug>-<N> dir name"
+
+    local repo out
+    repo=$(make_temp_repo "issue-workspace-55" "some-branch")
+    out=$(
+        cd "$repo"
+        unset WORK_PLANS_DIR_OVERRIDE WORKTREE_ISSUE
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 55
+    )
+    assert_eq "path under matching worktree toplevel" \
+        "${repo}/.agent/work-plans/issue-55" "$out"
+}
+
+# ---- Test: rule-2b resolves from branch name when env unset (issue #224) ----
+test_rule2b_branch_name_match() {
+    echo "TEST: unset WORKTREE_ISSUE resolves via feature/issue-<N> branch"
+
+    local repo out
+    repo=$(make_temp_repo "plain-checkout" "feature/issue-56")
+    out=$(
+        cd "$repo"
+        unset WORK_PLANS_DIR_OVERRIDE WORKTREE_ISSUE
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 56
+    )
+    assert_eq "path under branch-matched toplevel" \
+        "${repo}/.agent/work-plans/issue-56" "$out"
+
+    # Described branch variant: feature/ISSUE-<N>-<description> (case-insensitive).
+    repo=$(make_temp_repo "plain-checkout-2" "feature/ISSUE-57-fix-thing")
+    out=$(
+        cd "$repo"
+        unset WORK_PLANS_DIR_OVERRIDE WORKTREE_ISSUE
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 57
+    )
+    assert_eq "described branch variant resolves" \
+        "${repo}/.agent/work-plans/issue-57" "$out"
+}
+
+# ---- Test: rule-2b still refuses outside any matching worktree ----
+test_rule2b_refuses_outside_worktree() {
+    echo "TEST: unset WORKTREE_ISSUE outside any matching worktree still refuses"
+
+    local repo out rc
+    repo=$(make_temp_repo "main-checkout" "main")
+    rc=0
+    out=$(
+        cd "$repo"
+        unset WORK_PLANS_DIR_OVERRIDE WORKTREE_ISSUE
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 58 2>&1
+    ) || rc=$?
+    assert_eq "returns 1" "1" "$rc"
+    assert_contains "refusal message present" \
+        "refusing to resolve work-plans dir for issue #58" "$out"
+}
+
+# ---- Test: rule-2b number boundaries are exact ----
+test_rule2b_number_boundary() {
+    echo "TEST: issue number match is exact (no prefix/suffix bleed)"
+
+    local repo out rc
+    # Dir encodes 2244; requesting 224 must refuse.
+    repo=$(make_temp_repo "issue-workspace-2244" "feature/issue-2244")
+    rc=0
+    out=$(
+        cd "$repo"
+        unset WORK_PLANS_DIR_OVERRIDE WORKTREE_ISSUE
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 224 2>&1
+    ) || rc=$?
+    assert_eq "issue-x-2244 does not satisfy 224" "1" "$rc"
+    assert_contains "refusal message present" \
+        "refusing to resolve work-plans dir for issue #224" "$out"
+}
+
+# ---- Test: set-but-mismatched WORKTREE_ISSUE never takes the fallback ----
+test_mismatched_env_still_refuses_in_matching_dir() {
+    echo "TEST: mismatched WORKTREE_ISSUE refuses even inside a matching worktree"
+
+    local repo out rc
+    # Dir and branch both encode 59, but the env var asserts 100 —
+    # the #147 guard must win over the #224 fallback.
+    repo=$(make_temp_repo "issue-workspace-59" "feature/issue-59")
+    rc=0
+    out=$(
+        cd "$repo"
+        unset WORK_PLANS_DIR_OVERRIDE
+        export WORKTREE_ISSUE=100
+        # shellcheck source=../_resolve_work_plans_dir.sh
+        source "${HELPER}"
+        resolve_work_plans_dir 59 2>&1
+    ) || rc=$?
+    assert_eq "returns 1" "1" "$rc"
+    assert_contains "mismatch message names both issues" "'100', not '59'" "$out"
+}
+
 # ---- Test: direct execution errors out ----
 test_direct_execution_refused() {
     echo "TEST: running the helper directly errors out"
@@ -186,6 +309,11 @@ test_no_args_under_set_u
 test_rule1_override
 test_rule2_worktree_match
 test_rule3_mismatch_message
+test_rule2b_dir_name_match
+test_rule2b_branch_name_match
+test_rule2b_refuses_outside_worktree
+test_rule2b_number_boundary
+test_mismatched_env_still_refuses_in_matching_dir
 test_direct_execution_refused
 
 echo ""


### PR DESCRIPTION
## Summary

Implements Option 1 from #224: `resolve_work_plans_dir` gains a **rule 2b**
that derives the issue number from the filesystem when `WORKTREE_ISSUE` is
unset. Sessions entered via the native `EnterWorktree` tool (`/start-task`)
switch cwd without sourcing `worktree_enter.sh`, so the env var is never
exported — previously every `_resolve_work_plans_dir.sh` consumer (e.g.
`cross_model_review.sh`) refused to run even though the session was inside
the correct worktree.

## Behavior

Resolution rules, in order:

1. `WORK_PLANS_DIR_OVERRIDE` — unchanged.
2. `WORKTREE_ISSUE` equals the requested issue — unchanged.
3. **(new, 2b)** `WORKTREE_ISSUE` unset **and** the requested issue is
   numeric: resolve if the git toplevel basename matches
   `issue-<slug>-<N>` (worktree_create.sh naming) **or** the branch
   matches `feature/issue-<N>[-<description>]` (case-insensitive).
   Number matching is exactly anchored — `issue-x-2244` /
   `feature/issue-2244` cannot satisfy a request for `224`.
4. Refuse with remediation guidance — unchanged, message updated to note
   that neither the path nor the branch encodes the requested issue.

The #147 guard's purpose is preserved:

- Main tree (basename `agent_workspace`, branch `main`) still refuses.
- A **set-but-mismatched** `WORKTREE_ISSUE` never takes the fallback —
  it still refuses even when the cwd's worktree path would match.

## Tests

Five new test cases in
`.agent/scripts/tests/test_resolve_work_plans_dir.sh` using throwaway git
repos with controlled dir/branch names (no commits needed — unborn
branches report via `git branch --show-current`):

- unset env + matching `issue-<slug>-<N>` dir name → resolves
- unset env + `feature/issue-<N>` branch (incl. uppercase/described
  variant) → resolves
- unset env outside any matching worktree → still refuses
- exact number boundary (`2244` vs `224`) → still refuses
- mismatched `WORKTREE_ISSUE` inside a matching worktree → still refuses

Results: 21 passed, 0 failed (baseline before change: 12 passed, 0
failed). End-to-end check from this worktree with `WORKTREE_ISSUE`
unset: `resolve_work_plans_dir 224` resolves; `resolve_work_plans_dir
210` refuses.

Closes #224

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-fable-5`
