### PR TITLE
Multi-tenant hosting: projects/<name>/ discovery alongside legacy project/ symlink

### DIFF
--- a/.agent/WORKTREE_GUIDE.md
+++ b/.agent/WORKTREE_GUIDE.md
@@ -98,6 +98,7 @@ For changes to the managed project repo (`project/`).
 | Skill | `skill-<repo_slug>-<YYYYMMDD-HHMMSS>` |
 
 `<repo_slug>` is auto-detected from the remote URL (e.g., `workspace`, `myproject`).
+For registry-selected projects (see below) the registry name is used instead.
 Use `--repo-slug` to override.
 
 ## Disambiguation
@@ -107,9 +108,17 @@ Since `--type` is mandatory, workspace vs. project is never ambiguous.
 For multiple project repos, use `--repo`:
 
 ```bash
-source .agent/scripts/worktree_enter.sh --issue 42 --type project --repo <repo_name>
-.agent/scripts/worktree_remove.sh --issue 42 --type project --repo <repo_name>
+.agent/scripts/worktree_create.sh --issue 42 --type project --repo <name>
+source .agent/scripts/worktree_enter.sh --issue 42 --type project --repo <name>
+.agent/scripts/worktree_remove.sh --issue 42 --type project --repo <name>
 ```
+
+On `worktree_create.sh`, `--repo <name>` selects a registered project from
+`.agent/projects.local` (issue #227); the worktree is created under
+`worktrees/project/<name>/` so `enter`/`remove --repo <name>` find it by the
+same key. Without `--repo`, the legacy `project/` checkout is used; when
+`project/` is absent and exactly one project is registered, that project is
+auto-selected (multiple registrations require `--repo`).
 
 For multiple worktrees of the same type with different repo slugs, use `--repo-slug`:
 

--- a/.agent/project_types/single_project/adapter.sh
+++ b/.agent/project_types/single_project/adapter.sh
@@ -10,8 +10,20 @@
 # set as shell variables (not exported). Not executable on its own; must be
 # silent at source time.
 
-# Load .agent/project_config.sh and require the named command variable to
-# be set (e.g. BUILD_CMD). Prints the same guidance the old scripts printed.
+# Resolve the command-config file for the active project: the per-project
+# override (.agent/projects.d/<name>.sh, set by the dispatcher as
+# ACTIVE_PROJECT_CONFIG) when it exists, else the shared
+# .agent/project_config.sh.
+_single_project_config_file() {
+    if [ -n "${ACTIVE_PROJECT_CONFIG:-}" ] && [ -f "$ACTIVE_PROJECT_CONFIG" ]; then
+        echo "$ACTIVE_PROJECT_CONFIG"
+    else
+        echo "$WORKSPACE_ROOT/.agent/project_config.sh"
+    fi
+}
+
+# Load the command config and require the named command variable to be set
+# (e.g. BUILD_CMD). Prints the same guidance the old scripts printed.
 #
 # Callers must NOT guard this with `||` — verbs run under the dispatcher's
 # set -e, and an unguarded call is what makes a failure inside the sourced
@@ -20,14 +32,15 @@
 # swallowing config failures.
 _single_project_load_cmd() {
     local var_name="$1"
-    local config="$WORKSPACE_ROOT/.agent/project_config.sh"
+    local config
+    config="$(_single_project_config_file)"
 
     if [ ! -f "$config" ]; then
         echo "❌ No project_config.sh found."
         echo ""
         echo "Create $config with your project commands:"
         echo ""
-        echo "  cat > .agent/project_config.sh << 'EOF'"
+        echo "  cat > $config << 'EOF'"
         echo "  # Per-developer project configuration (gitignored)"
         echo "  PROJECT_TYPE=\"single_project\""
         echo "  BUILD_CMD=\"make\"          # or: cmake --build build, cargo build, etc."
@@ -35,6 +48,10 @@ _single_project_load_cmd() {
         echo "  INSTALL_CMD=\"\"            # optional deploy/install command"
         echo "  EOF"
         echo ""
+        if [ -n "${ACTIVE_PROJECT_NAME:-}" ]; then
+            echo "  (active project: $ACTIVE_PROJECT_NAME — per-project override: ${ACTIVE_PROJECT_CONFIG:-unset})"
+            echo ""
+        fi
         return 1
     fi
 
@@ -52,10 +69,16 @@ _single_project_load_cmd() {
 }
 
 adapter_setup() {
+    if [ -n "${ACTIVE_PROJECT_NAME:-}" ]; then
+        exec "$ADAPTER_TYPE_DIR/setup.sh" --project-root "$(adapter_project_root)" "$@"
+    fi
     exec "$ADAPTER_TYPE_DIR/setup.sh" "$@"
 }
 
 adapter_sync() {
+    if [ -n "${ACTIVE_PROJECT_NAME:-}" ]; then
+        exec python3 "$ADAPTER_TYPE_DIR/sync.py" --project-root "$(adapter_project_root)" "$@"
+    fi
     exec python3 "$ADAPTER_TYPE_DIR/sync.py" "$@"
 }
 
@@ -82,7 +105,8 @@ adapter_test() {
 }
 
 adapter_install() {
-    local config="$WORKSPACE_ROOT/.agent/project_config.sh"
+    local config
+    config="$(_single_project_config_file)"
     if [ -f "$config" ]; then
         # shellcheck source=/dev/null
         source "$config"
@@ -104,14 +128,20 @@ adapter_env() {
 }
 
 adapter_project_root() {
-    echo "$WORKSPACE_ROOT/project"
+    # ACTIVE_PROJECT_ROOT is set by the dispatcher (registry hosting dir for
+    # named projects, project/ for the legacy shape).
+    echo "${ACTIVE_PROJECT_ROOT:-$WORKSPACE_ROOT/project}"
 }
 
 adapter_repos() {
     local root
     root="$(adapter_project_root)"
     if [ ! -d "$root" ] || ! git -C "$root" rev-parse --git-dir >/dev/null 2>&1; then
-        echo "ERROR: project/ is not configured (run: make setup)" >&2
+        if [ -n "${ACTIVE_PROJECT_NAME:-}" ]; then
+            echo "ERROR: project '$ACTIVE_PROJECT_NAME' is not checked out at $root" >&2
+        else
+            echo "ERROR: project/ is not configured (run: make setup)" >&2
+        fi
         return 1
     fi
     local name

--- a/.agent/project_types/single_project/setup.sh
+++ b/.agent/project_types/single_project/setup.sh
@@ -19,7 +19,30 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$(dirname "$(dirname "$SCRIPT_DIR")")")"
 
+# Default: legacy project/ shape. The adapter passes --project-root for
+# registry-hosted projects (issue #227).
 PROJECT_DIR="$ROOT_DIR/project"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --project-root)
+            [ $# -ge 2 ] || { echo "Error: --project-root requires a directory argument" >&2; exit 1; }
+            PROJECT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: unknown option '$1'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Human-readable label for messages: "project/" for the legacy shape, the
+# actual path for registry-hosted projects.
+if [ "$PROJECT_DIR" = "$ROOT_DIR/project" ]; then
+    PROJECT_LABEL="project/"
+else
+    PROJECT_LABEL="$PROJECT_DIR"
+fi
 
 # --- Helper: check if project/ is a valid git repo ---
 is_git_repo() {
@@ -49,7 +72,7 @@ remove_placeholder() {
 # --- Case 1: project/ already exists and is a valid git repo ---
 if is_git_repo "$PROJECT_DIR"; then
     REMOTE_URL="$(get_remote_url "$PROJECT_DIR")"
-    echo "✅ project/ is already configured."
+    echo "✅ $PROJECT_LABEL is already configured."
     if [ -n "$REMOTE_URL" ]; then
         echo "   Remote: $REMOTE_URL"
     else
@@ -117,7 +140,7 @@ if [ -d "$PROJECT_INPUT" ]; then
     RESOLVED_PATH="$(cd "$PROJECT_INPUT" && pwd -P)"
     ln -s "$RESOLVED_PATH" "$PROJECT_DIR"
     echo ""
-    echo "✅ Symlinked: project → $RESOLVED_PATH"
+    echo "✅ Symlinked: ${PROJECT_LABEL%/} → $RESOLVED_PATH"
 else
     # Treat as a git URL — clone it
     # Remove project/ if it's a stale symlink or empty placeholder directory
@@ -127,7 +150,7 @@ else
     echo "Cloning '$PROJECT_INPUT'..."
     if git clone "$PROJECT_INPUT" "$PROJECT_DIR"; then
         echo ""
-        echo "✅ Cloned to project/"
+        echo "✅ Cloned to $PROJECT_LABEL"
     else
         echo "Error: git clone failed."
         exit 1
@@ -145,6 +168,6 @@ if is_git_repo "$PROJECT_DIR"; then
     echo ""
     echo "Run 'make dashboard' to check workspace status."
 else
-    echo "Error: project/ is still not a valid git repository after setup."
+    echo "Error: $PROJECT_LABEL is still not a valid git repository after setup."
     exit 1
 fi

--- a/.agent/project_types/single_project/sync.py
+++ b/.agent/project_types/single_project/sync.py
@@ -154,19 +154,27 @@ def main():
     parser.add_argument(
         "--dry-run", action="store_true", help="Simulate actions without executing."
     )
+    parser.add_argument(
+        "--project-root",
+        help="Project checkout to sync (registry-hosted project, issue #227); "
+        "default: the legacy project/ directory.",
+    )
     args = parser.parse_args()
 
     root_dir = Path(get_workspace_root())
-    project_dir = get_project_path()
+    project_dir = Path(args.project_root) if args.project_root else get_project_path()
 
     # Sync workspace repo
     if sync_repo(root_dir, "agent_workspace (workspace)", args.dry_run):
         sync_gitbug(root_dir, args.dry_run)
 
     # Sync project repo
-    if is_project_configured():
+    if is_project_configured(project_dir):
         if sync_repo(project_dir, f"project ({project_dir.resolve().name})", args.dry_run):
             sync_gitbug(project_dir, args.dry_run)
+    elif args.project_root:
+        print("Checking project...")
+        print(f"  ⚠️  {project_dir} is not a git checkout.")
     else:
         print("Checking project...")
         print("  ⚠️  project/ not configured. Run: make setup")

--- a/.agent/projects.local.example
+++ b/.agent/projects.local.example
@@ -11,7 +11,7 @@
 #   name          Project identity on this machine. Also the default hosting
 #                 dir (projects/<name>/) and the worktree repo key
 #                 (worktrees/project/<name>/). Allowed: [A-Za-z0-9._-],
-#                 must start with a letter or digit.
+#                 must start with a letter or digit; '..' is not allowed.
 #   project_type  Adapter type; must exist at .agent/project_types/<type>/
 #                 (ADR-0011). Currently: single_project.
 #   path          Optional hosting directory. Relative paths resolve against

--- a/.agent/projects.local.example
+++ b/.agent/projects.local.example
@@ -1,0 +1,33 @@
+# .agent/projects.local — per-machine project registry (issue #227, #172 step 2)
+#
+# Copy this file to .agent/projects.local (gitignored) to host named
+# projects under projects/<name>/ alongside — or instead of — the legacy
+# project/ symlink.
+#
+# One project per line, whitespace-separated:
+#
+#   <name>  <project_type>  [<path>]
+#
+#   name          Project identity on this machine. Also the default hosting
+#                 dir (projects/<name>/) and the worktree repo key
+#                 (worktrees/project/<name>/). Allowed: [A-Za-z0-9._-],
+#                 must start with a letter or digit.
+#   project_type  Adapter type; must exist at .agent/project_types/<type>/
+#                 (ADR-0011). Currently: single_project.
+#   path          Optional hosting directory. Relative paths resolve against
+#                 the workspace root; default is projects/<name>. Paths must
+#                 not contain spaces.
+#
+# Checkouts are managed manually for now: clone (or symlink) the project
+# into its hosting dir, then register it here. Per-project build/test
+# commands go in .agent/projects.d/<name>.sh (gitignored), with
+# .agent/project_config.sh as the shared fallback.
+#
+# How the active project is resolved (adapter dispatcher):
+#   1. --project <name> (or: make build PROJECT=<name>)
+#   2. current directory inside a registered hosting dir
+#   3. legacy project/ symlink (unchanged behavior)
+#
+# Examples:
+#gz4d      single_project
+#coastal   single_project   /data/checkouts/coastal_mapper

--- a/.agent/scripts/_project_registry.sh
+++ b/.agent/scripts/_project_registry.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# .agent/scripts/_project_registry.sh
+# Per-machine project registry helpers (issue #227 — #172 step 2).
+#
+# The registry lives at .agent/projects.local (gitignored). It maps a
+# project name to a hosting directory and a project type:
+#
+#   # <name>  <project_type>  [<path>]
+#   gz4d  single_project
+#   coastal  single_project  /data/checkouts/coastal_mapper
+#
+# - name: [A-Za-z0-9][A-Za-z0-9._-]* — also the default hosting dir name
+#   (projects/<name>/) and the worktree repo key (worktrees/project/<name>/)
+# - project_type: must have an adapter at .agent/project_types/<type>/
+# - path: optional hosting dir; relative paths resolve against the
+#   workspace root; default projects/<name>. Paths must not contain spaces.
+#
+# See .agent/projects.local.example for a commented template.
+#
+# Source this file from other scripts:
+#   source "$SCRIPT_DIR/_project_registry.sh"
+#
+# All functions take the workspace root as their first argument and are
+# silent on stdout except for their documented output. Malformed registry
+# lines are reported on stderr and make the parse fail (return 2) — a bad
+# registry must never silently resolve to the wrong project.
+
+# Print the registry file path for a workspace root.
+# Usage: file=$(registry_file "$root")
+registry_file() {
+    echo "$1/.agent/projects.local"
+}
+
+# Parse the registry and print one entry per line as:
+#   <name>\t<type>\t<abs_path>
+# Missing file → no output, return 0 (registry is optional).
+# Malformed lines → diagnostics on stderr, return 2 (valid lines still print).
+# Usage: entries=$(registry_entries "$root") || { ...parse error... }
+registry_entries() {
+    local root="$1" file lineno=0 rc=0
+    local raw name type path extra
+    file="$(registry_file "$root")"
+    [ -f "$file" ] || return 0
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        lineno=$((lineno + 1))
+        raw="${raw%%#*}"
+        name=""; type=""; path=""; extra=""
+        read -r name type path extra <<< "$raw" || true
+        [ -z "$name" ] && continue
+        if [ -n "$extra" ]; then
+            echo "ERROR: ${file}:${lineno}: too many fields (paths must not contain spaces)" >&2
+            rc=2
+            continue
+        fi
+        if ! [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "ERROR: ${file}:${lineno}: invalid project name '$name'" >&2
+            rc=2
+            continue
+        fi
+        if [ -z "$type" ] || ! [[ "$type" =~ ^[a-z0-9][a-z0-9_]*$ ]]; then
+            echo "ERROR: ${file}:${lineno}: invalid or missing project type for '$name'" >&2
+            rc=2
+            continue
+        fi
+        [ -z "$path" ] && path="projects/$name"
+        case "$path" in
+            /*) : ;;
+            *) path="$root/$path" ;;
+        esac
+        printf '%s\t%s\t%s\n' "$name" "$type" "$path"
+    done < "$file"
+    return $rc
+}
+
+# Print all registered project names, one per line.
+# Return codes follow registry_entries.
+# Usage: names=$(registry_names "$root")
+registry_names() {
+    local root="$1" entries rc=0
+    entries="$(registry_entries "$root")" || rc=$?
+    [ -n "$entries" ] && cut -f1 <<< "$entries"
+    return $rc
+}
+
+# Look up one project by name. Prints "<type>\t<abs_path>".
+# Return 1 if the name is not registered, 2 on registry parse errors.
+# Usage: entry=$(registry_lookup "$root" "$name")
+registry_lookup() {
+    local root="$1" want="$2" entries name type path
+    entries="$(registry_entries "$root")" || return 2
+    while IFS=$'\t' read -r name type path; do
+        [ -z "$name" ] && continue
+        if [ "$name" = "$want" ]; then
+            printf '%s\t%s\n' "$type" "$path"
+            return 0
+        fi
+    done <<< "$entries"
+    return 1
+}
+
+# Resolve the project owning a directory: the registry entry whose hosting
+# dir is the directory itself or an ancestor of it. Longest match wins.
+# Prints "<name>\t<type>\t<abs_path>".
+# Return 1 if no entry matches, 2 on registry parse errors.
+# Usage: entry=$(registry_resolve_from_dir "$root" "$dir")
+registry_resolve_from_dir() {
+    local root="$1" dir="$2" abs entries name type path
+    local rpath best="" best_len=0
+    abs="$(cd "$dir" 2>/dev/null && pwd -P)" || return 1
+    entries="$(registry_entries "$root")" || return 2
+    while IFS=$'\t' read -r name type path; do
+        [ -z "$name" ] && continue
+        rpath="$(cd "$path" 2>/dev/null && pwd -P)" || continue
+        if [ "$abs" = "$rpath" ] || [[ "$abs" == "$rpath/"* ]]; then
+            if [ "${#rpath}" -gt "$best_len" ]; then
+                best="$(printf '%s\t%s\t%s' "$name" "$type" "$path")"
+                best_len=${#rpath}
+            fi
+        fi
+    done <<< "$entries"
+    if [ -n "$best" ]; then
+        printf '%s\n' "$best"
+        return 0
+    fi
+    return 1
+}

--- a/.agent/scripts/_project_registry.sh
+++ b/.agent/scripts/_project_registry.sh
@@ -52,7 +52,9 @@ registry_entries() {
             rc=2
             continue
         fi
-        if ! [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+        # '..' is rejected so a registered name can never trip
+        # wt_project_base's path-traversal rule downstream.
+        if ! [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || [[ "$name" == *..* ]]; then
             echo "ERROR: ${file}:${lineno}: invalid project name '$name'" >&2
             rc=2
             continue

--- a/.agent/scripts/adapter
+++ b/.agent/scripts/adapter
@@ -6,7 +6,7 @@
 # adapter implementation in .agent/project_types/<type>/adapter.sh.
 #
 # Usage:
-#   .agent/scripts/adapter [--from <dir>] <verb> [args...]
+#   .agent/scripts/adapter [--from <dir>] [--project <name>] <verb> [args...]
 #
 # Verbs (the adapter contract — see REQUIRED_VERBS below):
 #   setup           First-time bring-up: clone, layer import, post-install hooks
@@ -25,9 +25,18 @@
 #   eval "$(.agent/scripts/adapter env)"
 # A type with no environment to expose emits nothing (and exits 0).
 #
-# --from <dir>: reserved for multi-tenant project resolution (#172 step 2,
-# cwd walk-up). Accepted now to lock the signature; step 1 always resolves
-# from the workspace root.
+# Multi-tenant resolution (#172 step 2, issue #227) — the active project is
+# resolved in this order:
+#   1. --project <name>: explicit selection from .agent/projects.local
+#   2. --from <dir> (default: caller's cwd) inside a registered hosting dir
+#   3. Legacy: PROJECT_TYPE from .agent/project_config.sh, root project/
+# `--project` and `--from` are extracted from argv wherever they appear, so
+# shims can forward them after the verb (no contract verb takes flags with
+# these names). The resolved project is exposed to the sourced adapter as
+# shell variables (not exported): ACTIVE_PROJECT_NAME (empty for legacy),
+# ACTIVE_PROJECT_ROOT, and ACTIVE_PROJECT_CONFIG (per-project command
+# config at .agent/projects.d/<name>.sh; adapters fall back to
+# .agent/project_config.sh when it doesn't exist).
 #
 # Contract requirements for .agent/project_types/<type>/adapter.sh:
 #   - Silent at source time: nothing written to stdout while being sourced
@@ -50,22 +59,12 @@ REQUIRED_VERBS=(setup sync validate build test install env project_root repos sc
 _ADAPTER_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(dirname "$(dirname "$_ADAPTER_SCRIPT_DIR")")"
 
-# Print the active project type. Reads PROJECT_TYPE from
+# Print the legacy project type. Reads PROJECT_TYPE from
 # .agent/project_config.sh; defaults to single_project so pre-adapter
 # configs (BUILD_CMD/TEST_CMD only) keep working unchanged.
+# Registry-resolved projects take their type from .agent/projects.local
+# instead (see the dispatch section below).
 _resolve_project_type() {
-    local from_dir="$WORKSPACE_ROOT"
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            --from) from_dir="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
-    # Step 1: from_dir is accepted but resolution is workspace-root only.
-    # Step 2 (#172) extends this to walk up from from_dir to a per-project
-    # config before falling back to the workspace config.
-    : "$from_dir"
-
     local config="$WORKSPACE_ROOT/.agent/project_config.sh"
     local project_type="single_project"
     if [ -f "$config" ]; then
@@ -89,17 +88,38 @@ if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
     return 0
 fi
 
+# shellcheck source=_project_registry.sh
+source "$_ADAPTER_SCRIPT_DIR/_project_registry.sh"
+
 usage() {
-    echo "Usage: adapter [--from <dir>] <verb> [args...]" >&2
+    echo "Usage: adapter [--from <dir>] [--project <name>] <verb> [args...]" >&2
     echo "Verbs: ${REQUIRED_VERBS[*]}" >&2
 }
 
-FROM_ARGS=()
-if [ "${1:-}" = "--from" ]; then
-    [ $# -ge 2 ] || { echo "ERROR: --from requires a directory argument" >&2; usage; exit 1; }
-    FROM_ARGS=(--from "$2")
-    shift 2
-fi
+# Extract --from/--project wherever they appear so shims that append flags
+# after the verb (build.sh --project x → adapter build --project x) work.
+FROM_DIR=""
+PROJECT_ARG=""
+ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --from)
+            [ $# -ge 2 ] || { echo "ERROR: --from requires a directory argument" >&2; usage; exit 1; }
+            FROM_DIR="$2"
+            shift 2
+            ;;
+        --project)
+            [ $# -ge 2 ] || { echo "ERROR: --project requires a project name" >&2; usage; exit 1; }
+            PROJECT_ARG="$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- ${ARGS[@]+"${ARGS[@]}"}
 
 if [ $# -lt 1 ]; then
     usage
@@ -119,7 +139,67 @@ if [ "$verb_known" != true ]; then
     exit 1
 fi
 
-PROJECT_TYPE_NAME="$(_resolve_project_type ${FROM_ARGS[@]+"${FROM_ARGS[@]}"})"
+# --- Resolve the active project (issue #227) ---
+# ACTIVE_PROJECT_* are read by the sourced adapter's functions (like
+# WORKSPACE_ROOT/ADAPTER_TYPE_DIR below), hence the SC2034 disables.
+ACTIVE_PROJECT_NAME=""
+# shellcheck disable=SC2034
+ACTIVE_PROJECT_ROOT="$WORKSPACE_ROOT/project"
+# shellcheck disable=SC2034
+ACTIVE_PROJECT_CONFIG=""
+PROJECT_TYPE_NAME=""
+
+if [ -n "$PROJECT_ARG" ]; then
+    # Explicit selection by registered name.
+    _RC=0
+    _ENTRY="$(registry_lookup "$WORKSPACE_ROOT" "$PROJECT_ARG")" || _RC=$?
+    if [ "$_RC" -ne 0 ]; then
+        if [ "$_RC" -eq 1 ]; then
+            echo "ERROR: project '$PROJECT_ARG' is not registered in $(registry_file "$WORKSPACE_ROOT")" >&2
+            _NAMES="$(registry_names "$WORKSPACE_ROOT" 2>/dev/null || true)"
+            if [ -n "$_NAMES" ]; then
+                echo "Registered projects:" >&2
+                sed 's/^/  /' <<< "$_NAMES" >&2
+            else
+                echo "  (no projects registered — see .agent/projects.local.example)" >&2
+            fi
+        fi
+        exit 1
+    fi
+    ACTIVE_PROJECT_NAME="$PROJECT_ARG"
+    PROJECT_TYPE_NAME="$(cut -f1 <<< "$_ENTRY")"
+    # shellcheck disable=SC2034
+    ACTIVE_PROJECT_ROOT="$(cut -f2 <<< "$_ENTRY")"
+else
+    # Discovery: resolve from the caller's directory (or --from <dir>).
+    _FROM="${FROM_DIR:-$PWD}"
+    if _ENTRY="$(registry_resolve_from_dir "$WORKSPACE_ROOT" "$_FROM")"; then
+        ACTIVE_PROJECT_NAME="$(cut -f1 <<< "$_ENTRY")"
+        PROJECT_TYPE_NAME="$(cut -f2 <<< "$_ENTRY")"
+        # shellcheck disable=SC2034
+        ACTIVE_PROJECT_ROOT="$(cut -f3 <<< "$_ENTRY")"
+    else
+        _RC=$?
+        [ "$_RC" -eq 2 ] && exit 1  # malformed registry — never guess
+        # Inside the hosting dir but not registered → fail loud rather than
+        # silently operating on the legacy project.
+        _WSROOT_P="$(cd "$WORKSPACE_ROOT" && pwd -P)"
+        _FROM_P="$(cd "$_FROM" 2>/dev/null && pwd -P || true)"
+        if [ -n "$_FROM_P" ] && [[ "$_FROM_P" == "$_WSROOT_P/projects/"* ]]; then
+            echo "ERROR: $_FROM_P is under projects/ but no registered project owns it." >&2
+            echo "Register it in $(registry_file "$WORKSPACE_ROOT") (see .agent/projects.local.example)." >&2
+            exit 1
+        fi
+        # Legacy: project/ symlink + workspace-level config.
+        PROJECT_TYPE_NAME="$(_resolve_project_type)"
+    fi
+fi
+
+if [ -n "$ACTIVE_PROJECT_NAME" ]; then
+    # shellcheck disable=SC2034
+    ACTIVE_PROJECT_CONFIG="$WORKSPACE_ROOT/.agent/projects.d/${ACTIVE_PROJECT_NAME}.sh"
+fi
+
 ADAPTER_TYPE_DIR="$WORKSPACE_ROOT/.agent/project_types/$PROJECT_TYPE_NAME"
 
 if [ ! -f "$ADAPTER_TYPE_DIR/adapter.sh" ]; then

--- a/.agent/scripts/dashboard.sh
+++ b/.agent/scripts/dashboard.sh
@@ -143,6 +143,9 @@ PROJECT_DIR="${MAIN_ROOT:-$ROOT_DIR}/project"
 REGISTRY_ENTRIES="$(registry_entries "${MAIN_ROOT:-$ROOT_DIR}")" || {
     check_fail "projects.local has malformed entries (see errors above)"
     ((FAILED_CHECKS++))
+    # Fail closed like the adapter dispatcher: don't report/sync/query a
+    # partial project list from a malformed registry.
+    REGISTRY_ENTRIES=""
 }
 if [ -d "$PROJECT_DIR" ] && git -C "$PROJECT_DIR" rev-parse --git-dir &>/dev/null; then
     PROJECT_REMOTE=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || echo "")
@@ -383,18 +386,18 @@ if [ "$SKIP_GITHUB" = false ]; then
     else
         # Build repo list: workspace + project
         REPOS=""
-        WS_REMOTE=$(cd "$ROOT_DIR" && git remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|.git$||' || true)
+        WS_REMOTE=$(cd "$ROOT_DIR" && git remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|\.git$||' || true)
         [ -n "$WS_REMOTE" ] && REPOS="$WS_REMOTE"
 
         if [ -d "$PROJECT_DIR" ] && git -C "$PROJECT_DIR" rev-parse --git-dir &>/dev/null; then
-            PROJ_REMOTE=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|.git$||' || true)
+            PROJ_REMOTE=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|\.git$||' || true)
             [ -n "$PROJ_REMOTE" ] && REPOS=$(printf '%s\n%s' "$REPOS" "$PROJ_REMOTE")
         fi
         if [ -n "${REGISTRY_ENTRIES:-}" ]; then
             while IFS=$'\t' read -r _name _type _path; do
                 [ -z "$_name" ] && continue
                 [ -d "$_path" ] && git -C "$_path" rev-parse --git-dir &>/dev/null || continue
-                _REG_REMOTE=$(git -C "$_path" remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|.git$||' || true)
+                _REG_REMOTE=$(git -C "$_path" remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|\.git$||' || true)
                 [ -n "$_REG_REMOTE" ] && REPOS=$(printf '%s\n%s' "$REPOS" "$_REG_REMOTE")
             done <<< "$REGISTRY_ENTRIES"
         fi

--- a/.agent/scripts/dashboard.sh
+++ b/.agent/scripts/dashboard.sh
@@ -29,6 +29,8 @@ ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 # shellcheck source=_issue_helpers.sh
 source "$SCRIPT_DIR/_issue_helpers.sh"
+# shellcheck source=_project_registry.sh
+source "$SCRIPT_DIR/_project_registry.sh"
 
 # --- Parse arguments ---
 SKIP_SYNC=false
@@ -136,8 +138,12 @@ else
     check_warn "git-bug not installed (optional: offline issue tracking — run: make skip-git-bug to suppress)"
 fi
 
-# Project directory
+# Project directory (legacy shape) + registered projects (issue #227)
 PROJECT_DIR="${MAIN_ROOT:-$ROOT_DIR}/project"
+REGISTRY_ENTRIES="$(registry_entries "${MAIN_ROOT:-$ROOT_DIR}")" || {
+    check_fail "projects.local has malformed entries (see errors above)"
+    ((FAILED_CHECKS++))
+}
 if [ -d "$PROJECT_DIR" ] && git -C "$PROJECT_DIR" rev-parse --git-dir &>/dev/null; then
     PROJECT_REMOTE=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || echo "")
     if [ -n "$PROJECT_REMOTE" ]; then
@@ -145,8 +151,18 @@ if [ -d "$PROJECT_DIR" ] && git -C "$PROJECT_DIR" rev-parse --git-dir &>/dev/nul
     else
         check_warn "project/ is a git repo but has no remote"
     fi
-else
+elif [ -z "$REGISTRY_ENTRIES" ]; then
     check_warn "project/ not configured. Run: make setup"
+fi
+if [ -n "$REGISTRY_ENTRIES" ]; then
+    while IFS=$'\t' read -r _name _type _path; do
+        [ -z "$_name" ] && continue
+        if [ -d "$_path" ] && git -C "$_path" rev-parse --git-dir &>/dev/null; then
+            check_pass "project '$_name' ($_type) checked out"
+        else
+            check_warn "project '$_name' registered but not checked out at $_path"
+        fi
+    done <<< "$REGISTRY_ENTRIES"
 fi
 
 # Configuration validation
@@ -211,6 +227,19 @@ if [ "$SKIP_SYNC" = false ]; then
         fi
     fi
 
+    if [ -n "${REGISTRY_ENTRIES:-}" ]; then
+        while IFS=$'\t' read -r _name _type _path; do
+            [ -z "$_name" ] && continue
+            [ -d "$_path" ] && git -C "$_path" rev-parse --git-dir &>/dev/null || continue
+            echo -n "Syncing project ($_name)... "
+            if git -C "$_path" fetch --quiet 2>/dev/null; then
+                echo "✅"
+            else
+                echo "⚠️ (fetch failed)"
+            fi
+        done <<< "$REGISTRY_ENTRIES"
+    fi
+
     echo ""
 fi
 
@@ -259,9 +288,37 @@ if [ -d "$PROJECT_DIR" ] && git -C "$PROJECT_DIR" rev-parse --git-dir &>/dev/nul
         echo "- **Remote**: $PROJ_REMOTE"
     fi
 else
-    echo "- **Status**: ⚠️ Not configured (run: make setup)"
+    if [ -n "${REGISTRY_ENTRIES:-}" ]; then
+        echo "- **Status**: (legacy project/ not configured; registered projects below)"
+    else
+        echo "- **Status**: ⚠️ Not configured (run: make setup)"
+    fi
 fi
 echo ""
+
+# Registered projects (issue #227)
+if [ -n "${REGISTRY_ENTRIES:-}" ]; then
+    echo "### Registered Projects"
+    while IFS=$'\t' read -r _name _type _path; do
+        [ -z "$_name" ] && continue
+        echo "#### $_name ($_type)"
+        if [ -d "$_path" ] && git -C "$_path" rev-parse --git-dir &>/dev/null; then
+            _BRANCH=$(git -C "$_path" branch --show-current 2>/dev/null || echo "detached HEAD")
+            _REMOTE=$(git -C "$_path" remote get-url origin 2>/dev/null || echo "(no remote)")
+            if [ -n "$(git -C "$_path" status --porcelain 2>/dev/null)" ]; then
+                echo "- **Status**: ⚠️ Modified"
+            else
+                echo "- **Status**: ✅ Clean"
+            fi
+            echo "- **Branch**: $_BRANCH"
+            echo "- **Remote**: $_REMOTE"
+            echo "- **Path**: $_path"
+        else
+            echo "- **Status**: ⚠️ Not checked out ($_path)"
+        fi
+        echo ""
+    done <<< "$REGISTRY_ENTRIES"
+fi
 
 echo "---"
 echo ""
@@ -332,6 +389,14 @@ if [ "$SKIP_GITHUB" = false ]; then
         if [ -d "$PROJECT_DIR" ] && git -C "$PROJECT_DIR" rev-parse --git-dir &>/dev/null; then
             PROJ_REMOTE=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|.git$||' || true)
             [ -n "$PROJ_REMOTE" ] && REPOS=$(printf '%s\n%s' "$REPOS" "$PROJ_REMOTE")
+        fi
+        if [ -n "${REGISTRY_ENTRIES:-}" ]; then
+            while IFS=$'\t' read -r _name _type _path; do
+                [ -z "$_name" ] && continue
+                [ -d "$_path" ] && git -C "$_path" rev-parse --git-dir &>/dev/null || continue
+                _REG_REMOTE=$(git -C "$_path" remote get-url origin 2>/dev/null | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|.git$||' || true)
+                [ -n "$_REG_REMOTE" ] && REPOS=$(printf '%s\n%s' "$REPOS" "$_REG_REMOTE")
+            done <<< "$REGISTRY_ENTRIES"
         fi
         REPOS=$(echo "$REPOS" | sort -u | grep -v '^$')
 

--- a/.agent/scripts/lib/workspace.py
+++ b/.agent/scripts/lib/workspace.py
@@ -85,7 +85,7 @@ def read_projects_registry(root=None):
         name = fields[0]
         ptype = fields[1] if len(fields) > 1 else ""
         path = fields[2] if len(fields) > 2 else f"projects/{name}"
-        if not _REGISTRY_NAME_RE.match(name):
+        if not _REGISTRY_NAME_RE.match(name) or ".." in name:
             errors.append(f"{registry}:{lineno}: invalid project name '{name}'")
             continue
         if not _REGISTRY_TYPE_RE.match(ptype):

--- a/.agent/scripts/lib/workspace.py
+++ b/.agent/scripts/lib/workspace.py
@@ -2,11 +2,17 @@
 Workspace Management Library
 
 Provides common functions for discovering and managing repositories in the
-general-purpose Agent Workspace (single-repo model).
+general-purpose Agent Workspace: the legacy single-repo model (project/)
+and the per-machine project registry (.agent/projects.local, issue #227).
 """
 
+import re
 import subprocess
 from pathlib import Path
+
+# Mirror the validation rules in .agent/scripts/_project_registry.sh.
+_REGISTRY_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_REGISTRY_TYPE_RE = re.compile(r"^[a-z0-9][a-z0-9_]*$")
 
 
 def get_workspace_root():
@@ -26,12 +32,70 @@ def get_project_path():
     return Path(get_workspace_root()) / "project"
 
 
-def is_project_configured():
+def is_project_configured(project=None):
     """
-    Return True if project/ exists and is a valid git repo.
+    Return True if the project checkout exists and is a valid git repo.
+
+    Defaults to the legacy project/ directory; pass a Path to check a
+    registry-hosted project instead.
     """
-    project = get_project_path()
-    return project.exists() and (project / ".git").exists()
+    if project is None:
+        project = get_project_path()
+    project = Path(project)
+    if not project.exists():
+        return False
+    if (project / ".git").exists():
+        return True
+    # project may be a symlink to a checkout
+    return (project.resolve() / ".git").exists()
+
+
+def get_projects_registry_path(root=None):
+    """Return the Path of the per-machine project registry (issue #227)."""
+    if root is None:
+        root = get_workspace_root()
+    return Path(root) / ".agent" / "projects.local"
+
+
+def read_projects_registry(root=None):
+    """
+    Parse .agent/projects.local (issue #227).
+
+    Returns (entries, errors) where entries is a list of dicts with keys
+    'name', 'type', and 'path' (absolute Path), and errors is a list of
+    human-readable strings for malformed lines. A missing registry file
+    yields ([], []) — the registry is optional.
+    """
+    if root is None:
+        root = get_workspace_root()
+    root = Path(root)
+    registry = get_projects_registry_path(root)
+    entries = []
+    errors = []
+    if not registry.is_file():
+        return entries, errors
+    for lineno, raw in enumerate(registry.read_text().splitlines(), start=1):
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) > 3:
+            errors.append(f"{registry}:{lineno}: too many fields (paths must not contain spaces)")
+            continue
+        name = fields[0]
+        ptype = fields[1] if len(fields) > 1 else ""
+        path = fields[2] if len(fields) > 2 else f"projects/{name}"
+        if not _REGISTRY_NAME_RE.match(name):
+            errors.append(f"{registry}:{lineno}: invalid project name '{name}'")
+            continue
+        if not _REGISTRY_TYPE_RE.match(ptype):
+            errors.append(f"{registry}:{lineno}: invalid or missing project type for '{name}'")
+            continue
+        abs_path = Path(path)
+        if not abs_path.is_absolute():
+            abs_path = root / path
+        entries.append({"name": name, "type": ptype, "path": abs_path})
+    return entries, errors
 
 
 def get_project_remote_url():

--- a/.agent/scripts/tests/test_adapter.sh
+++ b/.agent/scripts/tests/test_adapter.sh
@@ -76,6 +76,7 @@ make_sandbox() {
     SANDBOXES+=("$sb")
     mkdir -p "$sb/.agent/scripts" "$sb/.agent/project_types"
     cp "$REAL_ROOT/.agent/scripts/adapter" "$sb/.agent/scripts/adapter"
+    cp "$REAL_ROOT/.agent/scripts/_project_registry.sh" "$sb/.agent/scripts/_project_registry.sh"
     cp "$REAL_ROOT/.agent/scripts/validate_adapter.sh" "$sb/.agent/scripts/validate_adapter.sh"
     cp -r "$REAL_ROOT/.agent/project_types/single_project" "$sb/.agent/project_types/"
     echo "$sb"

--- a/.agent/scripts/tests/test_project_registry.sh
+++ b/.agent/scripts/tests/test_project_registry.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# Tests for the per-machine project registry (issue #227 — #172 step 2):
+# .agent/scripts/_project_registry.sh parsing, adapter dispatcher resolution
+# (--project, cwd discovery, legacy fallback), per-project command config,
+# validate_workspace.py both-shapes support, sync.py --project-root, and
+# worktree_create.sh --repo wiring.
+#
+# Tests run against sandbox workspaces (mktemp) with the real scripts copied
+# in, so no test touches the real workspace, its registry, or the network
+# (a failing `gh` stub shadows the real CLI for worktree tests).
+#
+# Run: bash .agent/scripts/tests/test_project_registry.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_ROOT="$(dirname "$(dirname "$(dirname "$SCRIPT_DIR")")")"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected: ${expected}"
+        echo "    actual:   ${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    needle:   ${needle}"
+        echo "    haystack: ${haystack}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Sandbox helpers ----
+
+SANDBOXES=()
+cleanup() {
+    local sb
+    for sb in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do
+        rm -rf "$sb"
+    done
+}
+trap cleanup EXIT
+
+make_sandbox() {
+    local sb
+    sb="$(mktemp -d)"
+    SANDBOXES+=("$sb")
+    mkdir -p "$sb/.agent/scripts/lib" "$sb/.agent/project_types"
+    cp "$REAL_ROOT/.agent/scripts/adapter" "$sb/.agent/scripts/adapter"
+    cp "$REAL_ROOT/.agent/scripts/_project_registry.sh" "$sb/.agent/scripts/_project_registry.sh"
+    cp "$REAL_ROOT/.agent/scripts/validate_adapter.sh" "$sb/.agent/scripts/validate_adapter.sh"
+    cp "$REAL_ROOT/.agent/scripts/lib/"*.py "$sb/.agent/scripts/lib/"
+    cp -r "$REAL_ROOT/.agent/project_types/single_project" "$sb/.agent/project_types/"
+    echo "$sb"
+}
+
+make_git_repo() {
+    local dir="$1" url="$2"
+    mkdir -p "$dir"
+    git -C "$dir" init --quiet
+    git -C "$dir" remote add origin "$url"
+}
+
+# Write a stub command that proves it ran and where. Echoes the stub path.
+make_stub() {
+    local sb="$1" name="$2" rc="${3:-0}"
+    mkdir -p "$sb/bin"
+    cat > "$sb/bin/$name" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB_${STUB_NAME}_RAN_IN:$(pwd -P) args:$*"
+exit ${STUB_RC}
+EOF
+    sed -i'' -e "s/\${STUB_NAME}/$name/" -e "s/\${STUB_RC}/$rc/" "$sb/bin/$name"
+    chmod +x "$sb/bin/$name"
+    echo "$sb/bin/$name"
+}
+
+# Register a project: make_registered_project <sb> <name> [<path>]
+# Creates a git checkout at the hosting dir and appends a registry line.
+# The origin URL is a local file:// path that fails fast, so fetch attempts
+# (worktree_create's remote-branch probe) never touch the network.
+make_registered_project() {
+    local sb="$1" name="$2" path="${3:-}"
+    local dir="${path:-$sb/projects/$name}"
+    make_git_repo "$dir" "file:///nonexistent/${name}.git"
+    if [ -n "$path" ]; then
+        echo "$name single_project $path" >> "$sb/.agent/projects.local"
+    else
+        echo "$name single_project" >> "$sb/.agent/projects.local"
+    fi
+    echo "$dir"
+}
+
+# ---- Registry parsing tests ----
+
+test_registry_absent_is_legacy() {
+    echo "TEST: no registry → legacy project_root (from a cwd outside projects/)"
+    local sb out
+    sb="$(make_sandbox)"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" project_root)" || true
+    assert_eq "legacy root" "$sb/project" "$out"
+}
+
+test_registry_malformed_line_fails() {
+    echo "TEST: malformed registry line fails loud"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    echo "bad name with spaces single_project" > "$sb/.agent/projects.local"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project bad project_root 2>&1)" || rc=$?
+    assert_eq "exits nonzero" "1" "$rc"
+    assert_contains "names the malformed line" "projects.local:1" "$out"
+}
+
+test_registry_comments_and_blanks() {
+    echo "TEST: comments and blank lines are ignored"
+    local sb out
+    sb="$(make_sandbox)"
+    {
+        echo "# a comment"
+        echo ""
+        echo "alpha single_project   # trailing comment"
+    } > "$sb/.agent/projects.local"
+    make_git_repo "$sb/projects/alpha" "git@github.com:owner/alpha.git"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project alpha project_root)" || true
+    assert_eq "entry parsed despite comments" "$sb/projects/alpha" "$out"
+}
+
+# ---- Dispatcher resolution tests ----
+
+test_project_flag_resolves() {
+    echo "TEST: --project <name> resolves root and type from the registry"
+    local sb out
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project alpha project_root)" || true
+    assert_eq "default hosting dir" "$sb/projects/alpha" "$out"
+}
+
+test_project_flag_after_verb() {
+    echo "TEST: --project is accepted after the verb (shim forwarding)"
+    local sb out
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" project_root --project alpha)" || true
+    assert_eq "same resolution" "$sb/projects/alpha" "$out"
+}
+
+test_project_flag_unknown() {
+    echo "TEST: --project with an unregistered name fails and lists projects"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project nope project_root 2>&1)" || rc=$?
+    assert_eq "exits nonzero" "1" "$rc"
+    assert_contains "names the unknown project" "'nope' is not registered" "$out"
+    assert_contains "lists registered projects" "alpha" "$out"
+}
+
+test_registry_type_resolution() {
+    echo "TEST: registry project type selects the adapter (not workspace config)"
+    local sb out
+    sb="$(make_sandbox)"
+    mkdir -p "$sb/.agent/project_types/other_type"
+    cat > "$sb/.agent/project_types/other_type/adapter.sh" <<'EOF'
+adapter_setup() { :; }
+adapter_sync() { :; }
+adapter_validate() { :; }
+adapter_build() { :; }
+adapter_test() { :; }
+adapter_install() { :; }
+adapter_env() { :; }
+adapter_project_root() { echo "OTHER_TYPE_ROOT"; }
+adapter_repos() { :; }
+adapter_scope_for_pr() { :; }
+EOF
+    echo "beta other_type" > "$sb/.agent/projects.local"
+    mkdir -p "$sb/projects/beta"
+    # Workspace config says single_project; the registry entry must win.
+    echo 'PROJECT_TYPE=single_project' > "$sb/.agent/project_config.sh"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project beta project_root)" || true
+    assert_eq "registry type dispatched" "OTHER_TYPE_ROOT" "$out"
+}
+
+test_cwd_discovery() {
+    echo "TEST: cwd inside a hosting dir resolves that project"
+    local sb out
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    mkdir -p "$sb/projects/alpha/src/deep"
+    out="$(cd "$sb/projects/alpha/src/deep" && "$sb/.agent/scripts/adapter" project_root)" || true
+    assert_eq "resolved from cwd" "$sb/projects/alpha" "$out"
+}
+
+test_from_flag_discovery() {
+    echo "TEST: --from <dir> resolves like cwd discovery"
+    local sb out
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    mkdir -p "$sb/projects/alpha/src"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --from "$sb/projects/alpha/src" project_root)" || true
+    assert_eq "resolved from --from dir" "$sb/projects/alpha" "$out"
+}
+
+test_custom_path_entry() {
+    echo "TEST: registry path field overrides the default hosting dir"
+    local sb out custom
+    sb="$(make_sandbox)"
+    custom="$sb/elsewhere/alpha_checkout"
+    make_registered_project "$sb" alpha "$custom" >/dev/null
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project alpha project_root)" || true
+    assert_eq "custom path used" "$custom" "$out"
+    out="$(cd "$custom" && "$sb/.agent/scripts/adapter" project_root)" || true
+    assert_eq "cwd discovery works on custom path" "$custom" "$out"
+}
+
+test_unregistered_under_projects_fails() {
+    echo "TEST: cwd under projects/ without a matching entry fails loud"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    mkdir -p "$sb/projects/orphan"
+    out="$(cd "$sb/projects/orphan" && "$sb/.agent/scripts/adapter" project_root 2>&1)" || rc=$?
+    assert_eq "exits nonzero" "1" "$rc"
+    assert_contains "explains the problem" "no registered project owns it" "$out"
+}
+
+test_legacy_unaffected_by_registry() {
+    echo "TEST: registry present + cwd outside projects/ still resolves legacy"
+    local sb out
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" project_root)" || true
+    assert_eq "legacy root wins outside projects/" "$sb/project" "$out"
+}
+
+# ---- Per-project command config tests ----
+
+test_build_uses_projects_d_config() {
+    echo "TEST: build --project uses .agent/projects.d/<name>.sh in the project root"
+    local sb out stub
+    sb="$(make_sandbox)"
+    stub="$(make_stub "$sb" alphabuild)"
+    make_registered_project "$sb" alpha >/dev/null
+    mkdir -p "$sb/.agent/projects.d"
+    echo "BUILD_CMD=\"$stub\"" > "$sb/.agent/projects.d/alpha.sh"
+    # Workspace config would run something else — must not be used.
+    echo 'BUILD_CMD="false"' > "$sb/.agent/project_config.sh"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project alpha build)" || true
+    assert_contains "per-project stub ran in project root" \
+        "STUB_alphabuild_RAN_IN:$(cd "$sb/projects/alpha" && pwd -P)" "$out"
+}
+
+test_build_falls_back_to_workspace_config() {
+    echo "TEST: build --project falls back to project_config.sh without projects.d file"
+    local sb out stub
+    sb="$(make_sandbox)"
+    stub="$(make_stub "$sb" sharedbuild)"
+    make_registered_project "$sb" alpha >/dev/null
+    echo "BUILD_CMD=\"$stub\"" > "$sb/.agent/project_config.sh"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project alpha build)" || true
+    assert_contains "shared stub ran in project root" \
+        "STUB_sharedbuild_RAN_IN:$(cd "$sb/projects/alpha" && pwd -P)" "$out"
+}
+
+# ---- sync.py --project-root ----
+
+test_sync_project_root() {
+    echo "TEST: adapter --project sync targets the registry checkout (--dry-run)"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project alpha sync --dry-run 2>&1)" || rc=$?
+    assert_eq "sync exits 0" "0" "$rc"
+    assert_contains "project checkout targeted" "project (alpha)" "$out"
+}
+
+# ---- validate_workspace.py tests ----
+
+run_validate() {
+    local sb="$1"
+    python3 "$sb/.agent/scripts/validate_workspace.py" 2>&1
+}
+
+make_validate_sandbox() {
+    local sb
+    sb="$(make_sandbox)"
+    cp "$REAL_ROOT/.agent/scripts/validate_workspace.py" "$sb/.agent/scripts/"
+    echo "$sb"
+}
+
+test_validate_registry_only() {
+    echo "TEST: validate passes on a registry-only machine (no legacy project/)"
+    local sb out rc=0
+    sb="$(make_validate_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    out="$(run_validate "$sb")" || rc=$?
+    assert_eq "exit 0" "0" "$rc"
+    assert_contains "passes" "PASSED" "$out"
+}
+
+test_validate_missing_checkout() {
+    echo "TEST: validate flags a registered project without a checkout"
+    local sb out rc=0
+    sb="$(make_validate_sandbox)"
+    echo "ghost single_project" > "$sb/.agent/projects.local"
+    out="$(run_validate "$sb")" || rc=$?
+    assert_eq "exit 1" "1" "$rc"
+    assert_contains "names the project" "project 'ghost'" "$out"
+}
+
+test_validate_unknown_type() {
+    echo "TEST: validate flags a registry entry with an unknown project type"
+    local sb out rc=0
+    sb="$(make_validate_sandbox)"
+    make_git_repo "$sb/projects/alpha" "git@github.com:owner/alpha.git"
+    echo "alpha no_such_type" > "$sb/.agent/projects.local"
+    out="$(run_validate "$sb")" || rc=$?
+    assert_eq "exit 1" "1" "$rc"
+    assert_contains "names the type" "unknown project type 'no_such_type'" "$out"
+}
+
+test_validate_malformed_registry() {
+    echo "TEST: validate flags malformed registry lines"
+    local sb out rc=0
+    sb="$(make_validate_sandbox)"
+    make_git_repo "$sb/project" "git@github.com:owner/legacy.git"
+    echo "alpha single_project extra junk" > "$sb/.agent/projects.local"
+    out="$(run_validate "$sb")" || rc=$?
+    assert_eq "exit 1" "1" "$rc"
+    assert_contains "reports the parse error" "too many fields" "$out"
+}
+
+test_validate_legacy_still_works() {
+    echo "TEST: validate on a legacy-only machine behaves as before"
+    local sb out rc=0
+    sb="$(make_validate_sandbox)"
+    make_git_repo "$sb/project" "git@github.com:owner/legacy.git"
+    out="$(run_validate "$sb")" || rc=$?
+    assert_eq "exit 0" "0" "$rc"
+    assert_contains "passes" "PASSED" "$out"
+}
+
+test_validate_neither_shape() {
+    echo "TEST: validate still fails when neither shape is configured"
+    local sb out rc=0
+    sb="$(make_validate_sandbox)"
+    out="$(run_validate "$sb")" || rc=$?
+    assert_eq "exit 1" "1" "$rc"
+    assert_contains "legacy guidance kept" "project/ directory does not exist" "$out"
+}
+
+# ---- worktree_create.sh --repo wiring ----
+
+# Worktree sandboxes get the worktree scripts, their helpers, and a failing
+# gh stub so issue lookups degrade gracefully offline.
+make_worktree_sandbox() {
+    local sb
+    sb="$(make_sandbox)"
+    cp "$REAL_ROOT/.agent/scripts/worktree_create.sh" "$sb/.agent/scripts/"
+    cp "$REAL_ROOT/.agent/scripts/_worktree_helpers.sh" "$sb/.agent/scripts/"
+    cp "$REAL_ROOT/.agent/scripts/_issue_helpers.sh" "$sb/.agent/scripts/"
+    mkdir -p "$sb/stubbin"
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$sb/stubbin/gh"
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$sb/stubbin/git-bug"
+    chmod +x "$sb/stubbin/gh" "$sb/stubbin/git-bug"
+    # The sandbox root itself must be a git repo (workspace repo stand-in).
+    git -C "$sb" init --quiet
+    echo "$sb"
+}
+
+# Seed a commit so worktree add has a HEAD to branch from.
+seed_commit() {
+    local dir="$1"
+    (cd "$dir" \
+        && git -c user.name=t -c user.email=t@t commit --allow-empty -m init --quiet)
+}
+
+test_worktree_create_unknown_repo() {
+    echo "TEST: worktree_create --repo with unregistered name fails and lists projects"
+    local sb out rc=0
+    sb="$(make_worktree_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    out="$(cd "$sb" && PATH="$sb/stubbin:$PATH" \
+        "$sb/.agent/scripts/worktree_create.sh" --issue 999 --type project --repo nope 2>&1)" || rc=$?
+    assert_eq "exits nonzero" "1" "$rc"
+    assert_contains "names the unknown project" "'nope' is not registered" "$out"
+    assert_contains "lists registered projects" "alpha" "$out"
+}
+
+test_worktree_create_registry_repo() {
+    echo "TEST: worktree_create --repo <name> creates the worktree from the registry checkout"
+    local sb out rc=0
+    sb="$(make_worktree_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    seed_commit "$sb/projects/alpha"
+    out="$(cd "$sb" && PATH="$sb/stubbin:$PATH" \
+        "$sb/.agent/scripts/worktree_create.sh" --issue 999 --type project --repo alpha 2>&1)" || rc=$?
+    assert_eq "exit 0" "0" "$rc"
+    assert_eq "worktree exists under the registry name" \
+        "yes" "$([ -d "$sb/worktrees/project/alpha/issue-alpha-999" ] && echo yes || echo no)"
+    assert_eq "worktree is a checkout of the alpha repo" \
+        "feature/issue-999" \
+        "$(git -C "$sb/worktrees/project/alpha/issue-alpha-999" branch --show-current 2>/dev/null)"
+}
+
+test_worktree_create_single_registry_autoselect() {
+    echo "TEST: worktree_create without --repo auto-selects the single registered project"
+    local sb out rc=0
+    sb="$(make_worktree_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    seed_commit "$sb/projects/alpha"
+    out="$(cd "$sb" && PATH="$sb/stubbin:$PATH" \
+        "$sb/.agent/scripts/worktree_create.sh" --issue 998 --type project 2>&1)" || rc=$?
+    assert_eq "exit 0" "0" "$rc"
+    assert_contains "announces the auto-selection" "Using registered project 'alpha'" "$out"
+    assert_eq "worktree created" \
+        "yes" "$([ -d "$sb/worktrees/project/alpha/issue-alpha-998" ] && echo yes || echo no)"
+}
+
+test_worktree_create_multiple_requires_repo() {
+    echo "TEST: worktree_create without --repo fails when multiple projects are registered"
+    local sb out rc=0
+    sb="$(make_worktree_sandbox)"
+    make_registered_project "$sb" alpha >/dev/null
+    make_registered_project "$sb" beta >/dev/null
+    out="$(cd "$sb" && PATH="$sb/stubbin:$PATH" \
+        "$sb/.agent/scripts/worktree_create.sh" --issue 997 --type project 2>&1)" || rc=$?
+    assert_eq "exits nonzero" "1" "$rc"
+    assert_contains "asks for --repo" "Use --repo to specify" "$out"
+    assert_contains "lists alpha" "--repo alpha" "$out"
+    assert_contains "lists beta" "--repo beta" "$out"
+}
+
+# ---- Run all tests ----
+echo "=== project registry / multi-tenant hosting tests ==="
+echo ""
+
+test_registry_absent_is_legacy
+test_registry_malformed_line_fails
+test_registry_comments_and_blanks
+test_project_flag_resolves
+test_project_flag_after_verb
+test_project_flag_unknown
+test_registry_type_resolution
+test_cwd_discovery
+test_from_flag_discovery
+test_custom_path_entry
+test_unregistered_under_projects_fails
+test_legacy_unaffected_by_registry
+test_build_uses_projects_d_config
+test_build_falls_back_to_workspace_config
+test_sync_project_root
+test_validate_registry_only
+test_validate_missing_checkout
+test_validate_unknown_type
+test_validate_malformed_registry
+test_validate_legacy_still_works
+test_validate_neither_shape
+test_worktree_create_unknown_repo
+test_worktree_create_registry_repo
+test_worktree_create_single_registry_autoselect
+test_worktree_create_multiple_requires_repo
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[[ $FAIL -eq 0 ]]

--- a/.agent/scripts/tests/test_project_registry.sh
+++ b/.agent/scripts/tests/test_project_registry.sh
@@ -126,6 +126,16 @@ test_registry_malformed_line_fails() {
     assert_contains "names the malformed line" "projects.local:1" "$out"
 }
 
+test_registry_rejects_dotdot_name() {
+    echo "TEST: registry name containing '..' is rejected"
+    local sb out rc=0
+    sb="$(make_sandbox)"
+    echo "a..b single_project" > "$sb/.agent/projects.local"
+    out="$(cd "$sb" && "$sb/.agent/scripts/adapter" --project a..b project_root 2>&1)" || rc=$?
+    assert_eq "exits nonzero" "1" "$rc"
+    assert_contains "flags the name" "invalid project name 'a..b'" "$out"
+}
+
 test_registry_comments_and_blanks() {
     echo "TEST: comments and blank lines are ignored"
     local sb out
@@ -372,6 +382,7 @@ make_worktree_sandbox() {
     local sb
     sb="$(make_sandbox)"
     cp "$REAL_ROOT/.agent/scripts/worktree_create.sh" "$sb/.agent/scripts/"
+    cp "$REAL_ROOT/.agent/scripts/worktree_enter.sh" "$sb/.agent/scripts/"
     cp "$REAL_ROOT/.agent/scripts/_worktree_helpers.sh" "$sb/.agent/scripts/"
     cp "$REAL_ROOT/.agent/scripts/_issue_helpers.sh" "$sb/.agent/scripts/"
     mkdir -p "$sb/stubbin"
@@ -432,6 +443,25 @@ test_worktree_create_single_registry_autoselect() {
         "yes" "$([ -d "$sb/worktrees/project/alpha/issue-alpha-998" ] && echo yes || echo no)"
 }
 
+test_worktree_create_dashed_name_roundtrip() {
+    echo "TEST: dashed registry name survives create → enter --repo round-trip"
+    local sb out rc=0
+    sb="$(make_worktree_sandbox)"
+    make_registered_project "$sb" my-proj >/dev/null
+    seed_commit "$sb/projects/my-proj"
+    out="$(cd "$sb" && PATH="$sb/stubbin:$PATH" \
+        "$sb/.agent/scripts/worktree_create.sh" --issue 996 --type project --repo my-proj 2>&1)" || rc=$?
+    assert_eq "create exit 0" "0" "$rc"
+    assert_eq "worktree dir uses the raw name" \
+        "yes" "$([ -d "$sb/worktrees/project/my-proj/issue-my-proj-996" ] && echo yes || echo no)"
+    rc=0
+    out="$(cd "$sb" && PATH="$sb/stubbin:$PATH" \
+        "$sb/.agent/scripts/worktree_enter.sh" --issue 996 --type project --repo my-proj --print-path 2>&1)" || rc=$?
+    assert_eq "enter --repo finds it" "0" "$rc"
+    assert_eq "enter resolves the same path" \
+        "$sb/worktrees/project/my-proj/issue-my-proj-996" "$out"
+}
+
 test_worktree_create_multiple_requires_repo() {
     echo "TEST: worktree_create without --repo fails when multiple projects are registered"
     local sb out rc=0
@@ -452,6 +482,7 @@ echo ""
 
 test_registry_absent_is_legacy
 test_registry_malformed_line_fails
+test_registry_rejects_dotdot_name
 test_registry_comments_and_blanks
 test_project_flag_resolves
 test_project_flag_after_verb
@@ -474,6 +505,7 @@ test_validate_neither_shape
 test_worktree_create_unknown_repo
 test_worktree_create_registry_repo
 test_worktree_create_single_registry_autoselect
+test_worktree_create_dashed_name_roundtrip
 test_worktree_create_multiple_requires_repo
 
 echo ""

--- a/.agent/scripts/validate_workspace.py
+++ b/.agent/scripts/validate_workspace.py
@@ -3,10 +3,15 @@
 Validate workspace configuration.
 
 Checks that:
-1. project/ exists and is a valid git repo
-2. project/ has a remote configured
-3. .venv shebangs match the current workspace path
-4. pre-commit hook points to a valid Python path
+1. A project checkout is configured — legacy project/ symlink and/or
+   registry entries in .agent/projects.local (issue #227); both shapes
+   may coexist during migration
+2. Configured checkouts are valid git repos (legacy project/ additionally
+   needs a remote)
+3. Registry entries are well-formed and name project types that have
+   adapters (ADR-0011)
+4. .venv shebangs match the current workspace path
+5. pre-commit hook points to a valid Python path
 
 Usage:
     python3 validate_workspace.py [--verbose]
@@ -20,7 +25,12 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from workspace import get_workspace_root, get_project_path, get_project_remote_url
+from workspace import (
+    get_workspace_root,
+    get_project_path,
+    get_project_remote_url,
+    read_projects_registry,
+)
 
 
 def get_git_branch(repo_path):
@@ -41,7 +51,7 @@ def get_git_branch(repo_path):
 
 def validate_workspace(verbose=False):
     """Validate workspace configuration. Returns True if valid."""
-    get_workspace_root()  # validate we're in a workspace
+    workspace_root = Path(get_workspace_root())
     project = get_project_path()
 
     print("Validating workspace...")
@@ -49,10 +59,19 @@ def validate_workspace(verbose=False):
 
     issues = []
 
-    # Check project/ exists
+    # Registry shape (.agent/projects.local, issue #227)
+    registry_entries, registry_errors = read_projects_registry(workspace_root)
+    for err in registry_errors:
+        issues.append(f"projects.local: {err}")
+
+    # Check project/ exists (legacy shape). A registry with entries makes
+    # the legacy symlink optional — both shapes may coexist.
     if not project.exists():
-        issues.append("project/ directory does not exist")
-        issues.append("  Run: make setup  (will prompt for repo URL or path)")
+        if not registry_entries:
+            issues.append("project/ directory does not exist")
+            issues.append("  Run: make setup  (will prompt for repo URL or path)")
+        elif verbose:
+            print("  legacy project/ not configured (registry projects present)")
     elif not (project / ".git").exists():
         # Could be a symlink to a git repo
         resolved = project.resolve()
@@ -67,16 +86,33 @@ def validate_workspace(verbose=False):
             branch = get_git_branch(project)
             print(f"  project/ is a git repo (branch: {branch or 'detached HEAD'})")
 
-    # Check remote URL
+    # Check remote URL (legacy shape only — registry checkouts are validated
+    # per entry below and don't require a remote named 'origin' here)
     remote_url = get_project_remote_url()
-    if not issues:
+    if not issues and project.exists():
         if not remote_url:
             issues.append("project/ has no remote 'origin' configured")
         elif verbose:
             print(f"  project remote: {remote_url}")
 
+    # Validate registry entries: known project type, valid checkout
+    for entry in registry_entries:
+        name, ptype, path = entry["name"], entry["type"], entry["path"]
+        adapter_file = workspace_root / ".agent" / "project_types" / ptype / "adapter.sh"
+        if not adapter_file.is_file():
+            issues.append(
+                f"project '{name}': unknown project type '{ptype}' "
+                f"(no adapter at .agent/project_types/{ptype}/)"
+            )
+        if not path.exists():
+            issues.append(f"project '{name}': hosting dir does not exist: {path}")
+            issues.append("  Clone the project there or fix .agent/projects.local")
+        elif not (path / ".git").exists() and not (path.resolve() / ".git").exists():
+            issues.append(f"project '{name}': {path} is not a git repository")
+        elif verbose:
+            print(f"  project '{name}' ({ptype}): {path} OK")
+
     # Check venv shebangs for stale paths (workspace was renamed/moved)
-    workspace_root = Path(get_workspace_root())
     venv_pip = workspace_root / ".venv" / "bin" / "pip"
     if venv_pip.exists():
         try:

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -23,6 +23,7 @@ ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 source "$SCRIPT_DIR/_worktree_helpers.sh"
 source "$SCRIPT_DIR/_issue_helpers.sh"
+source "$SCRIPT_DIR/_project_registry.sh"
 
 # Try to fetch a specific branch from origin.
 fetch_remote_branch() {
@@ -39,6 +40,7 @@ SKILL_NAME=""
 WORKTREE_TYPE=""
 BRANCH_NAME=""
 REPO_SLUG=""
+PROJECT_REPO=""
 PLAN_FILE=""
 PARENT_ISSUE_NUM=""
 WORKFLOW=""
@@ -69,6 +71,9 @@ show_usage() {
     echo "  --issue <number>      Issue number (required, unless --skill is used)"
     echo "  --skill <name>        Skill name (alternative to --issue; allowed: ${ALLOWED_SKILLS[*]})"
     echo "  --type <type>         Worktree type: 'workspace' or 'project' (required)"
+    echo "  --repo <name>         Registered project name from .agent/projects.local"
+    echo "                        (--type project only; default: legacy project/, or the"
+    echo "                        single registered project when project/ is absent)"
     echo "  --repo-slug <slug>    Repository slug for naming (auto-detected if not provided)"
     echo "  --branch <name>       Custom branch name (default: feature/issue-<N>)"
     echo "  --parent-issue <N>    Parent issue number; branches from parent's feature branch"
@@ -102,6 +107,15 @@ while [[ $# -gt 0 ]]; do
             ;;
         --type)
             WORKTREE_TYPE="$2"
+            shift 2
+            ;;
+        --repo)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: --repo requires a project name"
+                show_usage
+                exit 1
+            fi
+            PROJECT_REPO="$2"
             shift 2
             ;;
         --repo-slug)
@@ -226,12 +240,59 @@ if [ -n "$WORKFLOW" ]; then
     fi
 fi
 
-# For project type, project/ must be configured
+if [ -n "$PROJECT_REPO" ] && [ "$WORKTREE_TYPE" != "project" ]; then
+    echo "Error: --repo is only valid with --type project"
+    exit 1
+fi
+
+# For project type, resolve the project checkout: an explicit --repo name
+# from the registry, the legacy project/ symlink, or — when project/ is
+# absent — the single registered project (issue #227).
+PROJECT_NAME=""
 if [ "$WORKTREE_TYPE" == "project" ]; then
-    PROJECT_DIR="$ROOT_DIR/project"
+    PROJECT_DIR=""
+    if [ -n "$PROJECT_REPO" ]; then
+        _RC=0
+        _ENTRY="$(registry_lookup "$ROOT_DIR" "$PROJECT_REPO")" || _RC=$?
+        if [ "$_RC" -ne 0 ]; then
+            if [ "$_RC" -eq 1 ]; then
+                echo "Error: project '$PROJECT_REPO' is not registered in $(registry_file "$ROOT_DIR")"
+                _NAMES="$(registry_names "$ROOT_DIR" 2>/dev/null || true)"
+                if [ -n "$_NAMES" ]; then
+                    echo "Registered projects:"
+                    sed 's/^/  /' <<< "$_NAMES"
+                else
+                    echo "  (no projects registered — see .agent/projects.local.example)"
+                fi
+            fi
+            exit 1
+        fi
+        PROJECT_NAME="$PROJECT_REPO"
+        PROJECT_DIR="$(cut -f2 <<< "$_ENTRY")"
+    elif [ -d "$ROOT_DIR/project" ] && git -C "$ROOT_DIR/project" rev-parse --git-dir &>/dev/null; then
+        PROJECT_DIR="$ROOT_DIR/project"
+    else
+        # No legacy project/ — fall back to the registry.
+        _ENTRIES="$(registry_entries "$ROOT_DIR")" || exit 1
+        _COUNT=0
+        [ -n "$_ENTRIES" ] && _COUNT="$(wc -l <<< "$_ENTRIES")"
+        if [ "$_COUNT" -eq 1 ]; then
+            PROJECT_NAME="$(cut -f1 <<< "$_ENTRIES")"
+            PROJECT_DIR="$(cut -f3 <<< "$_ENTRIES")"
+            echo "Using registered project '$PROJECT_NAME' ($PROJECT_DIR)"
+        elif [ "$_COUNT" -gt 1 ]; then
+            echo "Error: Multiple projects registered. Use --repo to specify:"
+            cut -f1 <<< "$_ENTRIES" | sed 's/^/  --repo /'
+            exit 1
+        else
+            echo "Error: project/ is not configured."
+            echo "Run: make setup  (or register a project in .agent/projects.local)"
+            exit 1
+        fi
+    fi
     if [ ! -d "$PROJECT_DIR" ] || ! git -C "$PROJECT_DIR" rev-parse --git-dir &>/dev/null; then
-        echo "Error: project/ is not configured."
-        echo "Run: make setup"
+        echo "Error: project checkout is not a git repository: $PROJECT_DIR"
+        [ -n "$PROJECT_NAME" ] && echo "Clone the project there or fix .agent/projects.local"
         exit 1
     fi
 fi
@@ -240,32 +301,39 @@ fi
 if [ -z "$REPO_SLUG" ]; then
     REMOTE_URL=""
 
-    if [ "$WORKTREE_TYPE" == "project" ] && [ -d "$ROOT_DIR/project" ]; then
-        REMOTE_URL=$(git -C "$ROOT_DIR/project" remote get-url origin 2>/dev/null || echo "")
+    if [ "$WORKTREE_TYPE" == "project" ] && [ -d "$PROJECT_DIR" ]; then
+        REMOTE_URL=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || echo "")
     fi
 
-    if [ -z "$REMOTE_URL" ]; then
-        REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
-    fi
-
-    if [ -n "$REMOTE_URL" ]; then
+    if [ -n "$PROJECT_NAME" ]; then
+        # Registry-selected project: the registry name is the worktree repo
+        # key (worktrees/project/<name>/ — matches enter/remove --repo).
         GH_REPO_SLUG=$(extract_gh_slug "$REMOTE_URL")
-        REPO_SLUG=$(basename "$REMOTE_URL" .git)
-        # Normalize known workspace repo name
-        if [ "$REPO_SLUG" == "agent_workspace" ]; then
+        REPO_SLUG=$(echo "$PROJECT_NAME" | sed 's/[^A-Za-z0-9_]/_/g')
+    else
+        if [ -z "$REMOTE_URL" ]; then
+            REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")
+        fi
+
+        if [ -n "$REMOTE_URL" ]; then
+            GH_REPO_SLUG=$(extract_gh_slug "$REMOTE_URL")
+            REPO_SLUG=$(basename "$REMOTE_URL" .git)
+            # Normalize known workspace repo name
+            if [ "$REPO_SLUG" == "agent_workspace" ]; then
+                REPO_SLUG="workspace"
+            fi
+            REPO_SLUG=$(echo "$REPO_SLUG" | sed 's/[^A-Za-z0-9_]/_/g')
+        else
+            GH_REPO_SLUG=""
             REPO_SLUG="workspace"
         fi
-        REPO_SLUG=$(echo "$REPO_SLUG" | sed 's/[^A-Za-z0-9_]/_/g')
-    else
-        GH_REPO_SLUG=""
-        REPO_SLUG="workspace"
     fi
     echo "Auto-detected repository slug: $REPO_SLUG"
 else
     # --repo-slug given; still auto-detect GH_REPO_SLUG for gh CLI
     GH_REPO_SLUG=""
-    if [ "$WORKTREE_TYPE" == "project" ] && [ -d "$ROOT_DIR/project" ]; then
-        _URL=$(git -C "$ROOT_DIR/project" remote get-url origin 2>/dev/null || echo "")
+    if [ "$WORKTREE_TYPE" == "project" ] && [ -d "$PROJECT_DIR" ]; then
+        _URL=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || echo "")
         GH_REPO_SLUG=$(extract_gh_slug "$_URL")
     elif git -C "$ROOT_DIR" remote get-url origin &>/dev/null; then
         _URL=$(git -C "$ROOT_DIR" remote get-url origin)
@@ -276,8 +344,8 @@ fi
 
 # --- Determine project GH slug for PR targeting ---
 PROJECT_GH_SLUG=""
-if [ "$WORKTREE_TYPE" == "project" ] && [ -d "$ROOT_DIR/project" ]; then
-    _PROJ_URL=$(git -C "$ROOT_DIR/project" remote get-url origin 2>/dev/null || echo "")
+if [ "$WORKTREE_TYPE" == "project" ] && [ -d "$PROJECT_DIR" ]; then
+    _PROJ_URL=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || echo "")
     PROJECT_GH_SLUG=$(extract_gh_slug "$_PROJ_URL")
 fi
 
@@ -397,37 +465,37 @@ PARENT_BRANCH_FOUND=false
 # --- Create the worktree ---
 if [ "$WORKTREE_TYPE" == "project" ]; then
     # Project worktrees are git worktrees of the project repo
-    if git -C "$ROOT_DIR/project" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+    if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
         echo "Using existing local branch '$BRANCH_NAME'..."
-        git -C "$ROOT_DIR/project" worktree add "$WORKTREE_DIR" "$BRANCH_NAME"
-    elif fetch_remote_branch "$ROOT_DIR/project" "$BRANCH_NAME"; then
+        git -C "$PROJECT_DIR" worktree add "$WORKTREE_DIR" "$BRANCH_NAME"
+    elif fetch_remote_branch "$PROJECT_DIR" "$BRANCH_NAME"; then
         echo "Tracking remote branch 'origin/$BRANCH_NAME'..."
-        git -C "$ROOT_DIR/project" worktree add --track -b "$BRANCH_NAME" "$WORKTREE_DIR" "origin/$BRANCH_NAME"
+        git -C "$PROJECT_DIR" worktree add --track -b "$BRANCH_NAME" "$WORKTREE_DIR" "origin/$BRANCH_NAME"
     elif [ -n "$PARENT_BRANCH" ]; then
-        if git -C "$ROOT_DIR/project" show-ref --verify --quiet "refs/heads/$PARENT_BRANCH"; then
+        if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$PARENT_BRANCH"; then
             echo "Creating new branch '$BRANCH_NAME' from parent branch '$PARENT_BRANCH'..."
-            git -C "$ROOT_DIR/project" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" "$PARENT_BRANCH"
+            git -C "$PROJECT_DIR" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" "$PARENT_BRANCH"
             PARENT_BRANCH_FOUND=true
-        elif fetch_remote_branch "$ROOT_DIR/project" "$PARENT_BRANCH"; then
+        elif fetch_remote_branch "$PROJECT_DIR" "$PARENT_BRANCH"; then
             echo "Creating new branch '$BRANCH_NAME' from parent branch 'origin/$PARENT_BRANCH'..."
-            git -C "$ROOT_DIR/project" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" "origin/$PARENT_BRANCH"
+            git -C "$PROJECT_DIR" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" "origin/$PARENT_BRANCH"
             PARENT_BRANCH_FOUND=true
         else
             echo "⚠️  Parent branch '$PARENT_BRANCH' not found; falling back to HEAD"
-            git -C "$ROOT_DIR/project" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR"
+            git -C "$PROJECT_DIR" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR"
         fi
     else
         echo "Creating new branch '$BRANCH_NAME' from current HEAD..."
-        git -C "$ROOT_DIR/project" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR"
+        git -C "$PROJECT_DIR" worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR"
     fi
 
     # Check parent branch exists for PR targeting
     if [ -n "$PARENT_BRANCH" ] && [ "$PARENT_BRANCH_FOUND" = false ]; then
-        if git -C "$ROOT_DIR/project" show-ref --verify --quiet "refs/heads/$PARENT_BRANCH" || \
-           git -C "$ROOT_DIR/project" show-ref --verify --quiet "refs/remotes/origin/$PARENT_BRANCH"; then
+        if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$PARENT_BRANCH" || \
+           git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/remotes/origin/$PARENT_BRANCH"; then
             PARENT_BRANCH_FOUND=true
-        elif fetch_remote_branch "$ROOT_DIR/project" "$PARENT_BRANCH" && \
-             git -C "$ROOT_DIR/project" show-ref --verify --quiet "refs/remotes/origin/$PARENT_BRANCH"; then
+        elif fetch_remote_branch "$PROJECT_DIR" "$PARENT_BRANCH" && \
+             git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/remotes/origin/$PARENT_BRANCH"; then
             PARENT_BRANCH_FOUND=true
         fi
     fi

--- a/.agent/scripts/worktree_create.sh
+++ b/.agent/scripts/worktree_create.sh
@@ -307,9 +307,12 @@ if [ -z "$REPO_SLUG" ]; then
 
     if [ -n "$PROJECT_NAME" ]; then
         # Registry-selected project: the registry name is the worktree repo
-        # key (worktrees/project/<name>/ — matches enter/remove --repo).
+        # key (worktrees/project/<name>/ — matches enter/remove --repo), so
+        # it must be used raw. Its charset is validated by the registry
+        # parser and is a subset of what wt_project_base accepts; sanitizing
+        # '.'/'-' to '_' here would break enter/remove --repo <name> lookup.
         GH_REPO_SLUG=$(extract_gh_slug "$REMOTE_URL")
-        REPO_SLUG=$(echo "$PROJECT_NAME" | sed 's/[^A-Za-z0-9_]/_/g')
+        REPO_SLUG="$PROJECT_NAME"
     else
         if [ -z "$REMOTE_URL" ]; then
             REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || echo "")

--- a/.agent/scripts/worktree_remove.sh
+++ b/.agent/scripts/worktree_remove.sh
@@ -246,8 +246,17 @@ echo "Removing worktree..."
 
 # Determine which git repo owns this worktree
 if [ "$WORKTREE_TYPE" == "project" ]; then
-    # Project worktrees: git worktrees of the project repo
-    PROJECT_DIR="$ROOT_DIR/project"
+    # Project worktrees: git worktrees of the project repo. Resolve the
+    # owning repo from the worktree itself (its git-common-dir) so this
+    # works for both the legacy project/ symlink and registry-hosted
+    # projects (issue #227).
+    _COMMON_DIR="$(git -C "$WORKTREE_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+    if [ -n "$_COMMON_DIR" ]; then
+        PROJECT_DIR="$(dirname "$_COMMON_DIR")"
+    else
+        # Broken worktree metadata — fall back to the legacy location.
+        PROJECT_DIR="$ROOT_DIR/project"
+    fi
     if [ "$FORCE" = true ]; then
         git -C "$PROJECT_DIR" worktree remove --force "$WORKTREE_DIR"
     else
@@ -271,7 +280,7 @@ echo "✅ Worktree removed successfully"
 if [ -n "$BRANCH_NAME" ]; then
     echo ""
     REPO_CONTEXT="the project repo"
-    REPO_PATH="$ROOT_DIR/project"
+    REPO_PATH="${PROJECT_DIR:-$ROOT_DIR/project}"
     if [ "$WORKTREE_TYPE" == "workspace" ]; then
         REPO_CONTEXT="the workspace repo"
         REPO_PATH="$ROOT_DIR"

--- a/.agent/work-plans/issue-227/progress.md
+++ b/.agent/work-plans/issue-227/progress.md
@@ -34,12 +34,12 @@ issue: 227
 **CI**: all-pass
 
 ### Actions
-- [ ] Fix: dashboard.sh — escape the dot in all three `sed 's|.git$||'`
+- [x] Fix: dashboard.sh — escape the dot in all three `sed 's|.git$||'`
   slug-stripping pipelines (lines 386/390/397); unescaped `.` makes the
   pattern strip 4 chars from repo names ending in "git" even without a
   literal `.git` suffix. Two occurrences are pre-existing, one was added
   by this PR — fix all three.
-- [ ] Fix: dashboard.sh — clear REGISTRY_ENTRIES in the parse-error handler
+- [x] Fix: dashboard.sh — clear REGISTRY_ENTRIES in the parse-error handler
   so later sections (sync, registered-projects report, GitHub queries)
   don't act on a partial project list; the health-check failure banner
   carries the diagnosis.

--- a/.agent/work-plans/issue-227/progress.md
+++ b/.agent/work-plans/issue-227/progress.md
@@ -43,3 +43,20 @@ issue: 227
   so later sections (sync, registered-projects report, GitHub queries)
   don't act on a partial project list; the health-check failure banner
   carries the diagnosis.
+
+## External Review (round 3)
+**Status**: complete
+**When**: 2026-07-24 10:20
+**By**: Claude Code Agent (claude-fable-5)
+
+**PR**: #232 — round 3 (head 326143a): 1 comment, 0 valid, 1 false positive
+**CI**: all-pass
+
+### Actions
+- [x] No action: adapter.sh missing-config header "No project_config.sh
+  found." cannot mislead — _single_project_config_file() returns the
+  per-project override only when that file exists, so in the missing-file
+  branch $config is always the shared project_config.sh. The guidance
+  lines already reference $config, and the active project's override path
+  is printed when one is active. The var-not-set branch (where $config
+  can be the override) already names it via $config.

--- a/.agent/work-plans/issue-227/progress.md
+++ b/.agent/work-plans/issue-227/progress.md
@@ -24,3 +24,22 @@ issue: 227
   a false positive — the inner expansion is quoted (standard empty-array
   idiom, verified: "a b" and "c*" survive intact; same idiom used in
   test_adapter.sh / test_project_registry.sh).
+
+## External Review (round 2)
+**Status**: complete
+**When**: 2026-07-24 10:05
+**By**: Claude Code Agent (claude-fable-5)
+
+**PR**: #232 — 2 reviews total; round 2 (head e9950b5): 2 comments, 2 valid
+**CI**: all-pass
+
+### Actions
+- [ ] Fix: dashboard.sh — escape the dot in all three `sed 's|.git$||'`
+  slug-stripping pipelines (lines 386/390/397); unescaped `.` makes the
+  pattern strip 4 chars from repo names ending in "git" even without a
+  literal `.git` suffix. Two occurrences are pre-existing, one was added
+  by this PR — fix all three.
+- [ ] Fix: dashboard.sh — clear REGISTRY_ENTRIES in the parse-error handler
+  so later sections (sync, registered-projects report, GitHub queries)
+  don't act on a partial project list; the health-check failure banner
+  carries the diagnosis.

--- a/.agent/work-plans/issue-227/progress.md
+++ b/.agent/work-plans/issue-227/progress.md
@@ -13,7 +13,7 @@ issue: 227
 **CI**: all-pass (lint, docs validation, adapter contract ×2)
 
 ### Actions
-- [ ] Fix: worktree_create.sh — for registry-selected projects, use the raw
+- [x] Fix: worktree_create.sh — for registry-selected projects, use the raw
   registry name as REPO_SLUG instead of sanitizing `.`/`-` to `_`; the
   registry charset (`[A-Za-z0-9][A-Za-z0-9._-]*`) is already a subset of
   what `wt_project_base` accepts, and `enter`/`remove --repo <name>` locate

--- a/.agent/work-plans/issue-227/progress.md
+++ b/.agent/work-plans/issue-227/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 227
+---
+
+# Issue #227 — Multi-tenant hosting: projects/<name>/ discovery alongside legacy project/ symlink (#172 step 2)
+
+## External Review
+**Status**: complete
+**When**: 2026-07-24 09:45
+**By**: Claude Code Agent (claude-fable-5)
+
+**PR**: #232 — 1 review (Copilot), 1 valid, 1 false positive
+**CI**: all-pass (lint, docs validation, adapter contract ×2)
+
+### Actions
+- [ ] Fix: worktree_create.sh — for registry-selected projects, use the raw
+  registry name as REPO_SLUG instead of sanitizing `.`/`-` to `_`; the
+  registry charset (`[A-Za-z0-9][A-Za-z0-9._-]*`) is already a subset of
+  what `wt_project_base` accepts, and `enter`/`remove --repo <name>` locate
+  the worktree by the raw name. Reject `..` inside registry names (bash +
+  python parsers) so `wt_project_base`'s path-traversal rule can never be
+  hit by a registered name. Add a test with a dashed project name.
+- [x] No action: adapter `set -- ${ARGS[@]+"${ARGS[@]}"}` quoting concern is
+  a false positive — the inner expansion is quoted (standard empty-array
+  idiom, verified: "a b" and "c*" survive intact; same idiom used in
+  test_adapter.sh / test_project_registry.sh).

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@
 project/
 project
 
+# Multi-tenant project hosting (issue #227 — #172 step 2).
+# projects/ holds per-machine checkouts; the registry and per-project
+# command configs are per-machine too (see .agent/projects.local.example).
+projects/
+.agent/projects.local
+.agent/projects.d/
+
 # Worktrees (workspace and project, see issue #25)
 worktrees/
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-This workspace is a general-purpose multi-agent development platform. It manages
-one external project repository (`project/`) and provides the full agent infrastructure
-needed to develop it safely: worktree isolation, governance, skills, hooks, and
+This workspace is a general-purpose multi-agent development platform. It hosts
+external project repositories (the legacy `project/` symlink and/or named
+projects under `projects/`) and provides the full agent infrastructure
+needed to develop them safely: worktree isolation, governance, skills, hooks, and
 multi-agent coordination.
 
 ## Directory Structure
@@ -19,6 +20,8 @@ agent_workspace/
 │   ├── project_types/     # Project-type adapters (ADR-0011)
 │   │   └── single_project/  # adapter.sh + setup.sh + sync.py
 │   ├── project_config.sh  # PROJECT_TYPE / BUILD_CMD / TEST_CMD / INSTALL_CMD (gitignored, per-developer)
+│   ├── projects.local     # Per-machine project registry (gitignored; see projects.local.example)
+│   ├── projects.d/        # Per-project command configs, <name>.sh (gitignored)
 │   ├── work-plans/        # issue-<N>/plan.md and review artifacts
 │   ├── work-artifacts/    # Generated outputs
 │   ├── scratchpad/        # Temp workspace (gitignored)
@@ -35,7 +38,8 @@ agent_workspace/
 │   ├── workflows/         # CI
 │   ├── PULL_REQUEST_TEMPLATE.md
 │   └── ISSUE_TEMPLATE/
-├── project/               # Gitignored — cloned or symlinked project repo
+├── project/               # Gitignored — cloned or symlinked project repo (legacy shape)
+├── projects/              # Gitignored — named project checkouts, projects/<name>/ (issue #227)
 ├── docs/
 │   ├── PRINCIPLES.md
 │   └── decisions/         # Architecture Decision Records (ADRs)
@@ -53,22 +57,34 @@ agent_workspace/
 
 Project-shape-specific behavior (setup, sync, build, test, install, environment,
 repo enumeration, PR targeting) lives behind a 10-verb adapter contract
-(ADR-0011). `.agent/scripts/adapter <verb>` resolves `PROJECT_TYPE` from
-`.agent/project_config.sh` and dispatches to
+(ADR-0011). `.agent/scripts/adapter [--from <dir>] [--project <name>] <verb>`
+resolves the active project and dispatches to
 `.agent/project_types/<type>/adapter.sh`. `validate_adapter.sh` (pre-commit + CI)
 asserts every type implements every verb.
 
-The only type today is `single_project`: the `project/` directory holds one
-external git repository, configured during setup and gitignored. The project can be:
+Two hosting shapes coexist during the #172 migration (issue #227):
 
-- **Cloned**: `git clone <url> project/`
-- **Symlinked**: `ln -s /path/to/existing/clone project`
+- **Legacy**: the `project/` directory holds one external git repository —
+  cloned (`git clone <url> project/`) or symlinked
+  (`ln -s /path/to/existing/clone project`). `PROJECT_TYPE` comes from
+  `.agent/project_config.sh` (default `single_project`).
+- **Registry**: `.agent/projects.local` (per-machine, gitignored) maps
+  project names to hosting dirs (default `projects/<name>/`) and project
+  types. Per-project build/test commands live in
+  `.agent/projects.d/<name>.sh`, falling back to `.agent/project_config.sh`.
+  See `.agent/projects.local.example` for the format.
+
+The dispatcher resolves the active project in order: explicit
+`--project <name>` (`make build PROJECT=<name>`), the caller's cwd inside a
+registered hosting dir, then the legacy `project/` shape. A machine with only
+the legacy symlink behaves exactly as before.
 
 The project's `remote.origin.url` (from `.git/config`) is the source of truth for the
 project URL — no `configs/` directory is needed.
 
-`validate_workspace.py` checks that `project/` exists, is a valid git repo, and has a
-remote configured.
+`validate_workspace.py` understands both shapes: legacy `project/` (valid git
+repo with a remote) and registry entries (well-formed, known project type,
+checkout present).
 
 Further types (`multi_repo`, `ros2_colcon`) arrive with later #172 steps.
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ help:
 	@echo "  make dashboard        Show workspace + project status"
 	@echo "  make sync             Fetch/pull workspace + project repos"
 	@echo ""
+	@echo "  PROJECT=<name> targets a registered project from .agent/projects.local"
+	@echo "  (e.g. make build PROJECT=gz4d); default is the legacy project/ symlink."
+	@echo ""
 	@echo "Worktrees:"
 	@echo "  .agent/scripts/worktree_create.sh --issue <N> --type workspace"
 	@echo "  .agent/scripts/worktree_create.sh --issue <N> --type project"
@@ -75,14 +78,19 @@ help:
 setup: $(STAMP)/project.done $(STAMP)/git-bug.done
 	@echo "✅ Setup complete."
 
+# Multi-tenant hosting (issue #227): PROJECT=<name> selects a project from
+# .agent/projects.local; unset means legacy project/ (or cwd discovery in
+# direct script invocations).
+PROJECT_FLAG := $(if $(PROJECT),--project $(PROJECT))
+
 build: $(STAMP)/setup-dev.done
-	@$(MAIN_ROOT)/.agent/scripts/build.sh
+	@$(MAIN_ROOT)/.agent/scripts/build.sh $(PROJECT_FLAG)
 
 test: $(STAMP)/setup-dev.done
-	@$(MAIN_ROOT)/.agent/scripts/test.sh
+	@$(MAIN_ROOT)/.agent/scripts/test.sh $(PROJECT_FLAG)
 
 install: $(STAMP)/setup-dev.done
-	@$(MAIN_ROOT)/.agent/scripts/adapter install
+	@$(MAIN_ROOT)/.agent/scripts/adapter $(PROJECT_FLAG) install
 
 lint: $(STAMP)/setup-dev.done
 	$(PRE_COMMIT) run --all-files
@@ -106,7 +114,7 @@ repair:
 	@echo "✅ Repair complete. Run 'make validate' to verify."
 
 sync:
-	python3 $(MAIN_ROOT)/.agent/scripts/sync_project.py
+	python3 $(MAIN_ROOT)/.agent/scripts/sync_project.py $(PROJECT_FLAG)
 
 lock:
 	@$(MAIN_ROOT)/.agent/scripts/lock.sh


### PR DESCRIPTION
## Summary

Implements #172 step 2: named projects hosted under `projects/<name>/` can coexist with — or replace — the legacy `project/` symlink, resolved per machine by a new registry. Legacy-only machines behave exactly as before.

Closes #227
Part of #172

## What changed

- **Registry** — `.agent/projects.local` (gitignored, per-machine): one `name  project_type  [path]` line per project; path defaults to `projects/<name>` (gitignored, created when you clone a project there). Format documented in `.agent/projects.local.example`. Parsing lives in a shared sourceable helper, `.agent/scripts/_project_registry.sh`, with a mirrored parser in `lib/workspace.py`; malformed lines fail loud in both.
- **Dispatcher resolution** — `adapter [--from <dir>] [--project <name>] <verb>` resolves the active project: explicit `--project`, then cwd/`--from` inside a registered hosting dir, then legacy `project/`. A cwd under `projects/` that no entry owns is an error, not a silent legacy fallback. The active project reaches adapters as `ACTIVE_PROJECT_NAME/ROOT/CONFIG` shell variables.
- **Per-project commands** — `single_project` loads `.agent/projects.d/<name>.sh` (gitignored) when present, falling back to the shared `.agent/project_config.sh`; `PROJECT_TYPE` for registry projects comes from the registry. `setup.sh` / `sync.py` accept `--project-root`.
- **Fan-out** — `make build/test/install/sync PROJECT=<name>`; dashboard health-checks, fetches, and reports each registered project and includes their remotes in GitHub queries; `worktree_create.sh --repo <name>` creates project worktrees from a registry checkout under `worktrees/project/<name>/` (single-entry auto-select when `project/` is absent; multi-entry requires `--repo`); `worktree_remove.sh` resolves the owning repo from the worktree's git-common-dir instead of assuming `project/`.
- **Validation + tests** — `validate_workspace.py` understands both shapes. New `.agent/scripts/tests/test_project_registry.sh`: 25 tests / 46 assertions, all sandboxed and offline (failing `gh`/`git-bug` stubs, `file://` remotes).

## Acceptance criteria

- Legacy-only machine unchanged: all 77 existing adapter tests pass; discovery only activates when a registry exists.
- Named-project workflows verified by the new suite (build/test/sync/validate/worktrees) plus a synthetic-sandbox dashboard run.
- All verification used synthetic sandbox projects, per workspace policy.

## Out of scope (later #172 steps)

- `multi_repo` adapter (step 3), manifests/`.project_config` schema (step 4), migrating the current project into `projects/` (step 5).
- `merge_pr.sh` still detects project PRs via the legacy `project/` remote only; registry-hosted project PRs will be wired when a second project type lands (noted for step 3).
- `make setup` still bootstraps only the legacy shape; registry checkouts are cloned manually by design for this step.


---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-fable-5`